### PR TITLE
Regress: Fix Bootstrap not called

### DIFF
--- a/Sources/RxComposableArchitecture/Reducer.swift
+++ b/Sources/RxComposableArchitecture/Reducer.swift
@@ -536,26 +536,6 @@ public struct Reducer<State, Action, Environment> {
         }
     }
 
-    public func callAsFunction(
-        _ state: inout State,
-        _ action: Action,
-        _ environment: Environment
-    ) -> Effect<Action> {
-        func environmentToUse() -> Environment {
-            #if DEBUG
-                if let bootstrappedEnvironment = Bootstrap.get(environment: type(of: environment)) {
-                    return bootstrappedEnvironment
-                } else {
-                    return environment
-                }
-            #else
-                return environment
-            #endif
-        }
-
-        return reducer(&state, action, environmentToUse())
-    }
-
     public func combined(with other: Reducer) -> Reducer {
         .combine(self, other)
     }
@@ -574,19 +554,22 @@ public struct Reducer<State, Action, Environment> {
         _ environment: Environment,
         _ debug: (State) -> Void = { _ in }
     ) -> Effect<Action> {
-        let reducer = self.reducer(&state, action, environment)
+        func environmentToUse() -> Environment {
+            #if DEBUG
+                if let bootstrappedEnvironment = Bootstrap.get(environment: type(of: environment)) {
+                    return bootstrappedEnvironment
+                } else {
+                    return environment
+                }
+            #else
+                return environment
+            #endif
+        }
+
+        let reducer = reducer(&state, action, environmentToUse())
         debug(state)
 
         return reducer
-    }
-}
-
-extension Reducer where Environment == Void {
-    public func callAsFunction(
-        _ state: inout State,
-        _ action: Action
-    ) -> Effect<Action> {
-        callAsFunction(&state, action, ())
     }
 }
 

--- a/Sources/RxComposableArchitecture/Reducer.swift
+++ b/Sources/RxComposableArchitecture/Reducer.swift
@@ -551,25 +551,13 @@ public struct Reducer<State, Action, Environment> {
     public func run(
         _ state: inout State,
         _ action: Action,
-        _ environment: Environment,
-        _ debug: (State) -> Void = { _ in }
+        _ environment: Environment
     ) -> Effect<Action> {
-        func environmentToUse() -> Environment {
-            #if DEBUG
-                if let bootstrappedEnvironment = Bootstrap.get(environment: type(of: environment)) {
-                    return bootstrappedEnvironment
-                } else {
-                    return environment
-                }
-            #else
-                return environment
-            #endif
-        }
-
-        let reducer = reducer(&state, action, environmentToUse())
-        debug(state)
-
-        return reducer
+        #if DEBUG
+            reducer(&state, action, Bootstrap.get(environment: type(of: environment)) ?? environment)
+        #else
+            reducer(&state, action, environment)
+        #endif
     }
 }
 

--- a/Tests/RxComposableArchitectureTests/BootstrapTests.swift
+++ b/Tests/RxComposableArchitectureTests/BootstrapTests.swift
@@ -1,0 +1,42 @@
+//
+//  BoostrapTests.swift
+//  
+//
+//  Created by jefferson.setiawan on 03/08/22.
+//
+
+import RxSwift
+import XCTest
+
+@testable import RxComposableArchitecture
+
+internal final class BoostrapTests: XCTestCase {
+    internal func testBootsrap() {
+        struct Env {
+            var getNumber: () -> Int
+        }
+        
+        let reducer = Reducer<Int, Void, Env> { state, action, env in
+            state = env.getNumber()
+            return .none
+        }
+        let env = Env(getNumber: {
+            return 0
+        })
+        let store = Store(initialState: -1, reducer: reducer, environment: env)
+        
+        let mockEnv = Env(getNumber: {
+            return 100
+        })
+        Bootstrap.mock(environment: mockEnv)
+        
+        store.send(())
+
+        XCTAssertEqual(store.state, 100)
+        
+        // clearing the bootstrap
+        Bootstrap.clear(environment: Env.self)
+        store.send(())
+        XCTAssertEqual(store.state, 0)
+    }
+}


### PR DESCRIPTION
Remove callAsFunction
Add test for `Bootsrap` singleton