### PR TITLE
NeverEqual

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		1D6402E32849BC3400C4F882 /* EnvironmentReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6402E22849BC3400C4F882 /* EnvironmentReducerTests.swift */; };
 		1D6402E52849BF3200C4F882 /* ScopingReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6402E42849BF3200C4F882 /* ScopingReducerTests.swift */; };
 		1D6402E72849C04800C4F882 /* PullbackReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6402E62849C04800C4F882 /* PullbackReducerTests.swift */; };
+		1D6402EA284A01FB00C4F882 /* NeverEqualVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6402E9284A01FB00C4F882 /* NeverEqualVC.swift */; };
+		1D6402EC284A020200C4F882 /* NeverEqualVC+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6402EB284A020200C4F882 /* NeverEqualVC+Reducer.swift */; };
+		1D6402EE284A06A500C4F882 /* NeverEqualReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6402ED284A06A500C4F882 /* NeverEqualReducerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +84,9 @@
 		1D6402E22849BC3400C4F882 /* EnvironmentReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentReducerTests.swift; sourceTree = "<group>"; };
 		1D6402E42849BF3200C4F882 /* ScopingReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopingReducerTests.swift; sourceTree = "<group>"; };
 		1D6402E62849C04800C4F882 /* PullbackReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullbackReducerTests.swift; sourceTree = "<group>"; };
+		1D6402E9284A01FB00C4F882 /* NeverEqualVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeverEqualVC.swift; sourceTree = "<group>"; };
+		1D6402EB284A020200C4F882 /* NeverEqualVC+Reducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NeverEqualVC+Reducer.swift"; sourceTree = "<group>"; };
+		1D6402ED284A06A500C4F882 /* NeverEqualReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeverEqualReducerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -134,6 +140,7 @@
 		1D43C28A2833C36C009C1A8B /* Examples */ = {
 			isa = PBXGroup;
 			children = (
+				1D6402E8284A01ED00C4F882 /* 6-NeverEqual */,
 				1D6402DD2849B5AB00C4F882 /* 4-Pullback */,
 				1D6402D82849A1D600C4F882 /* 3-Scope */,
 				1D6402CB2849815600C4F882 /* Helper */,
@@ -156,6 +163,7 @@
 				1D6402E22849BC3400C4F882 /* EnvironmentReducerTests.swift */,
 				1D6402E42849BF3200C4F882 /* ScopingReducerTests.swift */,
 				1D6402E62849C04800C4F882 /* PullbackReducerTests.swift */,
+				1D6402ED284A06A500C4F882 /* NeverEqualReducerTests.swift */,
 			);
 			path = ExamplesTests;
 			sourceTree = "<group>";
@@ -230,6 +238,15 @@
 				1D6402E02849B5E700C4F882 /* PullbackVC.swift */,
 			);
 			path = "4-Pullback";
