### PR TITLE
Use deferred instead of removeFirst() when sending action

### DIFF
--- a/Sources/RxComposableArchitecture/Store.swift
+++ b/Sources/RxComposableArchitecture/Store.swift
@@ -59,8 +59,11 @@ public final class Store<State, Action> {
             self.isSending = false
             self.state = currentState
         }
-        while !bufferedActions.isEmpty {
-            let action = bufferedActions.removeFirst()
+        var index = bufferedActions.startIndex
+        defer { bufferedActions = [] }
+        while index < bufferedActions.endIndex {
+            defer { index += 1 }
+            let action = bufferedActions[index]
             let effect = reducer(&currentState, action)
             
             var didComplete = false


### PR DESCRIPTION
To squeze even more performance, we could employ this deferred method to process actions
- Link to the original TCA repo https://github.com/pointfreeco/swift-composable-architecture/pull/1328

Updated benchmark

```
name                                                               time          std        iterations
------------------------------------------------------------------------------------------------------
Effects.Merged Effect.none (create, flat)                           31708.000 ns ± 130.98 %      34983
Effects.Merged Effect.none (create, nested)                         65875.000 ns ±  73.53 %      21413
Effects.Merged Effect.none (sink)                                  117875.000 ns ±  11.41 %      12151
Store scoping.Nested store                                          22208.000 ns ±  43.25 %      57983
[NEW] Store scoping, with rescope.[NEW] Nested store, with rescope   7500.000 ns ±   7.48 %     185106
[NEW] Store scoping, with rescope and deferred                       7000.000 ns ±   6.89 %     199209
```