### PR TITLE
Tie Effects Lifetime to The Lifetime of the Store

### DIFF
--- a/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Examples/Examples.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		1D6402F9284DA71E00C4F882 /* NeverEqualVC+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6402F7284DA71E00C4F882 /* NeverEqualVC+Reducer.swift */; };
 		1D6402FA284DA71E00C4F882 /* NeverEqualVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6402F8284DA71E00C4F882 /* NeverEqualVC.swift */; };
 		1D6402FC284DA73400C4F882 /* NeverEqualReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6402FB284DA73400C4F882 /* NeverEqualReducerTests.swift */; };
+		9C82D5B228EFE16200E623DF /* TimerVC+Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C82D5B028EFE13800E623DF /* TimerVC+Reducer.swift */; };
+		9C82D5B328EFE16200E623DF /* TimerVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C82D5B128EFE13800E623DF /* TimerVC.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +95,8 @@
 		1D6402F7284DA71E00C4F882 /* NeverEqualVC+Reducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NeverEqualVC+Reducer.swift"; sourceTree = "<group>"; };
 		1D6402F8284DA71E00C4F882 /* NeverEqualVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NeverEqualVC.swift; sourceTree = "<group>"; };
 		1D6402FB284DA73400C4F882 /* NeverEqualReducerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NeverEqualReducerTests.swift; sourceTree = "<group>"; };
+		9C82D5B028EFE13800E623DF /* TimerVC+Reducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimerVC+Reducer.swift"; sourceTree = "<group>"; };
+		9C82D5B128EFE13800E623DF /* TimerVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerVC.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -153,6 +157,7 @@
 				1D6402DD2849B5AB00C4F882 /* 4-Pullback */,
 				1D6402EF284D9F3700C4F882 /* 5-OptionalIfLet */,
 				1D6402F6284DA71E00C4F882 /* 6-NeverEqual */,
+				9C82D5AF28EFE13800E623DF /* 7-Timer */,
 				1D43C28B2833C36C009C1A8B /* AppDelegate.swift */,
 				1D43C28D2833C36C009C1A8B /* SceneDelegate.swift */,
 				1D43C28F2833C36C009C1A8B /* RouteVC.swift */,
@@ -264,6 +269,15 @@
 				1D6402F8284DA71E00C4F882 /* NeverEqualVC.swift */,
 			);
 			path = "6-NeverEqual";
