### PR TITLE
Update store scoping to be more efficient.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run build
         run: swift build
+      - name: Run benchmark
+        run: swift run -configuration RxComposableArchitecture-Benchmark
   unit_test_monterey:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run build
         run: swift build
       - name: Run benchmark
-        run: swift run -configuration RxComposableArchitecture-Benchmark
+        run: swift run -configuration release RxComposableArchitecture-Benchmark
   unit_test_monterey:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run build
         run: swift build
       - name: Run benchmark
-        run: swift run -configuration release RxComposableArchitecture-Benchmark
+        run: swift run --configuration release RxComposableArchitecture-Benchmark
   unit_test_monterey:
     strategy:
       matrix:

--- a/Examples/ExamplesTests/ScopingReducerTests.swift
+++ b/Examples/ExamplesTests/ScopingReducerTests.swift
@@ -12,7 +12,7 @@ import RxSwift
 
 class ScopingReducerTests: XCTestCase {
     func testTapPlus() {
-        let testStore = TestStore(initialState: ScopingState(), reducer: scopingReducer, environment: ())
+        let testStore = TestStore(initialState: ScopingState(), reducer: scopingReducer, environment: (), useNewScope: true)
         
         testStore.send(.counter(.didTapPlus)) {
             $0.counter.number = 1
@@ -20,7 +20,7 @@ class ScopingReducerTests: XCTestCase {
     }
     
     func testTapMinus() {
-        let testStore = TestStore(initialState: ScopingState(), reducer: scopingReducer, environment: ())
+        let testStore = TestStore(initialState: ScopingState(), reducer: scopingReducer, environment: (), useNewScope: true)
         
         testStore.send(.counter(.didTapMinus)) {
             $0.counter.number = -1
@@ -28,7 +28,7 @@ class ScopingReducerTests: XCTestCase {
     }
     
     func testTapJumpButton() {
-        let testStore = TestStore(initialState: ScopingState(), reducer: scopingReducer, environment: ())
+        let testStore = TestStore(initialState: ScopingState(), reducer: scopingReducer, environment: (), useNewScope: true)
         
         testStore.send(.didTapJump) {
             $0.counter.number = 100

--- a/Sources/RxComposableArchitecture-Benchmark/StoreScope.swift
+++ b/Sources/RxComposableArchitecture-Benchmark/StoreScope.swift
@@ -24,7 +24,7 @@ let storeScopeSuite = BenchmarkSuite(name: "Store scoping") { suite in
     }
 }
 
-let newStoreScopeSuite = BenchmarkSuite(name: "[NEW] Store scoping") { suite in
+let newStoreScopeSuite = BenchmarkSuite(name: "[NEW] Store scoping, with rescope") { suite in
     let counterReducer = Reducer<Int, Bool, Void> { state, action, _ in
         if action {
             state += 1
@@ -42,7 +42,7 @@ let newStoreScopeSuite = BenchmarkSuite(name: "[NEW] Store scoping") { suite in
     }
     let lastViewStore = viewStores.last!
     
-    suite.benchmark("[NEW] Nested store") {
+    suite.benchmark("[NEW] Nested store, with rescope") {
         lastViewStore.send(true)
     }
 }


### PR DESCRIPTION
Implement https://github.com/tokopedia/RxComposableArchitecture/issues/51 to make store scoping more efficient

Discussion on Pointfree repo https://github.com/pointfreeco/swift-composable-architecture/discussions/1290\


## Updated benchmark
```
name                                                               time          std        iterations
------------------------------------------------------------------------------------------------------
Effects.Merged Effect.none (create, flat)                           31583.000 ns ±   8.91 %      44158
Effects.Merged Effect.none (create, nested)                         63667.000 ns ±   3.10 %      21640
Effects.Merged Effect.none (sink)                                  115250.000 ns ±   7.35 %      11741
Store scoping.Nested store                                          22792.000 ns ±  18.22 %      58805
[NEW] Store scoping.[NEW] Nested store       			    16500.000 ns ±   3.76 %      84861
[NEW] Store scoping, with rescope.[NEW] Nested store, with rescope   7500.000 ns ±   7.48 %     185106
```