+			sourceTree = "<group>";
+		};
+		1D6402E8284A01ED00C4F882 /* 6-NeverEqual */ = {
+			isa = PBXGroup;
+			children = (
+				1D6402E9284A01FB00C4F882 /* NeverEqualVC.swift */,
+				1D6402EB284A020200C4F882 /* NeverEqualVC+Reducer.swift */,
+			);
+			path = "6-NeverEqual";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -369,12 +386,14 @@
 				1D43C2902833C36C009C1A8B /* RouteVC.swift in Sources */,
 				1D6402D3284985B700C4F882 /* EnvironmentVC+Mock.swift in Sources */,
 				1D6402CF284981DD00C4F882 /* UIView+AutoLayout.swift in Sources */,
+				1D6402EC284A020200C4F882 /* NeverEqualVC+Reducer.swift in Sources */,
 				1D43C2C12833CBA7009C1A8B /* BasicUsageVC.swift in Sources */,
 				1D6402DA2849A1DA00C4F882 /* ScopingVC+Reducer.swift in Sources */,
 				1D6402DC2849A1E400C4F882 /* ScopingVC.swift in Sources */,
 				1D43C28C2833C36C009C1A8B /* AppDelegate.swift in Sources */,
 				1D6402D7284998D200C4F882 /* UIKit+Helper.swift in Sources */,
 				1D6402D5284985FB00C4F882 /* UUID+Mock.swift in Sources */,
+				1D6402EA284A01FB00C4F882 /* NeverEqualVC.swift in Sources */,
 				1D6402CD2849815F00C4F882 /* UIScrollVC.swift in Sources */,
 				1D6402E12849B5E700C4F882 /* PullbackVC.swift in Sources */,
 				1D6402C82848CFCF00C4F882 /* EnvironmentRoute.swift in Sources */,
@@ -393,6 +412,7 @@
 				1D6402E52849BF3200C4F882 /* ScopingReducerTests.swift in Sources */,
 				1D6402E32849BC3400C4F882 /* EnvironmentReducerTests.swift in Sources */,
 				1D43C2A32833C36D009C1A8B /* BasicReducerTests.swift in Sources */,
+				1D6402EE284A06A500C4F882 /* NeverEqualReducerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/Examples/6-NeverEqual/NeverEqualVC+Reducer.swift
+++ b/Examples/Examples/6-NeverEqual/NeverEqualVC+Reducer.swift
@@ -1,0 +1,31 @@
+//
+//  NeverEqualVC+Reducer.swift
+//  Examples
+//
+//  Created by jefferson.setiawan on 03/06/22.
+//
+
+import RxComposableArchitecture
+
+struct NeverEqualState: Equatable {
+     @NeverEqual
+     var showAlert: String?
+     @NeverEqual
+     var scrollToTop: Stateless?
+ }
+
+ enum NeverEqualAction: Equatable {
+     case didTapShowAlert
+     case didTapScrollToTop
+ }
+
+ internal let neverEqualDemoReducer = Reducer<NeverEqualState, NeverEqualAction, Void> { state, action, _ in
+     switch action {
+     case .didTapShowAlert:
+         state.showAlert = "This is an alert"
+         return .none
+     case .didTapScrollToTop:
+         state.scrollToTop = Stateless()
+         return .none
+     }
+ }

--- a/Examples/Examples/6-NeverEqual/NeverEqualVC.swift
+++ b/Examples/Examples/6-NeverEqual/NeverEqualVC.swift
@@ -1,0 +1,97 @@
+//
+//  NeverEqualVC.swift
+//  Examples
+//
+//  Created by jefferson.setiawan on 03/06/22.
+//
+
+import RxComposableArchitecture
+import RxSwift
+import UIKit
+
+class NeverEqualVC: UIScrollVC {
+    private let explanationTextView: UILabel = {
+        let text = UILabel()
+        text.text = "This is a demo of NeverEqual property wrapper usage."
+        text.numberOfLines = 0
+        return text
+    }()
+    private let showAlertButton = UIButton.template(title: "Show Alert")
+    
+    private let tallView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemMint
+        view.heightAnchor.constraint(equalToConstant: 400).isActive = true
+        return view
+    }()
+    
+    private let tallView2: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemTeal
+        view.heightAnchor.constraint(equalToConstant: 700).isActive = true
+        return view
+    }()
+    
+    private let scrollToTopButton = UIButton.template(title: "Scroll to Top")
+    
+    private let store: Store<NeverEqualState, NeverEqualAction>
+    
+    init(store: Store<NeverEqualState, NeverEqualAction>) {
+        self.store = store
+        super.init()
+        title = "NeverEqual Demo"
+    }
+    
+    override func loadView() {
+        super.loadView()
+        let stack = UIStackView.vertical(subviews: [
+            explanationTextView, showAlertButton, tallView, tallView2, scrollToTopButton
+        ], spacing: 16)
+        contentView.addSubview(stack)
+        stack.fillSuperview()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        store.subscribeNeverEqual(\.$showAlert)
+            .subscribe(onNext: { [weak self] message in
+                if let message = message {
+                    let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
+                    let okAction = UIAlertAction(title: "Ok", style: .default)
+                    alert.addAction(okAction)
+                    self?.navigationController?.present(alert, animated: true)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        store.subscribeNeverEqual(\.$scrollToTop)
+            .filter { $0 != nil }
+            .subscribe(onNext: { [weak self] _ in
+                self?.scrollView.scrollToTop()
+            })
+            .disposed(by: disposeBag)
+        
+        showAlertButton.addTarget(self, action: #selector(didTapShowAlert), for: .touchUpInside)
+        scrollToTopButton.addTarget(self, action: #selector(didTapScrollToTop), for: .touchUpInside)
+    }
+    
+    @objc private func didTapShowAlert() {
+        store.send(.didTapShowAlert)
+    }
+    
+    @objc private func didTapScrollToTop() {
+        store.send(.didTapScrollToTop)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension UIScrollView {
+    public func scrollToTop(animated: Bool = true) {
+        let inset = self.contentInset
+        
+        self.setContentOffset(CGPoint(x: -inset.left, y: -inset.top), animated: animated)
+    }
+}

--- a/Examples/Examples/Helper/UIScrollVC.swift
+++ b/Examples/Examples/Helper/UIScrollVC.swift
@@ -9,7 +9,7 @@ import RxSwift
 import UIKit
 
 class UIScrollVC: UIViewController {
-    private let scrollView: UIScrollView = {
+    let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.keyboardDismissMode = .interactive
         return scrollView

--- a/Examples/Examples/RouteVC.swift
+++ b/Examples/Examples/RouteVC.swift
@@ -14,6 +14,7 @@ class RouteVC: UITableViewController {
         case environment = "2. Environment"
         case scoping = "3. Scope"
         case pullback = "4. Pullback"
+        case neverEqual = "6. Demo NeverEqual"
     }
 
     internal var routes: [Route] = Route.allCases
@@ -48,6 +49,13 @@ class RouteVC: UITableViewController {
             let viewController = PullbackVC(store: Store(
                 initialState: PullbackState(),
                 reducer: pullbackReducer,
+                environment: ()
+            ))
+            navigationController?.pushViewController(viewController, animated: true)
+        case .neverEqual:
+            let viewController = NeverEqualVC(store: Store(
+                initialState: NeverEqualState(),
+                reducer: neverEqualDemoReducer,
                 environment: ()
             ))
             navigationController?.pushViewController(viewController, animated: true)

--- a/Examples/ExamplesTests/NeverEqualReducerTests.swift
+++ b/Examples/ExamplesTests/NeverEqualReducerTests.swift
@@ -1,0 +1,44 @@
+//
+//  NeverEqualReducerTests.swift
+//  ExamplesTests
+//
+//  Created by jefferson.setiawan on 03/06/22.
+//
+
+import RxComposableArchitecture
+import XCTest
+
+@testable import Examples
+
+final class NeverEqualReducerTests: XCTestCase {
+    internal func testTapToast() {
+        let testStore = TestStore(
+            initialState: NeverEqualState(),
+            reducer: neverEqualDemoReducer,
+            environment: ()
+        )
+        testStore.send(.didTapShowAlert) {
+            $0.showAlert = "This is an alert"
+        }
+
+        testStore.send(.didTapShowAlert) {
+            $0.showAlert = "This is an alert"
+        }
+    }
+
+    internal func testTapScrollToTop() {
+        let testStore = TestStore(
+            initialState: NeverEqualState(),
+            reducer: neverEqualDemoReducer,
+            environment: ()
+        )
+        testStore.stateDiffMode = .full
+        testStore.send(.didTapScrollToTop) {
+            $0.scrollToTop = Stateless()
+        }
+
+        testStore.send(.didTapScrollToTop) {
+            $0.scrollToTop = Stateless()
+        }
+    }
+}

--- a/Sources/RxComposableArchitecture/PropertyWrapper/NeverEqual.swift
+++ b/Sources/RxComposableArchitecture/PropertyWrapper/NeverEqual.swift
@@ -1,0 +1,86 @@
+//
+//  NeverEqual.swift
+//  
+//
+//  Created by jefferson.setiawan on 03/06/22.
+//
+
+/*
+ This PropertyWrapper is used for the UI that doesn't have an actual clear state, for example is `scrollToTop`,
+ We only give the instruction about what to do, code example:
+ ```swift
+ struct EmitState: Equatable {
+     var scrollToTop: Stateless?
+ }
+
+ enum EmitAction: Equatable {
+     case didTapScrollToTop
+     case resetScrollToTop
+ }
+
+ // reducer
+
+ Reducer {
+   switch action {
+     case .didTapScrollToTop:
+         state.scrollToTop = Stateless()
+         return Effect(value: .resetScrollToTop)
+     case .resetScrollToTop:
+         state.scrollToTop = nil
+         return .none
+   }
+ }
+ ```
+ 
+ By default, if `scrollToTop` property never get resetted, it will never emit again even though you are sending multiple `.didTapScrollToTop` action to the reducer.
+ This is because the `store.subscribe` has `distinctUntilChanged`, so the `subscribe` will only be emitted once it's not equal from the previous property.
+ 
+ We usually do this juggling (set and reset) because we don't know when the right time to reset the property, and when PointFree enhance its store.send mechanism, this mechanism will not work.
+ 
+ When using the NeverEqual, you don't need to reset the state again just to make it not equal.
+ ```swift
+ struct EmitState: Equatable {
+     @NeverEqual var scrollToTop: Stateless?
+ }
+ 
+ Reducer {
+   switch action {
+     case .didTapScrollToTop:
+         state.scrollToTop = Stateless()
+         return .none
+    }
+ }
+ 
+ // UI
+ 
+ store.subscribeNeverEqual(\.$scrollToTop)
+    .subscribe(onNext: { ... })
+ ```
+ Behind the scene, the property wrapper will increment the number everytime you set it to new value, so it will not equal.
+ 
+*/
+@propertyWrapper
+ public struct NeverEqual<Value> {
+     private var value: Value
+     private var numberOfIncrement: UInt8 = 0
+
+     public var wrappedValue: Value {
+         get { value }
+         set {
+             value = newValue
+             if numberOfIncrement == .max {
+                 numberOfIncrement = 0
+             } else {
+                 numberOfIncrement += 1
+             }
+         }
+     }
+
+     public var projectedValue: NeverEqual<Value> { self }
+
+     public init(wrappedValue: Value) {
+         self.value = wrappedValue
+     }
+ }
+
+ extension NeverEqual: Equatable where Value: Equatable {}

--- a/Sources/RxComposableArchitecture/Store.swift
+++ b/Sources/RxComposableArchitecture/Store.swift
@@ -194,6 +194,16 @@ public final class Store<State, Action> {
     }
 }
 