+			sourceTree = "<group>";
+		};
+		9C82D5AF28EFE13800E623DF /* 7-Timer */ = {
+			isa = PBXGroup;
+			children = (
+				9C82D5B028EFE13800E623DF /* TimerVC+Reducer.swift */,
+				9C82D5B128EFE13800E623DF /* TimerVC.swift */,
+			);
+			path = "7-Timer";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -399,6 +413,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9C82D5B228EFE16200E623DF /* TimerVC+Reducer.swift in Sources */,
+				9C82D5B328EFE16200E623DF /* TimerVC.swift in Sources */,
 				1D6402D12849855B00C4F882 /* EnvironmentDemoVC+Reducer.swift in Sources */,
 				1D43C2902833C36C009C1A8B /* RouteVC.swift in Sources */,
 				1D6402F3284D9FF400C4F882 /* OptionalIfLetVC+Reducer.swift in Sources */,

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,24 @@
         }
       },
       {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
+          "version": "1.1.4"
+        }
+      },
+      {
+        "package": "Benchmark",
+        "repositoryURL": "https://github.com/google/swift-benchmark",
+        "state": {
+          "branch": null,
+          "revision": "8163295f6fe82356b0bcf8e1ab991645de17d096",
+          "version": "0.1.2"
+        }
+      },
+      {
         "package": "swift-case-paths",
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {

--- a/Examples/Examples/7-Timer/TimerVC+Reducer.swift
+++ b/Examples/Examples/7-Timer/TimerVC+Reducer.swift
@@ -1,0 +1,33 @@
+//
+//  TimerVC+Reducer.swift
+//  Examples
+//
+//  Created by victor.cuaca on 07/10/22.
+//
+
+import RxComposableArchitecture
+import RxSwift
+
+struct TimerState: Equatable {
+    var tickCount: Int = 0
+}
+
+enum TimerAction: Equatable {
+    case onDidLoad
+    case onTimerTick
+}
+
+internal let timerDemoReducer = Reducer<TimerState, TimerAction, Void> { state, action, _ in
+    switch action {
+    case .onDidLoad:
+        return Effect<Int>.timer(id: "0", every: .seconds(1), on: MainScheduler.instance)
+            .map { _ in
+                print(">> Timer tick")
+                return TimerAction.onTimerTick
+            }
+        
+    case .onTimerTick:
+        state.tickCount += 1
+        return .none
+    }
+}

--- a/Examples/Examples/7-Timer/TimerVC.swift
+++ b/Examples/Examples/7-Timer/TimerVC.swift
@@ -12,7 +12,7 @@ import UIKit
 class TimerVC: UIScrollVC {
     private let explanationTextView: UILabel = {
         let text = UILabel()
-        text.text = "This is a demo of NeverEqual property wrapper usage."
+        text.text = "This is a demo of a timer."
         text.numberOfLines = 0
         return text
     }()

--- a/Examples/Examples/7-Timer/TimerVC.swift
+++ b/Examples/Examples/7-Timer/TimerVC.swift
@@ -1,0 +1,55 @@
+//
+//  TimerVC.swift
+//  Examples
+//
+//  Created by victor.cuaca on 07/10/22.
+//
+
+import RxComposableArchitecture
+import RxSwift
+import UIKit
+
+class TimerVC: UIScrollVC {
+    private let explanationTextView: UILabel = {
+        let text = UILabel()
+        text.text = "This is a demo of NeverEqual property wrapper usage."
+        text.numberOfLines = 0
+        return text
+    }()
+    
+    private let tickCountLabel = UILabel()
+       
+    private let store: Store<TimerState, TimerAction>
+    
+    init(store: Store<TimerState, TimerAction>) {
+        self.store = store
+        super.init()
+        title = "Timer Demo"
+    }
+    
+    override func loadView() {
+        super.loadView()
+        let stack = UIStackView.vertical(subviews: [
+            explanationTextView, tickCountLabel
+        ], spacing: 16)
+        stack.alignment = .center
+        contentView.addSubview(stack)
+        stack.fillSuperview()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        store.subscribe(\.tickCount)
+            .subscribe(onNext: { [tickCountLabel] tickCount in
+                tickCountLabel.text = "\(tickCount)"
+            })
+            .disposed(by: disposeBag)
+        
+        store.send(.onDidLoad)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Examples/Examples/RouteVC.swift
+++ b/Examples/Examples/RouteVC.swift
@@ -16,6 +16,7 @@ class RouteVC: UITableViewController {
         case pullback = "4. Pullback"
         case optionalIfLet = "5. IfLet & Reducer.optional"
         case neverEqual = "6. Demo NeverEqual"
+        case timer = "7. Demo Timer"
     }
 
     internal var routes: [Route] = Route.allCases
@@ -68,6 +69,14 @@ class RouteVC: UITableViewController {
             let viewController = NeverEqualVC(store: Store(
                 initialState: NeverEqualState(),
                 reducer: neverEqualDemoReducer,
+                environment: (),
+                useNewScope: true
+            ))
+            navigationController?.pushViewController(viewController, animated: true)
+        case .timer:
+            let viewController = TimerVC(store: Store(
+                initialState: TimerState(),
+                reducer: timerDemoReducer,
                 environment: (),
                 useNewScope: true
             ))

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,24 @@
         }
       },
       {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
+          "version": "1.1.4"
+        }
+      },
+      {
+        "package": "Benchmark",
+        "repositoryURL": "https://github.com/google/swift-benchmark",
+        "state": {
+          "branch": null,
+          "revision": "8163295f6fe82356b0bcf8e1ab991645de17d096",
+          "version": "0.1.2"
+        }
+      },
+      {
         "package": "swift-case-paths",
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {

--- a/Sources/RxComposableArchitecture/Store.swift
+++ b/Sources/RxComposableArchitecture/Store.swift
@@ -19,10 +19,11 @@ public final class Store<State, Action> {
     internal let relay: BehaviorRelay<State>
     
     private let useNewScope: Bool
+    fileprivate let cancelsEffectsOnDeinit: Bool
     fileprivate var scope: AnyScope?
     
     #if DEBUG
-    private let mainThreadChecksEnabled: Bool
+    fileprivate let mainThreadChecksEnabled: Bool
     #endif
 
     public var observable: Observable<State> {
@@ -40,6 +41,7 @@ public final class Store<State, Action> {
         relay = BehaviorRelay(value: initialState)
         self.reducer = { state, action in reducer.run(&state, action, environment) }
         self.useNewScope = useNewScope
+        self.cancelsEffectsOnDeinit = cancelsEffectsOnDeinit
         
         #if DEBUG
         self.mainThreadChecksEnabled = mainThreadChecksEnabled
@@ -163,7 +165,9 @@ public final class Store<State, Action> {
                     return .none
                 },
                 environment: (),
-                useNewScope: useNewScope
+                useNewScope: useNewScope,
+                mainThreadChecksEnabled: mainThreadChecksEnabled,
+                cancelsEffectsOnDeinit: cancelsEffectsOnDeinit
             )
 
             relay
@@ -390,7 +394,9 @@ extension Store where State: Collection, State.Element: HashDiffable, State: Equ
                     return .none
                 },
                 environment: (),
-                useNewScope: useNewScope
+                useNewScope: useNewScope,
+                mainThreadChecksEnabled: mainThreadChecksEnabled,
+                cancelsEffectsOnDeinit: cancelsEffectsOnDeinit
             )
             
             relay
@@ -419,7 +425,9 @@ extension Store where State: Collection, State.Element: HashDiffable, State: Equ
                     return .none
                 },
                 environment: (),
-                useNewScope: useNewScope
+                useNewScope: useNewScope,
+                mainThreadChecksEnabled: mainThreadChecksEnabled,
+                cancelsEffectsOnDeinit: cancelsEffectsOnDeinit
             )
 
             // reflect changes on store parent to local store
@@ -484,7 +492,9 @@ private struct Scope<RootState, RootAction>: AnyScope {
                 return .none
             },
             environment: (),
-            useNewScope: true
+            useNewScope: true,
+            mainThreadChecksEnabled: root.mainThreadChecksEnabled,
+            cancelsEffectsOnDeinit: root.cancelsEffectsOnDeinit
         )
         
         scopedStore.relay

--- a/Sources/RxComposableArchitecture/Store.swift
+++ b/Sources/RxComposableArchitecture/Store.swift
@@ -23,7 +23,7 @@ public final class Store<State, Action> {
     fileprivate var scope: AnyScope?
     
     #if DEBUG
-    fileprivate let mainThreadChecksEnabled: Bool
+    private let mainThreadChecksEnabled: Bool
     #endif
 
     public var observable: Observable<State> {
@@ -166,7 +166,7 @@ public final class Store<State, Action> {
                 },
                 environment: (),
                 useNewScope: useNewScope,
-                mainThreadChecksEnabled: mainThreadChecksEnabled,
+                mainThreadChecksEnabled: isMainThreadChecksEnabled,
                 cancelsEffectsOnDeinit: cancelsEffectsOnDeinit
             )
 
@@ -322,6 +322,14 @@ extension Store {
             .map(\.wrappedValue)
             .eraseToEffect()
     }
+    
+    fileprivate var isMainThreadChecksEnabled: Bool {
+        #if DEBUG
+        return mainThreadChecksEnabled
+        #else
+        return false
+        #endif
+    }
 }
 
 extension Store where State: Equatable {
@@ -395,7 +403,7 @@ extension Store where State: Collection, State.Element: HashDiffable, State: Equ
                 },
                 environment: (),
                 useNewScope: useNewScope,
-                mainThreadChecksEnabled: mainThreadChecksEnabled,
+                mainThreadChecksEnabled: isMainThreadChecksEnabled,
                 cancelsEffectsOnDeinit: cancelsEffectsOnDeinit
             )
             
@@ -426,7 +434,7 @@ extension Store where State: Collection, State.Element: HashDiffable, State: Equ
                 },
                 environment: (),
                 useNewScope: useNewScope,
