### PR TITLE
Add cancel overloads that take types

### DIFF
--- a/Sources/RxComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/RxComposableArchitecture/Effects/Cancellation.swift
@@ -5,9 +5,10 @@ extension Effect {
     /// Turns an effect into one that is capable of being canceled.
     ///
     /// To turn an effect into a cancellable one you must provide an identifier, which is used in
-    /// `Effect.cancel(id:)` to identify which in-flight effect should be canceled. Any hashable
-    /// value can be used for the identifier, such as a string, but you can add a bit of protection
-    /// against typos by defining a new type that conforms to `Hashable`, such as an empty struct:
+    /// ``Effect/cancel(id:)-iun1`` to identify which in-flight effect should be canceled. Any
+    /// hashable value can be used for the identifier, such as a string, but you can add a bit of
+    /// protection against typos by defining a new type for the identifier, or by defining a custom
+    /// hashable type:
     ///
     ///     struct LoadUserId: Hashable {}
     ///
@@ -73,6 +74,20 @@ extension Effect {
 
         return cancelInFlight ? .concatenate(.cancel(id: id), effect) : effect
     }
+    
+    /// Turns an effect into one that is capable of being canceled.
+    ///
+    /// A convenience for calling ``Effect/cancellable(id:cancelInFlight:)-17skv`` with a static type
+    /// as the effect's unique identifier.
+    ///
+    /// - Parameters:
+    ///   - id: A unique type identifying the effect.
+    ///   - cancelInFlight: Determines if any in-flight effect with the same identifier should be
+    ///     canceled before starting this new one.
+    /// - Returns: A new effect that is capable of being canceled by an identifier.
+    public func cancellable(id: Any.Type, cancelInFlight: Bool = false) -> Effect {
+        self.cancellable(id: ObjectIdentifier(id), cancelInFlight: cancelInFlight)
+    }
 
     /// An effect that will cancel any currently in-flight effect with the given identifier.
     ///
@@ -87,12 +102,36 @@ extension Effect {
         }
     }
     
+    /// An effect that will cancel any currently in-flight effect with the given identifier.
+    ///
+    /// A convenience for calling ``Effect/cancel(id:)-iun1`` with a static type as the effect's
+    /// unique identifier.
+    ///
+    /// - Parameter id: A unique type identifying the effect.
+    /// - Returns: A new effect that will cancel any currently in-flight effect with the given
+    ///   identifier.
+    public static func cancel(id: Any.Type) -> Effect {
+        .cancel(id: ObjectIdentifier(id))
+    }
+    
     /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
     ///
     /// - Parameter ids: An array of effect identifiers.
     /// - Returns: A new effect that will cancel any currently in-flight effects with the given
     ///   identifiers.
     public static func cancel(ids: [AnyHashable]) -> Effect {
+        .merge(ids.map(Effect.cancel(id:)))
+    }
+    
+    /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
+    ///
+    /// A convenience for calling ``Effect/cancel(ids:)-dmwy`` with a static type as the effect's
+    /// unique identifier.
+    ///
+    /// - Parameter ids: An array of unique types identifying the effects.
+    /// - Returns: A new effect that will cancel any currently in-flight effects with the given
+    ///   identifiers.
+    public static func cancel(ids: [Any.Type]) -> Effect {
         .merge(ids.map(Effect.cancel(id:)))
     }
 }

--- a/Sources/RxComposableArchitecture/Effects/Debouncing.swift
+++ b/Sources/RxComposableArchitecture/Effects/Debouncing.swift
@@ -34,4 +34,23 @@ extension Effect {
             .eraseToEffect()
             .cancellable(id: id, cancelInFlight: true)
     }
+    
+    /// Turns an effect into one that can be debounced.
+    ///
+    /// A convenience for calling ``Effect/debounce(id:for:scheduler:options:)-76yye`` with a static
+    /// type as the effect's unique identifier.
+    ///
+    /// - Parameters:
+    ///   - id: A unique type identifying the effect.
+    ///   - dueTime: The duration you want to debounce for.
+    ///   - scheduler: The scheduler you want to deliver the debounced output to.
+    ///   - options: Scheduler options that customize the effect's delivery of elements.
+    /// - Returns: An effect that publishes events only after a specified time elapses.
+    public func debounce(
+        id: Any.Type,
+        for dueTime: RxTimeInterval,
+        scheduler: SchedulerType
+    ) -> Effect<Element> {
+        self.debounce(id: ObjectIdentifier(id), for: dueTime, scheduler: scheduler)
+    }
 }

