### PR TITLE
Add benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,25 +9,12 @@ on:
       - '*'
 
 jobs:
-  build_big_sur:
-    strategy:
-      matrix:
-        xcode:
-          - '13.0'
-          - '13.2.1'
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v2
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
-      - name: Run build
-        run: swift build
   build_monterey:
     strategy:
       matrix:
         xcode:
-          - '13.1'
           - '13.4'
+          - '14.0'
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
@@ -35,25 +22,12 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run build
         run: swift build
-  unit_test_big_sur:
-    strategy:
-      matrix:
-        xcode:
-          - '13.0'
-          - '13.2.1'          
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v2
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
-      - name: Run tests
-        run: swift test --enable-test-discovery --enable-code-coverage | xcpretty
   unit_test_monterey:
     strategy:
       matrix:
         xcode:
-          - '13.1'
-          - '13.4'         
+          - '13.4'
+          - '14.0'
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v2

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ReactiveX/RxSwift", from: "5.1.1"),
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.1"),
+        .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     ],
     targets: [
         .target(
@@ -29,5 +30,11 @@ let package = Package(
         .testTarget(
             name: "RxComposableArchitectureTests",
             dependencies: ["RxComposableArchitecture"]),
+        .executableTarget(
+            name: "RxComposableArchitecture-Benchmark",
+            dependencies: [
+                "RxComposableArchitecture",
+                .product(name: "Benchmark", package: "Benchmark")
+            ])
     ]
 )

--- a/Sources/RxComposableArchitecture-Benchmark/Common.swift
+++ b/Sources/RxComposableArchitecture-Benchmark/Common.swift
@@ -1,0 +1,54 @@
+import Benchmark
+
+extension BenchmarkSuite {
+    func benchmark(
+        _ name: String,
+        run: @escaping () throws -> Void,
+        setUp: @escaping () -> Void = {},
+        tearDown: @escaping () -> Void
+    ) {
+        self.register(
+            benchmark: Benchmarking(name: name, run: run, setUp: setUp, tearDown: tearDown)
+        )
+    }
+}
+
+struct Benchmarking: AnyBenchmark {
+    let name: String
+    let settings: [BenchmarkSetting] = []
+    private let _run: () throws -> Void
+    private let _setUp: () -> Void
+    private let _tearDown: () -> Void
+    
+    init(
+        name: String,
+        run: @escaping () throws -> Void,
+        setUp: @escaping () -> Void = {},
+        tearDown: @escaping () -> Void = {}
+    ) {
+        self.name = name
+        self._run = run
+        self._setUp = setUp
+        self._tearDown = tearDown
+    }
+    
+    func setUp() {
+        self._setUp()
+    }
+    
+    func run(_ state: inout BenchmarkState) throws {
+        try self._run()
+    }
+    
+    func tearDown() {
+        self._tearDown()
+    }
+}
+
+@inline(__always)
+func doNotOptimizeAway<T>(_ x: T) {
+    @_optimize(none)
+    func assumePointeeIsRead(_ x: UnsafeRawPointer) {}
+    
+    withUnsafePointer(to: x) { assumePointeeIsRead($0) }
+}

--- a/Sources/RxComposableArchitecture-Benchmark/Effect.swift
+++ b/Sources/RxComposableArchitecture-Benchmark/Effect.swift
@@ -1,0 +1,29 @@
+import Benchmark
+import RxComposableArchitecture
+import Foundation
+import RxSwift
+
+let effectSuite = BenchmarkSuite(name: "Effects") {
+    $0.benchmark("Merged Effect.none (create, flat)") {
+        doNotOptimizeAway(Effect<Int>.merge((1...100).map { _ in .none }))
+    }
+    
+    $0.benchmark("Merged Effect.none (create, nested)") {
+        var effect = Effect<Int>.none
+        for _ in 1...100 {
+            effect = .merge(.none)
+        }
+        doNotOptimizeAway(effect)
+    }
+    
+    let effect = Effect<Int>.merge((1...100).map { _ in .none })
+    var disposeBag = DisposeBag()
+    var didComplete = false
+    $0.benchmark("Merged Effect.none (sink)") {
+        doNotOptimizeAway(
+            effect.subscribe(onCompleted: {  didComplete = true }).disposed(by: disposeBag)
+        )
+    } tearDown: {
+        precondition(didComplete)
+    }
+}

--- a/Sources/RxComposableArchitecture-Benchmark/StoreScope.swift
+++ b/Sources/RxComposableArchitecture-Benchmark/StoreScope.swift
@@ -1,0 +1,48 @@
+import Benchmark
+import RxComposableArchitecture
+
+let storeScopeSuite = BenchmarkSuite(name: "Store scoping") { suite in
+    let counterReducer = Reducer<Int, Bool, Void> { state, action, _ in
+        if action {
+            state += 1
+            return .none
+        } else {
+            state -= 1
+            return .none
+        }
+    }
+    var store = Store(initialState: 0, reducer: counterReducer, environment: ())
+    var viewStores: [Store<Int, Bool>] = [store]
+    for _ in 1...5 {
+        store = store.scope(state: { $0 })
+        viewStores.append(store)
+    }
+    let lastViewStore = viewStores.last!
+    
+    suite.benchmark("Nested store") {
+        lastViewStore.send(true)
+    }
+}
+
+let newStoreScopeSuite = BenchmarkSuite(name: "[NEW] Store scoping") { suite in
+    let counterReducer = Reducer<Int, Bool, Void> { state, action, _ in
+        if action {
+            state += 1
+            return .none
+        } else {
+            state -= 1
+            return .none
+        }
+    }
+    var store = Store(initialState: 0, reducer: counterReducer, environment: (), useNewScope: true)
+    var viewStores: [Store<Int, Bool>] = [store]
+    for _ in 1...5 {
+        store = store.scope(state: { $0 })
+        viewStores.append(store)
+    }
+    let lastViewStore = viewStores.last!
+    
+    suite.benchmark("[NEW] Nested store") {
+        lastViewStore.send(true)
+    }
+}

--- a/Sources/RxComposableArchitecture-Benchmark/main.swift
+++ b/Sources/RxComposableArchitecture-Benchmark/main.swift
@@ -1,0 +1,9 @@
+import Benchmark
+import RxComposableArchitecture
+
+Benchmark.main([
+    defaultBenchmarkSuite,
+    effectSuite,
+    storeScopeSuite,
+    newStoreScopeSuite,
+])


### PR DESCRIPTION
Add benchmark as seen in original TCA repo

Benchmark result:
```
name                                        time          std        iterations
-------------------------------------------------------------------------------
Effects.Merged Effect.none (create, flat)    30500.000 ns ±   3.65 %      44784
Effects.Merged Effect.none (create, nested)  61417.000 ns ±   2.59 %      22549
Effects.Merged Effect.none (sink)           109334.000 ns ±   7.90 %      12611
Store scoping.Nested store                   21334.000 ns ±   4.21 %      65308
[NEW] Store scoping.[NEW] Nested store       16500.000 ns ±   3.76 %      84861
```