-                mainThreadChecksEnabled: mainThreadChecksEnabled,
+                mainThreadChecksEnabled: isMainThreadChecksEnabled,
                 cancelsEffectsOnDeinit: cancelsEffectsOnDeinit
             )
 
@@ -493,7 +501,7 @@ private struct Scope<RootState, RootAction>: AnyScope {
             },
             environment: (),
             useNewScope: true,
-            mainThreadChecksEnabled: root.mainThreadChecksEnabled,
+            mainThreadChecksEnabled: root.isMainThreadChecksEnabled,
             cancelsEffectsOnDeinit: root.cancelsEffectsOnDeinit
         )
         


### PR DESCRIPTION
| BEFORE | AFTER |
|--------- |--------|
| https://user-images.githubusercontent.com/62132009/193533270-28eff156-104b-4f6f-b697-b46f86ac2bea.mp4 | https://user-images.githubusercontent.com/62132009/193533292-8e62aeae-eac8-4c64-a862-842ae88b51e7.mp4 |

## What
Currently, effects will not automatically be cancelled on store's deinit causing long running effects to still be running indefinitely. This is because of the nature of `CompositeDisposable` where it does not automatically dispose of it's disposables on deinit (like a regular dispose bag).

## How
To solve the issue, we need to tie the lifecycle of the composite disposable to the dispose bag or we could also manually call `compositeDisposable.dispose()` on `deinit`.