--- a/Sources/RxComposableArchitecture/Effects/Timer.swift
+++ b/Sources/RxComposableArchitecture/Effects/Timer.swift
@@ -21,9 +21,9 @@ extension Effect where Output: RxAbstractInteger {
     /// we can see how effects emit. However, because `Timer.publish` takes a concrete `RunLoop` as
     /// its scheduler, we can't substitute in a `TestScheduler` during tests`.
     ///
-    /// That is why we provide the `Effect.timer` effect. It allows you to create a timer that works
-    /// with any scheduler, not just a run loop, which means you can use a `DispatchQueue` or
-    /// `RunLoop` when running your live app, but use a `TestScheduler` in tests.
+    /// That is why we provide `Effect.timer`. It allows you to create a timer that works with any
+    /// scheduler, not just a run loop, which means you can use a `DispatchQueue` or `RunLoop` when
+    /// running your live app, but use a `TestScheduler` in tests.
     ///
     /// To start and stop a timer in your feature you can create the timer effect from an action
     /// and then use the `.cancel(id:)` effect to stop the timer:
@@ -106,5 +106,31 @@ extension Effect where Output: RxAbstractInteger {
             .interval(interval, scheduler: scheduler)
             .eraseToEffect()
             .cancellable(id: id, cancelInFlight: true)
+    }
+    
+    /// Returns an effect that repeatedly emits the current time of the given scheduler on the given
+    /// interval.
+    ///
+    /// A convenience for calling ``Effect/timer(id:every:tolerance:on:options:)-4exe6`` with a
+    /// static type as the effect's unique identifier.
+    ///
+    /// - Parameters:
+    ///   - id: A unique type identifying the effect.
+    ///   - interval: The time interval on which to publish events. For example, a value of `0.5`
+    ///     publishes an event approximately every half-second.
+    ///   - scheduler: The scheduler on which the timer runs.
+    ///   - tolerance: The allowed timing variance when emitting events. Defaults to `nil`, which
+    ///     allows any variance.
+    ///   - options: Scheduler options passed to the timer. Defaults to `nil`.
+    public static func timer(
+        id: Any.Type,
+        every interval: RxTimeInterval,
+        on scheduler: SchedulerType
+    ) -> Effect {
+        self.timer(
+            id: ObjectIdentifier(id),
+            every: interval,
+            on: scheduler
+        )
     }
 }

--- a/Sources/RxComposableArchitecture/Reducer.swift
+++ b/Sources/RxComposableArchitecture/Reducer.swift
@@ -198,7 +198,7 @@ public struct Reducer<State, Action, Environment> {
     ///         let childReducer = Reducer<
     ///           ChildState, ChildAction, ChildEnvironment
     ///         > { state, action environment in
-    ///           struct MotionId: Hashable {}
+    ///           enum MotionId {}
     ///
     ///           switch action {
     ///           case .onAppear:
@@ -206,11 +206,11 @@ public struct Reducer<State, Action, Environment> {
     ///             return environment.motionClient
     ///               .start()
     ///               .map(ChildAction.motion)
-    ///               .cancellable(id: MotionId())
+    ///               .cancellable(id: MotionId.self)
     ///
     ///           case .onDisappear:
     ///             // And explicitly cancel them when the domain is torn down
-    ///             return .cancel(id: MotionId())
+    ///             return .cancel(id: MotionId.self)
     ///           ...
     ///           }
     ///         }

--- a/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
@@ -98,13 +98,13 @@ import RxSwift
 ///     let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
 ///       state, action, environment in
 ///
-///         struct SearchId: Hashable {}
+///         enum SearchId {}
 ///
 ///         switch action {
 ///         case let .queryChanged(query):
 ///           state.query = query
 ///           return environment.request(self.query)
-///             .debounce(id: SearchId(), for: 0.5, scheduler: environment.mainQueue)
+///             .debounce(id: SearchId.self, for: 0.5, scheduler: environment.mainQueue)
 ///
 ///         case let .response(results):
 ///           state.results = results

--- a/Tests/RxComposableArchitectureTests/EffectTests.swift
+++ b/Tests/RxComposableArchitectureTests/EffectTests.swift
@@ -6,7 +6,6 @@
 //
 
 import RxSwift
-//import TestSupport
 import XCTest
 
 @testable import RxComposableArchitecture
@@ -129,7 +128,7 @@ internal final class EffectTests: XCTestCase {
     }
 
     internal func testEffectSubscriberInitializer_WithCancellation() {
-        struct CancelId: Hashable {}
+        enum CancelId {}
 
         let effect = Effect<Int>.run { subscriber in
             subscriber.onNext(1)
@@ -142,7 +141,7 @@ internal final class EffectTests: XCTestCase {
 
             return Disposables.create()
         }
-        .cancellable(id: CancelId())
+        .cancellable(id: CancelId.self)
 
         var values: [Int] = []
         var isComplete = false
@@ -153,7 +152,7 @@ internal final class EffectTests: XCTestCase {
         XCTAssertEqual(values, [1])
         XCTAssertEqual(isComplete, false)
 
-        Effect<Void>.cancel(id: CancelId())
+        Effect<Void>.cancel(id: CancelId.self)
             .subscribe(onNext: {})
             .disposed(by: disposeBag)
 

--- a/Tests/RxComposableArchitectureTests/RxComposableArchitectureTests.swift
+++ b/Tests/RxComposableArchitectureTests/RxComposableArchitectureTests.swift
@@ -115,11 +115,11 @@ internal class RxComposableArchitectureTests: XCTestCase {
         }
 
         let reducer = Reducer<Int, Action, Environment> { state, action, environment in
-            struct CancelId: Hashable {}
+            enum CancelId {}
 
             switch action {
             case .cancel:
-                return .cancel(id: CancelId())
+                return .cancel(id: CancelId.self)
 
             case .incr:
                 state += 1
@@ -127,7 +127,7 @@ internal class RxComposableArchitectureTests: XCTestCase {
                     .observeOn(environment.mainQueue)
                     .map(Action.response)
                     .eraseToEffect()
-                    .cancellable(id: CancelId())
+                    .cancellable(id: CancelId.self)
 
             case let .response(value):
                 state = value


### PR DESCRIPTION
While it's easy enough to create instances of hashable structs for cancel tokens, it's effectively using static info under the hood (more so as of https://github.com/tokopedia/RxComposableArchitecture/pull/47). So let's consider adding overloads that take Any.Type instead. In use:
```swift
-struct CancelId: Hashable {}
-return .cancel(id: CancelId())
+enum CancelId {}
+return .cancel(id: CancelId.self)
```