+extension Store {
+    public func subscribeNeverEqual<LocalState: Equatable>(
+        _ toLocalState: @escaping (State) -> NeverEqual<LocalState>
+    ) -> Effect<LocalState> {
+        relay.map(toLocalState).distinctUntilChanged()
+            .map(\.wrappedValue)
+            .eraseToEffect()
+    }
+}
+
 extension Store where State: Equatable {
     public func subscribe() -> Effect<State> {
         return relay.distinctUntilChanged().eraseToEffect()

--- a/Tests/RxComposableArchitectureTests/NeverEqualTests.swift
+++ b/Tests/RxComposableArchitectureTests/NeverEqualTests.swift
@@ -1,0 +1,65 @@
+//
+//  NeverEqualTests.swift
+//  
+//
+//  Created by jefferson.setiawan on 03/06/22.
+//
+
+import RxComposableArchitecture
+import RxSwift
+import XCTest
+
+internal final class NeverEqualTests: XCTestCase {
+    private let disposeBag = DisposeBag()
+    
+    func testIncrement() {
+        @NeverEqual var value = "Hello"
+        let oldValue = $value
+        value = "hello"
+        XCTAssertNotEqual(oldValue, $value)
+    }
+    
+    internal func testDistinctSet() {
+        @NeverEqual var value = "Hello"
+        (0 ..< 255).forEach { _ in
+            value = "Hello"
+        } // testing to max 255
+        value = "Hello" // trigger 256, it should reset the numberOfIncrement to 0 again
+        XCTAssertEqual($value, NeverEqual(wrappedValue: "Hello"))
+    }
+    
+    internal func testStoreSubscriptionOfNeverEqual() {
+        struct MyState: Equatable {
+            @NeverEqual var run: Stateless?
+        }
+        enum MyAction: Equatable {
+            case tap
+        }
+        
+        let store = Store(
+            initialState: MyState(),
+            reducer: Reducer<MyState, MyAction, Void> { state, action, _ in
+                switch action {
+                case .tap:
+                    state.run = Stateless()
+                    return .none
+                }
+            },
+            environment: ()
+        )
+        var called = 0
+        store.subscribeNeverEqual(\.$run)
+            .subscribe(onNext: {
+                if $0 != nil {
+                    called += 1
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        store.send(.tap)
+        XCTAssertEqual(called, 1)
+        
+        store.send(.tap)
+        XCTAssertEqual(called, 2)
+    }
+}


### PR DESCRIPTION
This PropertyWrapper is used for the UI that doesn't have an actual clear state, for example is scroll to top or run an animation,
 We only give the instruction about what to do, code example:
 ```swift
 struct EmitState: Equatable {
     var scrollToTop: Stateless?
 }

 enum EmitAction: Equatable {
     case didTapScrollToTop
     case resetScrollToTop
 }

 // reducer

 Reducer {
   switch action {
     case .didTapScrollToTop:
         state.scrollToTop = Stateless()
         return Effect(value: .resetScrollToTop)
     case .resetScrollToTop:
         state.scrollToTop = nil
         return .none
   }
 }
 ```
 
 By default, if `scrollToTop` property never get resetted, it will never emit again even though you are sending multiple `.didTapScrollToTop` action to the reducer.
 This is because the `store.subscribe` has `distinctUntilChanged`, so the `subscribe` will only be emitted once it's not equal from the previous property.
 
 We usually do this juggling (set and reset) because we don't know when the right time to reset the property, and when PointFree enhance its store.send mechanism, this mechanism will not work.
 
 When using the NeverEqual, you don't need to reset the state again just to make it not equal.
 ```swift
 struct EmitState: Equatable {
     @NeverEqual var scrollToTop: Stateless?
 }
 
 Reducer {
   switch action {
     case .didTapScrollToTop:
         state.scrollToTop = Stateless()
         return .none
    }
 }
 
 // UI
 
 store.subscribeNeverEqual(\.$scrollToTop)
    .subscribe(onNext: { ... })
 ```
 Behind the scene, the property wrapper will increment the number everytime you set it to new value, so it will not equal.