### PR TITLE
Format code using swift-format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,5 @@
+{
+  "indentation" : {
+    "spaces" : 4
+  }
+}

--- a/Examples/Examples/1-BasicUsage/BasicUsageVC.swift
+++ b/Examples/Examples/1-BasicUsage/BasicUsageVC.swift
@@ -12,44 +12,48 @@ import UIKit
 class BasicUsageVC: UIScrollVC {
     private let explanationTextView: UILabel = {
         let text = UILabel()
-        text.text = "This is a demo for Basic usage State, Action, Reducer, and how to bind it to the UI"
+        text.text =
+            "This is a demo for Basic usage State, Action, Reducer, and how to bind it to the UI"
         text.numberOfLines = 0
         return text
     }()
     private let plusButton = UIButton.template(title: "+")
-    
+
     private let minusButton = UIButton.template(title: "-")
-    
+
     private let numberLabel: UILabel = {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .largeTitle)
         return label
     }()
-    
+
     private let errorLabel: UILabel = {
         let label = UILabel()
         label.textColor = .red
         return label
     }()
-    
+
     private let store: Store<BasicState, BasicAction>
-    
+
     init(store: Store<BasicState, BasicAction>) {
         self.store = store
         super.init()
         title = "Basic Usage of State, Action & Reducer"
     }
-    
+
     override func loadView() {
         super.loadView()
-        let horizontalStack = UIStackView.horizontal(subviews: [minusButton, numberLabel, plusButton])
+        let horizontalStack = UIStackView.horizontal(subviews: [
+            minusButton, numberLabel, plusButton,
+        ])
         horizontalStack.alignment = .center
-        let stack = UIStackView.vertical(subviews: [explanationTextView, horizontalStack, errorLabel], spacing: 16)
+        let stack = UIStackView.vertical(
+            subviews: [explanationTextView, horizontalStack, errorLabel], spacing: 16)
         stack.alignment = .center
         contentView.addSubview(stack)
         stack.fillSuperview()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         store.subscribe(\.number)
@@ -57,25 +61,25 @@ class BasicUsageVC: UIScrollVC {
                 numberLabel.text = String($0)
             })
             .disposed(by: disposeBag)
-        
+
         store.subscribe(\.errorMessage)
             .subscribe(onNext: { [errorLabel] in
                 errorLabel.text = $0
             })
             .disposed(by: disposeBag)
-        
+
         plusButton.addTarget(self, action: #selector(didTapPlus), for: .touchUpInside)
         minusButton.addTarget(self, action: #selector(didTapMinus), for: .touchUpInside)
     }
-    
+
     @objc private func didTapPlus() {
         store.send(.didTapPlus)
     }
-    
+
     @objc private func didTapMinus() {
         store.send(.didTapMinus)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Examples/Examples/2-Environment/EnvironmentDemoVC.swift
+++ b/Examples/Examples/2-Environment/EnvironmentDemoVC.swift
@@ -12,70 +12,71 @@ class EnvironmentDemoVC: UIScrollVC {
     private let explanationTextView: UITextView = {
         let textView = UITextView()
         textView.text = """
-        In this example, you will learn how to use Environment.
-        You'll also learn how to use side effect (such as networking and analytics)
-        Because we can initialize the environment in init, you can easily swap the environment from the EnvironmentRoute.swift. You can try to change from .live to .mock
-        """
+            In this example, you will learn how to use Environment.
+            You'll also learn how to use side effect (such as networking and analytics)
+            Because we can initialize the environment in init, you can easily swap the environment from the EnvironmentRoute.swift. You can try to change from .live to .mock
+            """
         textView.isScrollEnabled = false
         return textView
     }()
-    
+
     private let textLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         return label
     }()
-    
+
     private let dateTextLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         return label
     }()
-    
+
     private let uuidTextLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         return label
     }()
-    
+
     private let loadingIndicator = UIActivityIndicatorView()
-    
+
     private let reloadButton = UIButton.template(title: "Reload")
     private let getDateButton = UIButton.template(title: "Get new Date")
     private let getUUIDButton = UIButton.template(title: "Get new UUID")
-    
+
     private let store: Store<EnvironmentState, EnvironmentAction>
-    
+
     init(store: Store<EnvironmentState, EnvironmentAction>) {
         self.store = store
         super.init()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        let stack = UIStackView.vertical(subviews: [
-            explanationTextView,
-            UIStackView.vertical(subviews: [
-                UIStackView.horizontal(subviews: [textLabel, loadingIndicator]),
-                reloadButton,
-                UIView.divider()
-            ]),
-            UIStackView.vertical(subviews: [dateTextLabel, getDateButton, UIView.divider()]),
-            UIStackView.vertical(subviews: [uuidTextLabel, getUUIDButton]),
-        ], spacing: 8)
-        
+
+        let stack = UIStackView.vertical(
+            subviews: [
+                explanationTextView,
+                UIStackView.vertical(subviews: [
+                    UIStackView.horizontal(subviews: [textLabel, loadingIndicator]),
+                    reloadButton,
+                    UIView.divider(),
+                ]),
+                UIStackView.vertical(subviews: [dateTextLabel, getDateButton, UIView.divider()]),
+                UIStackView.vertical(subviews: [uuidTextLabel, getUUIDButton]),
+            ], spacing: 8)
+
         contentView.addSubview(stack)
         stack.fillSuperview(padding: UIEdgeInsets(top: 0, left: 16, bottom: 16, right: 16))
-        
+
         reloadButton.addTarget(self, action: #selector(didTapReload), for: .touchUpInside)
         getDateButton.addTarget(self, action: #selector(didTapGetDate), for: .touchUpInside)
         getUUIDButton.addTarget(self, action: #selector(didTapGenerateUUID), for: .touchUpInside)
-        
+
         bindState()
         store.send(.didLoad)
     }
-    
+
     private func bindState() {
         store.subscribe(\.text)
             .subscribe(onNext: { [textLabel] in
@@ -106,10 +107,13 @@ class EnvironmentDemoVC: UIScrollVC {
         store.subscribe(\.alertMessage)
             .subscribe(onNext: { [weak self] message in
                 if let message = message {
-                    let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
-                    let okAction = UIAlertAction(title: "Ok", style: .default, handler: { _ in
-                        self?.store.send(.dismissAlert)
-                    })
+                    let alert = UIAlertController(
+                        title: message, message: nil, preferredStyle: .alert)
+                    let okAction = UIAlertAction(
+                        title: "Ok", style: .default,
+                        handler: { _ in
+                            self?.store.send(.dismissAlert)
+                        })
                     alert.addAction(okAction)
                     self?.navigationController?.present(alert, animated: true)
                 }
@@ -126,19 +130,19 @@ class EnvironmentDemoVC: UIScrollVC {
             })
             .disposed(by: disposeBag)
     }
-    
+
     @objc private func didTapReload() {
         store.send(.refresh)
     }
-    
+
     @objc private func didTapGetDate() {
         store.send(.getCurrentDate)
     }
-    
+
     @objc private func didTapGenerateUUID() {
         store.send(.generateUUID)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Examples/Examples/2-Environment/EnvironmentRoute.swift
+++ b/Examples/Examples/2-Environment/EnvironmentRoute.swift
@@ -22,53 +22,59 @@ class EnvironmentRouteVC: UITableViewController {
         title = "RxComposableArchitecture Examples"
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
     }
-    
+
     override internal func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
         let selectedRoute = routes[indexPath.row]
         switch selectedRoute {
         case .live:
-            let viewController = EnvironmentDemoVC(store: Store(
-                initialState: EnvironmentState(),
-                reducer: environmentReducer,
-                environment: EnvironmentVCEnvironment.live
-            ))
+            let viewController = EnvironmentDemoVC(
+                store: Store(
+                    initialState: EnvironmentState(),
+                    reducer: environmentReducer,
+                    environment: EnvironmentVCEnvironment.live
+                ))
             navigationController?.pushViewController(viewController, animated: true)
         case .mockSuccess:
-            let viewController = EnvironmentDemoVC(store: Store(
-                initialState: EnvironmentState(),
-                reducer: environmentReducer,
-                environment: EnvironmentVCEnvironment.mockSuccess
-            ))
+            let viewController = EnvironmentDemoVC(
+                store: Store(
+                    initialState: EnvironmentState(),
+                    reducer: environmentReducer,
+                    environment: EnvironmentVCEnvironment.mockSuccess
+                ))
             navigationController?.pushViewController(viewController, animated: true)
         case .mockFailed:
-            let viewController = EnvironmentDemoVC(store: Store(
-                initialState: EnvironmentState(),
-                reducer: environmentReducer,
-                environment: EnvironmentVCEnvironment.mockFailed
-            ))
+            let viewController = EnvironmentDemoVC(
+                store: Store(
+                    initialState: EnvironmentState(),
+                    reducer: environmentReducer,
+                    environment: EnvironmentVCEnvironment.mockFailed
+                ))
             navigationController?.pushViewController(viewController, animated: true)
         case .mockRandom:
-            let viewController = EnvironmentDemoVC(store: Store(
-                initialState: EnvironmentState(),
-                reducer: environmentReducer,
-                environment: EnvironmentVCEnvironment.mockRandom
-            ))
+            let viewController = EnvironmentDemoVC(
+                store: Store(
+                    initialState: EnvironmentState(),
+                    reducer: environmentReducer,
+                    environment: EnvironmentVCEnvironment.mockRandom
+                ))
             navigationController?.pushViewController(viewController, animated: true)
         }
     }
-    
+
     override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
         routes.count
     }
 
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)
+        -> UITableViewCell
+    {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
         cell.textLabel?.text = routes[indexPath.row].rawValue
         return cell
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Examples/Examples/2-Environment/EnvironmentVC+Mock.swift
+++ b/Examples/Examples/2-Environment/EnvironmentVC+Mock.swift
@@ -11,7 +11,7 @@ import RxSwift
 extension EnvironmentVCEnvironment {
     internal static let live = Self(
         loadData: {
-            Observable.just(Result.success(Int.random(in: 0 ... 10000)))
+            Observable.just(Result.success(Int.random(in: 0...10000)))
                 .delay(.milliseconds(500), scheduler: MainScheduler.instance)
                 .eraseToEffect()
         },
@@ -22,7 +22,7 @@ extension EnvironmentVCEnvironment {
 
     internal static let mockSuccess = Self(
         loadData: {
-            Observable.just(Result.success(Int.random(in: 0 ... 10000)))
+            Observable.just(Result.success(Int.random(in: 0...10000)))
                 .delay(.milliseconds(500), scheduler: MainScheduler.instance)
                 .eraseToEffect()
         },
@@ -37,9 +37,12 @@ extension EnvironmentVCEnvironment {
     )
     internal static let mockFailed = Self(
         loadData: {
-            Observable.just(Result.failure(CustomError(message: "Server Error code: \(Int.random(in: 0 ... 500))")))
-                .delay(.milliseconds(500), scheduler: MainScheduler.instance)
-                .eraseToEffect()
+            Observable.just(
+                Result.failure(
+                    CustomError(message: "Server Error code: \(Int.random(in: 0 ... 500))"))
+            )
+            .delay(.milliseconds(500), scheduler: MainScheduler.instance)
+            .eraseToEffect()
         },
         trackEvent: {
             print("MOCKING \($0)")
@@ -54,13 +57,15 @@ extension EnvironmentVCEnvironment {
     internal static let mockRandom = Self(
         loadData: {
             if Bool.random() {
-                return Observable.just(Result<Int, CustomError>.success(Int.random(in: 0 ... 10000)))
+                return Observable.just(Result<Int, CustomError>.success(Int.random(in: 0...10000)))
                     .delay(.milliseconds(500), scheduler: MainScheduler.instance)
                     .eraseToEffect()
             } else {
-                return Observable.just(Result<Int, CustomError>.failure(CustomError(message: "Server Error")))
-                    .delay(.milliseconds(500), scheduler: MainScheduler.instance)
-                    .eraseToEffect()
+                return Observable.just(
+                    Result<Int, CustomError>.failure(CustomError(message: "Server Error"))
+                )
+                .delay(.milliseconds(500), scheduler: MainScheduler.instance)
+                .eraseToEffect()
             }
         },
         trackEvent: {

--- a/Examples/Examples/3-Scope/ScopingVC.swift
+++ b/Examples/Examples/3-Scope/ScopingVC.swift
@@ -13,54 +13,56 @@ class ScopingVC: UIScrollVC {
     private let explanationTextView: UITextView = {
         let textView = UITextView()
         textView.text = """
-        Scope can means giving the child only what it need (ChildState, ChildAction) even ChildEnvironment. The purpose is to make sure that the child can't change or do what it should not do.
-        """
+            Scope can means giving the child only what it need (ChildState, ChildAction) even ChildEnvironment. The purpose is to make sure that the child can't change or do what it should not do.
+            """
         textView.isScrollEnabled = false
         return textView
     }()
-    
+
     private let textLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         return label
     }()
-    
+
     private let jumpTo100Button = UIButton.template(title: "Change to 100")
-    
+
     private let counterView: CounterView
-    
+
     private let store: Store<ScopingState, ScopingAction>
-    
+
     init(store: Store<ScopingState, ScopingAction>) {
         self.store = store
-        counterView = CounterView(store: store.scope(
-            state: \.counter,
-            action: ScopingAction.counter
-        ))
+        counterView = CounterView(
+            store: store.scope(
+                state: \.counter,
+                action: ScopingAction.counter
+            ))
         super.init()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        let stack = UIStackView.vertical(subviews: [
-            explanationTextView,
-            UIStackView.horizontal(subviews: [textLabel, ]),
-            jumpTo100Button,
-            counterView
-        ], spacing: 8)
+
+        let stack = UIStackView.vertical(
+            subviews: [
+                explanationTextView,
+                UIStackView.horizontal(subviews: [textLabel]),
+                jumpTo100Button,
+                counterView,
+            ], spacing: 8)
         stack.alignment = .center
-        
+
         contentView.addSubview(stack)
         stack.fillSuperview(padding: UIEdgeInsets(top: 0, left: 16, bottom: 16, right: 16))
-        
+
         jumpTo100Button.addTarget(self, action: #selector(didTapJump), for: .touchUpInside)
     }
-    
+
     @objc private func didTapJump() {
         store.send(.didTapJump)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -68,18 +70,18 @@ class ScopingVC: UIScrollVC {
 
 class CounterView: UIStackView {
     private let plusButton = UIButton.template(title: "+")
-    
+
     private let minusButton = UIButton.template(title: "-")
-    
+
     private let numberLabel: UILabel = {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .largeTitle)
         return label
     }()
-    
+
     private let store: Store<CounterState, CounterAction>
     private let disposeBag = DisposeBag()
-    
+
     init(store: Store<CounterState, CounterAction>) {
         self.store = store
         super.init(frame: .zero)
@@ -87,21 +89,20 @@ class CounterView: UIStackView {
         self.addArrangedSubview(minusButton)
         self.addArrangedSubview(numberLabel)
         self.addArrangedSubview(plusButton)
-        
+
         bindState()
         plusButton.addTarget(self, action: #selector(didTapPlus), for: .touchUpInside)
         minusButton.addTarget(self, action: #selector(didTapMinus), for: .touchUpInside)
     }
-    
+
     @objc private func didTapPlus() {
         store.send(.didTapPlus)
     }
-    
+
     @objc private func didTapMinus() {
         store.send(.didTapMinus)
     }
-    
-    
+
     private func bindState() {
         store.subscribe(\.number)
             .subscribe(onNext: { [numberLabel] in
@@ -109,7 +110,7 @@ class CounterView: UIStackView {
             })
             .disposed(by: disposeBag)
     }
-    
+
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Examples/Examples/4-Pullback/PullbackVC+Reducer.swift
+++ b/Examples/Examples/4-Pullback/PullbackVC+Reducer.swift
@@ -18,7 +18,8 @@ internal enum PullbackAction: Equatable {
     case counter(CounterAction)
 }
 
-internal let pullbackCounterReducer = Reducer<CounterState, CounterAction, Void> { state, action, _ in
+internal let pullbackCounterReducer = Reducer<CounterState, CounterAction, Void> {
+    state, action, _ in
     switch action {
     case .didTapMinus:
         state.number -= 1

--- a/Examples/Examples/4-Pullback/PullbackVC.swift
+++ b/Examples/Examples/4-Pullback/PullbackVC.swift
@@ -13,61 +13,63 @@ class PullbackVC: UIScrollVC {
     private let explanationTextView: UITextView = {
         let textView = UITextView()
         textView.text = """
-        Pullback is used when you want to break the reducer to smaller part, in this example, the min and plus action is handled by ChildScopeNode.reducer, when doing this, make sure you combine it to your parent Reducer (see this file `internal static var reducer`)
+            Pullback is used when you want to break the reducer to smaller part, in this example, the min and plus action is handled by ChildScopeNode.reducer, when doing this, make sure you combine it to your parent Reducer (see this file `internal static var reducer`)
 
-        From PointFree Pullback is transforming predicates on small, specific data into predicates on large, general data. For example, given a predicate on integers we could pull it back to be a predicate on user models by projecting into the user’s id field.
-        More info on pullback: https://www.pointfree.co/blog/posts/22-some-news-about-contramap
-            https://www.pointfree.co/episodes/ep69-composable-state-management-state-pullbacks
-        """
+            From PointFree Pullback is transforming predicates on small, specific data into predicates on large, general data. For example, given a predicate on integers we could pull it back to be a predicate on user models by projecting into the user’s id field.
+            More info on pullback: https://www.pointfree.co/blog/posts/22-some-news-about-contramap
+                https://www.pointfree.co/episodes/ep69-composable-state-management-state-pullbacks
+            """
         textView.isScrollEnabled = false
         return textView
     }()
-    
+
     private let textLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         return label
     }()
-    
+
     private let textField: UITextField = {
         let text = UITextField()
         text.placeholder = "Please type here..."
         return text
     }()
-    
+
     private let counterView: CounterView
-    
+
     private let store: Store<PullbackState, PullbackAction>
-    
+
     private var observation: NSKeyValueObservation?
-    
+
     init(store: Store<PullbackState, PullbackAction>) {
         self.store = store
-        counterView = CounterView(store: store.scope(
-            state: \.counter,
-            action: PullbackAction.counter
-        ))
+        counterView = CounterView(
+            store: store.scope(
+                state: \.counter,
+                action: PullbackAction.counter
+            ))
         super.init()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        let stack = UIStackView.vertical(subviews: [
-            explanationTextView,
-            textLabel,
-            textField,
-            counterView
-        ], spacing: 8)
+
+        let stack = UIStackView.vertical(
+            subviews: [
+                explanationTextView,
+                textLabel,
+                textField,
+                counterView,
+            ], spacing: 8)
         stack.alignment = .center
         contentView.addSubview(stack)
         stack.fillSuperview(padding: UIEdgeInsets(top: 0, left: 16, bottom: 16, right: 16))
-        
+
         textField.delegate = self
-        
+
         bindState()
     }
-    
+
     private func bindState() {
         store.subscribe(\.text)
             .subscribe(onNext: { [textLabel] in
@@ -75,14 +77,17 @@ class PullbackVC: UIScrollVC {
             })
             .disposed(by: disposeBag)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }
 
 extension PullbackVC: UITextFieldDelegate {
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    func textField(
+        _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
         store.send(.textDidChange(textField.text ?? ""))
         return true
     }

--- a/Examples/Examples/5-OptionalIfLet/OptionalIfLetVC+Reducer.swift
+++ b/Examples/Examples/5-OptionalIfLet/OptionalIfLetVC+Reducer.swift
@@ -24,7 +24,7 @@ internal let optionalIfLetReducer = Reducer<OptionalIfLetState, OptionalIfLetAct
             state: \.counter,
             action: /OptionalIfLetAction.counter,
             environment: { _ in }
-    ),
+        ),
     Reducer { state, action, _ in
         switch action {
         case .didToggle:

--- a/Examples/Examples/5-OptionalIfLet/OptionalIfLetVC.swift
+++ b/Examples/Examples/5-OptionalIfLet/OptionalIfLetVC.swift
@@ -13,18 +13,18 @@ class OptionalIfLetVC: UIScrollVC {
     private let explanationTextView: UITextView = {
         let textView = UITextView()
         textView.text = """
-        IfLet is used usually when you have an optional property that you need to scoped.
-        """
+            IfLet is used usually when you have an optional property that you need to scoped.
+            """
         textView.isScrollEnabled = false
         return textView
     }()
-    
+
     private let textLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
         return label
     }()
-    
+
     private let switchLabelView: UILabel = {
         let label = UILabel()
         label.text = "Toggle Counter View"
@@ -32,59 +32,63 @@ class OptionalIfLetVC: UIScrollVC {
         return label
     }()
     private let switchView = UISwitch()
-    
+
     private var counterView: CounterView?
-    
+
     private let store: Store<OptionalIfLetState, OptionalIfLetAction>
-    
+
     private let stackView: UIStackView
-    
+
     init(store: Store<OptionalIfLetState, OptionalIfLetAction>) {
         self.store = store
-        stackView = UIStackView.vertical(subviews: [
-            explanationTextView,
-            textLabel,
-            UIStackView.horizontal(subviews: [switchLabelView, switchView], spacing: 16)
-        ], spacing: 8)
+        stackView = UIStackView.vertical(
+            subviews: [
+                explanationTextView,
+                textLabel,
+                UIStackView.horizontal(subviews: [switchLabelView, switchView], spacing: 16),
+            ], spacing: 8)
         stackView.alignment = .center
         super.init()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         contentView.addSubview(stackView)
         stackView.fillSuperview(padding: UIEdgeInsets(top: 0, left: 16, bottom: 16, right: 16))
-        
+
         switchView.addTarget(self, action: #selector(didTapSwitch), for: .touchUpInside)
         bindState()
     }
-    
+
     private func bindState() {
         store.subscribe(\.number)
             .subscribe(onNext: { [textLabel] in
                 textLabel.text = "Last saved number: \($0)"
             })
             .disposed(by: disposeBag)
-        
+
         store.scope(
             state: \.counter,
             action: OptionalIfLetAction.counter
-        ).ifLet(then: { [weak self] wrappedStore in
-            let counterView = CounterView(store: wrappedStore)
-            self?.counterView = counterView
-            self?.stackView.addArrangedSubview(counterView)
-        }, else: { [weak self] in
-            self?.counterView?.removeFromSuperview()
-            self?.counterView = nil
-        })
+        ).ifLet(
+            then: { [weak self] wrappedStore in
+                let counterView = CounterView(store: wrappedStore)
+                self?.counterView = counterView
+                self?.stackView.addArrangedSubview(counterView)
+            },
+            else: { [weak self] in
+                self?.counterView?.removeFromSuperview()
+                self?.counterView = nil
+            }
+        )
         .disposed(by: disposeBag)
     }
-    
+
     @objc private func didTapSwitch() {
         store.send(.didToggle)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Examples/Examples/6-NeverEqual/NeverEqualVC+Reducer.swift
+++ b/Examples/Examples/6-NeverEqual/NeverEqualVC+Reducer.swift
@@ -8,24 +8,25 @@
 import RxComposableArchitecture
 
 struct NeverEqualState: Equatable {
-     @NeverEqual
-     var showAlert: String?
-     @NeverEqual
-     var scrollToTop: Stateless?
- }
+    @NeverEqual
+    var showAlert: String?
+    @NeverEqual
+    var scrollToTop: Stateless?
+}
 
- enum NeverEqualAction: Equatable {
-     case didTapShowAlert
-     case didTapScrollToTop
- }
+enum NeverEqualAction: Equatable {
+    case didTapShowAlert
+    case didTapScrollToTop
+}
 
- internal let neverEqualDemoReducer = Reducer<NeverEqualState, NeverEqualAction, Void> { state, action, _ in
-     switch action {
-     case .didTapShowAlert:
-         state.showAlert = "This is an alert"
-         return .none
-     case .didTapScrollToTop:
-         state.scrollToTop = Stateless()
-         return .none
-     }
- }
+internal let neverEqualDemoReducer = Reducer<NeverEqualState, NeverEqualAction, Void> {
+    state, action, _ in
+    switch action {
+    case .didTapShowAlert:
+        state.showAlert = "This is an alert"
+        return .none
+    case .didTapScrollToTop:
+        state.scrollToTop = Stateless()
+        return .none
+    }
+}

--- a/Examples/Examples/6-NeverEqual/NeverEqualVC.swift
+++ b/Examples/Examples/6-NeverEqual/NeverEqualVC.swift
@@ -17,72 +17,74 @@ class NeverEqualVC: UIScrollVC {
         return text
     }()
     private let showAlertButton = UIButton.template(title: "Show Alert")
-    
+
     private let tallView: UIView = {
         let view = UIView()
         view.backgroundColor = .systemMint
         view.heightAnchor.constraint(equalToConstant: 400).isActive = true
         return view
     }()
-    
+
     private let tallView2: UIView = {
         let view = UIView()
         view.backgroundColor = .systemTeal
         view.heightAnchor.constraint(equalToConstant: 700).isActive = true
         return view
     }()
-    
+
     private let scrollToTopButton = UIButton.template(title: "Scroll to Top")
-    
+
     private let store: Store<NeverEqualState, NeverEqualAction>
-    
+
     init(store: Store<NeverEqualState, NeverEqualAction>) {
         self.store = store
         super.init()
         title = "NeverEqual Demo"
     }
-    
+
     override func loadView() {
         super.loadView()
-        let stack = UIStackView.vertical(subviews: [
-            explanationTextView, showAlertButton, tallView, tallView2, scrollToTopButton
-        ], spacing: 16)
+        let stack = UIStackView.vertical(
+            subviews: [
+                explanationTextView, showAlertButton, tallView, tallView2, scrollToTopButton,
+            ], spacing: 16)
         contentView.addSubview(stack)
         stack.fillSuperview()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         store.subscribeNeverEqual(\.$showAlert)
             .subscribe(onNext: { [weak self] message in
                 if let message = message {
-                    let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
+                    let alert = UIAlertController(
+                        title: message, message: nil, preferredStyle: .alert)
                     let okAction = UIAlertAction(title: "Ok", style: .default)
                     alert.addAction(okAction)
                     self?.navigationController?.present(alert, animated: true)
                 }
             })
             .disposed(by: disposeBag)
-        
+
         store.subscribeNeverEqual(\.$scrollToTop)
             .filter { $0 != nil }
             .subscribe(onNext: { [weak self] _ in
                 self?.scrollView.scrollToTop()
             })
             .disposed(by: disposeBag)
-        
+
         showAlertButton.addTarget(self, action: #selector(didTapShowAlert), for: .touchUpInside)
         scrollToTopButton.addTarget(self, action: #selector(didTapScrollToTop), for: .touchUpInside)
     }
-    
+
     @objc private func didTapShowAlert() {
         store.send(.didTapShowAlert)
     }
-    
+
     @objc private func didTapScrollToTop() {
         store.send(.didTapScrollToTop)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -91,7 +93,7 @@ class NeverEqualVC: UIScrollVC {
 extension UIScrollView {
     public func scrollToTop(animated: Bool = true) {
         let inset = self.contentInset
-        
+
         self.setContentOffset(CGPoint(x: -inset.left, y: -inset.top), animated: animated)
     }
 }

--- a/Examples/Examples/7-Timer/TimerVC+Reducer.swift
+++ b/Examples/Examples/7-Timer/TimerVC+Reducer.swift
@@ -25,7 +25,7 @@ internal let timerDemoReducer = Reducer<TimerState, TimerAction, Void> { state, 
                 print(">> Timer tick")
                 return TimerAction.onTimerTick
             }
-        
+
     case .onTimerTick:
         state.tickCount += 1
         return .none

--- a/Examples/Examples/7-Timer/TimerVC.swift
+++ b/Examples/Examples/7-Timer/TimerVC.swift
@@ -16,39 +16,40 @@ class TimerVC: UIScrollVC {
         text.numberOfLines = 0
         return text
     }()
-    
+
     private let tickCountLabel = UILabel()
-       
+
     private let store: Store<TimerState, TimerAction>
-    
+
     init(store: Store<TimerState, TimerAction>) {
         self.store = store
         super.init()
         title = "Timer Demo"
     }
-    
+
     override func loadView() {
         super.loadView()
-        let stack = UIStackView.vertical(subviews: [
-            explanationTextView, tickCountLabel
-        ], spacing: 16)
+        let stack = UIStackView.vertical(
+            subviews: [
+                explanationTextView, tickCountLabel,
+            ], spacing: 16)
         stack.alignment = .center
         contentView.addSubview(stack)
         stack.fillSuperview()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         store.subscribe(\.tickCount)
             .subscribe(onNext: { [tickCountLabel] tickCount in
                 tickCountLabel.text = "\(tickCount)"
             })
             .disposed(by: disposeBag)
-        
+
         store.send(.onDidLoad)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Examples/Examples/AppDelegate.swift
+++ b/Examples/Examples/AppDelegate.swift
@@ -9,9 +9,11 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 }
-

--- a/Examples/Examples/Helper/UIKit+Helper.swift
+++ b/Examples/Examples/Helper/UIKit+Helper.swift
@@ -23,7 +23,7 @@ extension UIStackView {
         stack.spacing = spacing
         return stack
     }
-    
+
     static func horizontal(subviews: [UIView], spacing: CGFloat = 0) -> UIStackView {
         let stack = UIStackView(arrangedSubviews: subviews)
         stack.axis = .horizontal

--- a/Examples/Examples/Helper/UIScrollVC.swift
+++ b/Examples/Examples/Helper/UIScrollVC.swift
@@ -14,35 +14,37 @@ class UIScrollVC: UIViewController {
         scrollView.keyboardDismissMode = .interactive
         return scrollView
     }()
-    
+
     let contentView = UIView()
-    
+
     let disposeBag = DisposeBag()
-    
+
     init() {
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     override func loadView() {
         super.loadView()
         setupScrollView()
         scrollView.backgroundColor = .systemBackground
     }
-    
+
     private func setupScrollView() {
         view.addSubview(scrollView)
         scrollView.addSubview(contentView)
-        
-        let centerYConstraint = contentView.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor)
+
+        let centerYConstraint = contentView.centerYAnchor.constraint(
+            equalTo: scrollView.centerYAnchor)
         centerYConstraint.priority = .defaultLow
         centerYConstraint.isActive = true
-        
-        let bottomContentViewConstraint = contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor)
+
+        let bottomContentViewConstraint = contentView.bottomAnchor.constraint(
+            equalTo: scrollView.bottomAnchor)
         bottomContentViewConstraint.priority = .defaultLow
         bottomContentViewConstraint.isActive = true
-        
+
         scrollView.fill(to: view)
-        
+
         contentView.anchor(
             top: scrollView.topAnchor,
             leading: scrollView.leadingAnchor,
@@ -51,7 +53,7 @@ class UIScrollVC: UIViewController {
             centerX: scrollView.centerXAnchor
         )
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Examples/Examples/Helper/UIView+AutoLayout.swift
+++ b/Examples/Examples/Helper/UIView+AutoLayout.swift
@@ -9,19 +9,23 @@ import UIKit
 
 extension UIView {
     public func fillSuperview(padding: UIEdgeInsets = .zero) {
-        anchor(top: superview?.topAnchor, leading: superview?.leadingAnchor, bottom: superview?.bottomAnchor, trailing: superview?.trailingAnchor, padding: padding)
+        anchor(
+            top: superview?.topAnchor, leading: superview?.leadingAnchor,
+            bottom: superview?.bottomAnchor, trailing: superview?.trailingAnchor, padding: padding)
     }
-    
+
     public func fill(to view: UIView, padding: UIEdgeInsets = .zero) {
-        anchor(top: view.topAnchor, leading: view.leadingAnchor, bottom: view.bottomAnchor, trailing: view.trailingAnchor, padding: padding)
+        anchor(
+            top: view.topAnchor, leading: view.leadingAnchor, bottom: view.bottomAnchor,
+            trailing: view.trailingAnchor, padding: padding)
     }
-    
+
     public func anchorSize(to view: UIView) {
         translatesAutoresizingMaskIntoConstraints = false
         widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
         heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true
     }
-    
+
     public func anchorSize(to size: CGSize) {
         translatesAutoresizingMaskIntoConstraints = false
         if size.width != 0 {
@@ -31,13 +35,15 @@ extension UIView {
             heightAnchor.constraint(equalToConstant: size.height).isActive = true
         }
     }
-    
+
     public func anchorCenter(to view: UIView, offset: CGSize = .zero) {
         translatesAutoresizingMaskIntoConstraints = false
-        centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: offset.width).isActive = true
-        centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: offset.height).isActive = true
+        centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: offset.width).isActive =
+            true
+        centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: offset.height).isActive =
+            true
     }
-    
+
     public func anchor(
         top: NSLayoutYAxisAnchor?,
         leading: NSLayoutXAxisAnchor?,
@@ -52,36 +58,36 @@ extension UIView {
         if let top = top {
             topAnchor.constraint(equalTo: top, constant: padding.top).isActive = true
         }
-        
+
         if let leading = leading {
             leadingAnchor.constraint(equalTo: leading, constant: padding.left).isActive = true
         }
-        
+
         if let bottom = bottom {
             bottomAnchor.constraint(equalTo: bottom, constant: -padding.bottom).isActive = true
         }
-        
+
         if let trailing = trailing {
             trailingAnchor.constraint(equalTo: trailing, constant: -padding.right).isActive = true
         }
-        
+
         if size.width != 0 {
             widthAnchor.constraint(equalToConstant: size.width).isActive = true
         }
-        
+
         if size.height != 0 {
             heightAnchor.constraint(equalToConstant: size.height).isActive = true
         }
-        
+
         if let centerX = centerX {
             centerXAnchor.constraint(equalTo: centerX).isActive = true
         }
-        
+
         if let centerY = centerY {
             centerYAnchor.constraint(equalTo: centerY).isActive = true
         }
     }
-    
+
     public func anchorSafeArea(
         top: NSLayoutYAxisAnchor?,
         leading: NSLayoutXAxisAnchor?,
@@ -94,33 +100,38 @@ extension UIView {
     ) {
         translatesAutoresizingMaskIntoConstraints = false
         if let top = top {
-            safeAreaLayoutGuide.topAnchor.constraint(equalTo: top, constant: padding.top).isActive = true
+            safeAreaLayoutGuide.topAnchor.constraint(equalTo: top, constant: padding.top).isActive =
+                true
         }
-        
+
         if let leading = leading {
-            safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: leading, constant: padding.left).isActive = true
+            safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: leading, constant: padding.left)
+                .isActive = true
         }
-        
+
         if let bottom = bottom {
-            safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: bottom, constant: -padding.bottom).isActive = true
+            safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: bottom, constant: -padding.bottom)
+                .isActive = true
         }
-        
+
         if let trailing = trailing {
-            safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: trailing, constant: -padding.right).isActive = true
+            safeAreaLayoutGuide.trailingAnchor.constraint(
+                equalTo: trailing, constant: -padding.right
+            ).isActive = true
         }
-        
+
         if size.width != 0 {
             widthAnchor.constraint(equalToConstant: size.width).isActive = true
         }
-        
+
         if size.height != 0 {
             heightAnchor.constraint(equalToConstant: size.height).isActive = true
         }
-        
+
         if let centerX = centerX {
             centerXAnchor.constraint(equalTo: centerX).isActive = true
         }
-        
+
         if let centerY = centerY {
             centerYAnchor.constraint(equalTo: centerY).isActive = true
         }

--- a/Examples/Examples/RouteVC.swift
+++ b/Examples/Examples/RouteVC.swift
@@ -25,75 +25,83 @@ class RouteVC: UITableViewController {
         title = "RxComposableArchitecture Examples"
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
     }
-    
+
     override internal func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
         let selectedRoute = routes[indexPath.row]
         switch selectedRoute {
         case .basic:
-            let viewController = BasicUsageVC(store: Store(
-                initialState: BasicState(number: 0),
-                reducer: basicUsageReducer,
-                environment: (),
-                useNewScope: true
-            ))
+            let viewController = BasicUsageVC(
+                store: Store(
+                    initialState: BasicState(number: 0),
+                    reducer: basicUsageReducer,
+                    environment: (),
+                    useNewScope: true
+                ))
             navigationController?.pushViewController(viewController, animated: true)
         case .environment:
             navigationController?.pushViewController(EnvironmentRouteVC(), animated: true)
         case .scoping:
-            let viewController = ScopingVC(store: Store(
-                initialState: ScopingState(),
-                reducer: scopingReducer,
-                environment: (),
-                useNewScope: true
-            ))
+            let viewController = ScopingVC(
+                store: Store(
+                    initialState: ScopingState(),
+                    reducer: scopingReducer,
+                    environment: (),
+                    useNewScope: true
+                ))
             navigationController?.pushViewController(viewController, animated: true)
         case .pullback:
-            let viewController = PullbackVC(store: Store(
-                initialState: PullbackState(),
-                reducer: pullbackReducer,
-                environment: (),
-                useNewScope: true
-            ))
+            let viewController = PullbackVC(
+                store: Store(
+                    initialState: PullbackState(),
+                    reducer: pullbackReducer,
+                    environment: (),
+                    useNewScope: true
+                ))
             navigationController?.pushViewController(viewController, animated: true)
         case .optionalIfLet:
-            let viewController = OptionalIfLetVC(store: Store(
-                initialState: OptionalIfLetState(),
-                reducer: optionalIfLetReducer,
-                environment: (),
-                useNewScope: true
-            ))
+            let viewController = OptionalIfLetVC(
+                store: Store(
+                    initialState: OptionalIfLetState(),
+                    reducer: optionalIfLetReducer,
+                    environment: (),
+                    useNewScope: true
+                ))
             navigationController?.pushViewController(viewController, animated: true)
         case .neverEqual:
-            let viewController = NeverEqualVC(store: Store(
-                initialState: NeverEqualState(),
-                reducer: neverEqualDemoReducer,
-                environment: (),
-                useNewScope: true
-            ))
+            let viewController = NeverEqualVC(
+                store: Store(
+                    initialState: NeverEqualState(),
+                    reducer: neverEqualDemoReducer,
+                    environment: (),
+                    useNewScope: true
+                ))
             navigationController?.pushViewController(viewController, animated: true)
         case .timer:
-            let viewController = TimerVC(store: Store(
-                initialState: TimerState(),
-                reducer: timerDemoReducer,
-                environment: (),
-                useNewScope: true
-            ))
+            let viewController = TimerVC(
+                store: Store(
+                    initialState: TimerState(),
+                    reducer: timerDemoReducer,
+                    environment: (),
+                    useNewScope: true
+                ))
             navigationController?.pushViewController(viewController, animated: true)
         }
     }
-    
+
     override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
         routes.count
     }
 
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)
+        -> UITableViewCell
+    {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
         cell.textLabel?.text = routes[indexPath.row].rawValue
         return cell
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Examples/Examples/SceneDelegate.swift
+++ b/Examples/Examples/SceneDelegate.swift
@@ -11,11 +11,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    func scene(
+        _ scene: UIScene, willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = UINavigationController(rootViewController: RouteVC())
         window?.makeKeyAndVisible()
     }
 }
-

--- a/Examples/ExamplesTests/BasicReducerTests.swift
+++ b/Examples/ExamplesTests/BasicReducerTests.swift
@@ -7,46 +7,57 @@
 
 import RxComposableArchitecture
 import XCTest
+
 @testable import Examples
 
 class BasicReducerTests: XCTestCase {
 
     func testTapPlus() {
-        let testStore = TestStore(initialState: BasicState(number: 0), reducer: basicUsageReducer, environment: (), useNewScope: true)
-        
+        let testStore = TestStore(
+            initialState: BasicState(number: 0), reducer: basicUsageReducer, environment: (),
+            useNewScope: true)
+
         testStore.send(.didTapPlus) {
             $0.number = 1
         }
     }
-    
+
     func testTapMinus() {
-        let testStore = TestStore(initialState: BasicState(number: 5), reducer: basicUsageReducer, environment: (), useNewScope: true)
-        
+        let testStore = TestStore(
+            initialState: BasicState(number: 5), reducer: basicUsageReducer, environment: (),
+            useNewScope: true)
+
         testStore.send(.didTapMinus) {
             $0.number = 4
         }
     }
-    
+
     func testTapMinusOnZero() {
-        let testStore = TestStore(initialState: BasicState(number: 0), reducer: basicUsageReducer, environment: (), useNewScope: true)
-        
+        let testStore = TestStore(
+            initialState: BasicState(number: 0), reducer: basicUsageReducer, environment: (),
+            useNewScope: true)
+
         testStore.send(.didTapMinus) {
             $0.errorMessage = "Can't below 0"
         }
     }
-    
+
     func testShouldResetErrorWhenTappingPlus() {
-        let testStore = TestStore(initialState: BasicState(number: 0, errorMessage: "SomeError"), reducer: basicUsageReducer, environment: (), useNewScope: true)
-        
+        let testStore = TestStore(
+            initialState: BasicState(number: 0, errorMessage: "SomeError"),
+            reducer: basicUsageReducer, environment: (), useNewScope: true)
+
         testStore.send(.didTapPlus) {
             $0.number = 1
             $0.errorMessage = nil
         }
     }
-    
+
     func testShouldResetErrorWhenTappingMinusWithNumberGreaterThanZero() {
-        let testStore = TestStore(initialState: BasicState(number: 1, errorMessage: "SomeError"), reducer: basicUsageReducer, environment: (), useNewScope: true)
-        
+        let testStore = TestStore(
+            initialState: BasicState(number: 1, errorMessage: "SomeError"),
+            reducer: basicUsageReducer, environment: (), useNewScope: true)
+
         testStore.send(.didTapMinus) {
             $0.number = 0
             $0.errorMessage = nil

--- a/Examples/ExamplesTests/EnvironmentReducerTests.swift
+++ b/Examples/ExamplesTests/EnvironmentReducerTests.swift
@@ -5,9 +5,10 @@
 //  Created by jefferson.setiawan on 03/06/22.
 //
 
-import XCTest
 import RxComposableArchitecture
 import RxSwift
+import XCTest
+
 @testable import Examples
 
 final class EnvironmentReducerTests: XCTestCase {
@@ -27,7 +28,7 @@ final class EnvironmentReducerTests: XCTestCase {
             reducer: environmentReducer,
             environment: EnvironmentVCEnvironment.failing
         )
-        
+
         store.environment.loadData = { Observable.just(.success(2)).eraseToEffect() }
 
         store.send(.didLoad) {
@@ -85,11 +86,12 @@ final class EnvironmentReducerTests: XCTestCase {
             $0.isLoading = false
             $0.text = "Data from environment: 5"
         }
-        XCTAssertEqual(trackEventSink,
-                       [
-                           AnalyticsEvent(name: "refresh", category: "DUMMY"),
-                           AnalyticsEvent(name: "refresh", category: "DUMMY")
-                       ])
+        XCTAssertEqual(
+            trackEventSink,
+            [
+                AnalyticsEvent(name: "refresh", category: "DUMMY"),
+                AnalyticsEvent(name: "refresh", category: "DUMMY"),
+            ])
     }
 
     func testGetCurrentDate() {
@@ -98,7 +100,7 @@ final class EnvironmentReducerTests: XCTestCase {
             reducer: environmentReducer,
             environment: EnvironmentVCEnvironment.failing
         )
-        
+
         store.environment.date = { Date(timeIntervalSince1970: 1_597_300_000) }
         store.environment.trackEvent = trackEventHandler
         store.send(.getCurrentDate) {
@@ -113,7 +115,7 @@ final class EnvironmentReducerTests: XCTestCase {
             reducer: environmentReducer,
             environment: EnvironmentVCEnvironment.failing
         )
-        
+
         store.environment.uuid = UUID.incrementing
         store.environment.trackEvent = trackEventHandler
         store.send(.generateUUID) {
@@ -122,11 +124,12 @@ final class EnvironmentReducerTests: XCTestCase {
         store.send(.generateUUID) {
             $0.uuidString = "00000000-0000-0000-0000-000000000001"
         }
-        XCTAssertEqual(trackEventSink,
-                       [
-                           AnalyticsEvent(name: "generateUUID", category: "DUMMY"),
-                           AnalyticsEvent(name: "generateUUID", category: "DUMMY")
-                       ])
+        XCTAssertEqual(
+            trackEventSink,
+            [
+                AnalyticsEvent(name: "generateUUID", category: "DUMMY"),
+                AnalyticsEvent(name: "generateUUID", category: "DUMMY"),
+            ])
     }
 }
 

--- a/Examples/ExamplesTests/OptionalIfLetReducerTests.swift
+++ b/Examples/ExamplesTests/OptionalIfLetReducerTests.swift
@@ -5,25 +5,29 @@
 //  Created by jefferson.setiawan on 06/06/22.
 //
 
-import XCTest
 import RxComposableArchitecture
 import RxSwift
+import XCTest
+
 @testable import Examples
 
 class OptionalIfLetReducerTests: XCTestCase {
     func testDidSwitchToggle() {
-        let testStore = TestStore(initialState: OptionalIfLetState(), reducer: optionalIfLetReducer, environment: ())
+        let testStore = TestStore(
+            initialState: OptionalIfLetState(), reducer: optionalIfLetReducer, environment: ())
         testStore.send(.didToggle) {
             $0.counter = CounterState()
         }
     }
-    
+
     func testChangeCounterThenToggle() {
-        let testStore = TestStore(initialState: OptionalIfLetState(number: 0, counter: CounterState(number: 10)), reducer: optionalIfLetReducer, environment: ())
+        let testStore = TestStore(
+            initialState: OptionalIfLetState(number: 0, counter: CounterState(number: 10)),
+            reducer: optionalIfLetReducer, environment: ())
         testStore.send(.counter(.didTapPlus)) {
             $0.counter!.number = 11
         }
-        
+
         testStore.send(.didToggle) {
             $0.number = 11
             $0.counter = nil

--- a/Examples/ExamplesTests/PullbackReducerTests.swift
+++ b/Examples/ExamplesTests/PullbackReducerTests.swift
@@ -5,25 +5,28 @@
 //  Created by jefferson.setiawan on 03/06/22.
 //
 
-import XCTest
 import RxComposableArchitecture
 import RxSwift
+import XCTest
+
 @testable import Examples
 
 class PullbackReducerTests: XCTestCase {
     func testDidChangeText() {
-        let testStore = TestStore(initialState: PullbackState(), reducer: pullbackReducer, environment: ())
+        let testStore = TestStore(
+            initialState: PullbackState(), reducer: pullbackReducer, environment: ())
         testStore.send(.textDidChange("Hello")) {
             $0.text = "You write: Hello"
         }
     }
-    
+
     func testSmallerReducer() {
-        let testStore = TestStore(initialState: CounterState(), reducer: pullbackCounterReducer, environment: ())
+        let testStore = TestStore(
+            initialState: CounterState(), reducer: pullbackCounterReducer, environment: ())
         testStore.send(.didTapMinus) {
             $0.number = -1
         }
-        
+
         testStore.send(.didTapPlus) {
             $0.number = 0
         }

--- a/Examples/ExamplesTests/ScopingReducerTests.swift
+++ b/Examples/ExamplesTests/ScopingReducerTests.swift
@@ -5,31 +5,38 @@
 //  Created by jefferson.setiawan on 03/06/22.
 //
 
-import XCTest
 import RxComposableArchitecture
 import RxSwift
+import XCTest
+
 @testable import Examples
 
 class ScopingReducerTests: XCTestCase {
     func testTapPlus() {
-        let testStore = TestStore(initialState: ScopingState(), reducer: scopingReducer, environment: (), useNewScope: true)
-        
+        let testStore = TestStore(
+            initialState: ScopingState(), reducer: scopingReducer, environment: (),
+            useNewScope: true)
+
         testStore.send(.counter(.didTapPlus)) {
             $0.counter.number = 1
         }
     }
-    
+
     func testTapMinus() {
-        let testStore = TestStore(initialState: ScopingState(), reducer: scopingReducer, environment: (), useNewScope: true)
-        
+        let testStore = TestStore(
+            initialState: ScopingState(), reducer: scopingReducer, environment: (),
+            useNewScope: true)
+
         testStore.send(.counter(.didTapMinus)) {
             $0.counter.number = -1
         }
     }
-    
+
     func testTapJumpButton() {
-        let testStore = TestStore(initialState: ScopingState(), reducer: scopingReducer, environment: (), useNewScope: true)
-        
+        let testStore = TestStore(
+            initialState: ScopingState(), reducer: scopingReducer, environment: (),
+            useNewScope: true)
+
         testStore.send(.didTapJump) {
             $0.counter.number = 100
         }

--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,13 @@ let package = Package(
     products: [
         .library(
             name: "RxComposableArchitecture",
-            targets: ["RxComposableArchitecture"]),
+            targets: ["RxComposableArchitecture"])
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveX/RxSwift", from: "5.1.1"),
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.1"),
-        .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
+        .package(
+            name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
     ],
     targets: [
         .target(
@@ -34,7 +35,7 @@ let package = Package(
             name: "RxComposableArchitecture-Benchmark",
             dependencies: [
                 "RxComposableArchitecture",
-                .product(name: "Benchmark", package: "Benchmark")
-            ])
+                .product(name: "Benchmark", package: "Benchmark"),
+            ]),
     ]
 )

--- a/Sources/RxComposableArchitecture-Benchmark/Common.swift
+++ b/Sources/RxComposableArchitecture-Benchmark/Common.swift
@@ -19,7 +19,7 @@ struct Benchmarking: AnyBenchmark {
     private let _run: () throws -> Void
     private let _setUp: () -> Void
     private let _tearDown: () -> Void
-    
+
     init(
         name: String,
         run: @escaping () throws -> Void,
@@ -31,15 +31,15 @@ struct Benchmarking: AnyBenchmark {
         self._setUp = setUp
         self._tearDown = tearDown
     }
-    
+
     func setUp() {
         self._setUp()
     }
-    
+
     func run(_ state: inout BenchmarkState) throws {
         try self._run()
     }
-    
+
     func tearDown() {
         self._tearDown()
     }
@@ -49,6 +49,6 @@ struct Benchmarking: AnyBenchmark {
 func doNotOptimizeAway<T>(_ x: T) {
     @_optimize(none)
     func assumePointeeIsRead(_ x: UnsafeRawPointer) {}
-    
+
     withUnsafePointer(to: x) { assumePointeeIsRead($0) }
 }

--- a/Sources/RxComposableArchitecture-Benchmark/Effect.swift
+++ b/Sources/RxComposableArchitecture-Benchmark/Effect.swift
@@ -1,13 +1,13 @@
 import Benchmark
-import RxComposableArchitecture
 import Foundation
+import RxComposableArchitecture
 import RxSwift
 
 let effectSuite = BenchmarkSuite(name: "Effects") {
     $0.benchmark("Merged Effect.none (create, flat)") {
         doNotOptimizeAway(Effect<Int>.merge((1...100).map { _ in .none }))
     }
-    
+
     $0.benchmark("Merged Effect.none (create, nested)") {
         var effect = Effect<Int>.none
         for _ in 1...100 {
@@ -15,13 +15,13 @@ let effectSuite = BenchmarkSuite(name: "Effects") {
         }
         doNotOptimizeAway(effect)
     }
-    
+
     let effect = Effect<Int>.merge((1...100).map { _ in .none })
     var disposeBag = DisposeBag()
     var didComplete = false
     $0.benchmark("Merged Effect.none (sink)") {
         doNotOptimizeAway(
-            effect.subscribe(onCompleted: {  didComplete = true }).disposed(by: disposeBag)
+            effect.subscribe(onCompleted: { didComplete = true }).disposed(by: disposeBag)
         )
     } tearDown: {
         precondition(didComplete)

--- a/Sources/RxComposableArchitecture-Benchmark/StoreScope.swift
+++ b/Sources/RxComposableArchitecture-Benchmark/StoreScope.swift
@@ -18,7 +18,7 @@ let storeScopeSuite = BenchmarkSuite(name: "Store scoping") { suite in
         viewStores.append(store)
     }
     let lastViewStore = viewStores.last!
-    
+
     suite.benchmark("Nested store") {
         lastViewStore.send(true)
     }
@@ -41,7 +41,7 @@ let newStoreScopeSuite = BenchmarkSuite(name: "[NEW] Store scoping, with rescope
         viewStores.append(store)
     }
     let lastViewStore = viewStores.last!
-    
+
     suite.benchmark("[NEW] Nested store, with rescope") {
         lastViewStore.send(true)
     }

--- a/Sources/RxComposableArchitecture/Binding.swift
+++ b/Sources/RxComposableArchitecture/Binding.swift
@@ -145,7 +145,7 @@ public struct BindingAction<Root>: Equatable {
         _ keyPath: WritableKeyPath<Root, Value>,
         _ value: Value
     ) -> Self
-        where Value: Equatable {
+    where Value: Equatable {
         .init(
             keyPath: keyPath,
             set: { $0[keyPath: keyPath] = value },
@@ -163,7 +163,8 @@ public struct BindingAction<Root>: Equatable {
         _ keyPath: WritableKeyPath<NewRoot, Root>
     ) -> BindingAction<NewRoot> {
         .init(
-            keyPath: (keyPath as AnyKeyPath).appending(path: self.keyPath) as! PartialKeyPath<NewRoot>,
+            keyPath: (keyPath as AnyKeyPath).appending(path: self.keyPath)
+                as! PartialKeyPath<NewRoot>,
             set: { self.set(&$0[keyPath: keyPath]) },
             value: value,
             valueIsEqualTo: valueIsEqualTo

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/CoreImage.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/CoreImage.swift
@@ -1,61 +1,61 @@
 #if canImport(CoreImage)
-  import CoreImage
+    import CoreImage
 
-  @available(watchOS, unavailable)
-  extension CIQRCodeDescriptor.ErrorCorrectionLevel: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .levelL:
-        return "CIQRCodeDescriptor.ErrorCorrectionLevel.levelL"
-      case .levelM:
-        return "CIQRCodeDescriptor.ErrorCorrectionLevel.levelM"
-      case .levelQ:
-        return "CIQRCodeDescriptor.ErrorCorrectionLevel.levelQ"
-      case .levelH:
-        return "CIQRCodeDescriptor.ErrorCorrectionLevel.levelH"
-      @unknown default:
-        return
-          "CIQRCodeDescriptor.ErrorCorrectionLevel.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(watchOS, unavailable)
+    extension CIQRCodeDescriptor.ErrorCorrectionLevel: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .levelL:
+                return "CIQRCodeDescriptor.ErrorCorrectionLevel.levelL"
+            case .levelM:
+                return "CIQRCodeDescriptor.ErrorCorrectionLevel.levelM"
+            case .levelQ:
+                return "CIQRCodeDescriptor.ErrorCorrectionLevel.levelQ"
+            case .levelH:
+                return "CIQRCodeDescriptor.ErrorCorrectionLevel.levelH"
+            @unknown default:
+                return
+                    "CIQRCodeDescriptor.ErrorCorrectionLevel.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  extension CIDataMatrixCodeDescriptor.ECCVersion: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
+    extension CIDataMatrixCodeDescriptor.ECCVersion: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
 
-      case .v000:
-        return "CIDataMatrixCodeDescriptor.ECCVersion.v000"
-      case .v050:
-        return "CIDataMatrixCodeDescriptor.ECCVersion.v050"
-      case .v080:
-        return "CIDataMatrixCodeDescriptor.ECCVersion.v080"
-      case .v100:
-        return "CIDataMatrixCodeDescriptor.ECCVersion.v100"
-      case .v140:
-        return "CIDataMatrixCodeDescriptor.ECCVersion.v140"
-      case .v200:
-        return "CIDataMatrixCodeDescriptor.ECCVersion.v200"
-      @unknown default:
-        return
-          "CIDataMatrixCodeDescriptor.ECCVersion.(@unknown default, rawValue: \(self.rawValue))"
-      }
+            case .v000:
+                return "CIDataMatrixCodeDescriptor.ECCVersion.v000"
+            case .v050:
+                return "CIDataMatrixCodeDescriptor.ECCVersion.v050"
+            case .v080:
+                return "CIDataMatrixCodeDescriptor.ECCVersion.v080"
+            case .v100:
+                return "CIDataMatrixCodeDescriptor.ECCVersion.v100"
+            case .v140:
+                return "CIDataMatrixCodeDescriptor.ECCVersion.v140"
+            case .v200:
+                return "CIDataMatrixCodeDescriptor.ECCVersion.v200"
+            @unknown default:
+                return
+                    "CIDataMatrixCodeDescriptor.ECCVersion.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  extension CIRenderDestinationAlphaMode: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .none:
-        return "CIRenderDestinationAlphaMode.none"
-      case .premultiplied:
-        return "CIRenderDestinationAlphaMode.premultiplied"
-      case .unpremultiplied:
-        return "CIRenderDestinationAlphaMode.unpremultiplied"
-      @unknown default:
-        return "CIRenderDestinationAlphaMode.(@unknown default, rawValue: \(self.rawValue)"
-      }
+    extension CIRenderDestinationAlphaMode: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .none:
+                return "CIRenderDestinationAlphaMode.none"
+            case .premultiplied:
+                return "CIRenderDestinationAlphaMode.premultiplied"
+            case .unpremultiplied:
+                return "CIRenderDestinationAlphaMode.unpremultiplied"
+            @unknown default:
+                return "CIRenderDestinationAlphaMode.(@unknown default, rawValue: \(self.rawValue)"
+            }
+        }
     }
-  }
 
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/CoreLocation.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/CoreLocation.swift
@@ -1,117 +1,117 @@
 #if canImport(CoreLocation)
-  import CoreLocation
+    import CoreLocation
 
-  #if compiler(>=5.4)
-    extension CLAccuracyAuthorization: CustomDumpStringConvertible {
-      public var customDumpDescription: String {
-        switch self {
-        case .fullAccuracy:
-          return "CLAccuracyAuthorization.fullAccuracy"
-        case .reducedAccuracy:
-          return "CLAccuracyAuthorization.reducedAccuracy"
-        @unknown default:
-          return "CLAccuracyAuthorization.(@unknown default, rawValue: \(self.rawValue))"
+    #if compiler(>=5.4)
+        extension CLAccuracyAuthorization: CustomDumpStringConvertible {
+            public var customDumpDescription: String {
+                switch self {
+                case .fullAccuracy:
+                    return "CLAccuracyAuthorization.fullAccuracy"
+                case .reducedAccuracy:
+                    return "CLAccuracyAuthorization.reducedAccuracy"
+                @unknown default:
+                    return "CLAccuracyAuthorization.(@unknown default, rawValue: \(self.rawValue))"
+                }
+            }
         }
-      }
-    }
-  #endif
+    #endif
 
-  extension CLActivityType: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .airborne:
-        return "CLActivityType.airborne"
-      case .automotiveNavigation:
-        return "CLActivityType.automotiveNavigation"
-      case .other:
-        return "CLActivityType.other"
-      case .fitness:
-        return "CLActivityType.fitness"
-      case .otherNavigation:
-        return "CLActivityType.otherNavigation"
-      @unknown default:
-        return "CLActivityType.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    extension CLActivityType: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .airborne:
+                return "CLActivityType.airborne"
+            case .automotiveNavigation:
+                return "CLActivityType.automotiveNavigation"
+            case .other:
+                return "CLActivityType.other"
+            case .fitness:
+                return "CLActivityType.fitness"
+            case .otherNavigation:
+                return "CLActivityType.otherNavigation"
+            @unknown default:
+                return "CLActivityType.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  extension CLAuthorizationStatus: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .authorizedAlways:
-        return "CLAuthorizationStatus.authorizedAlways"
-      case .authorizedWhenInUse:
-        return "CLAuthorizationStatus.authorizedWhenInUse"
-      case .denied:
-        return "CLAuthorizationStatus.denied"
-      case .notDetermined:
-        return "CLAuthorizationStatus.notDetermined"
-      case .restricted:
-        return "CLAuthorizationStatus.restricted"
-      @unknown default:
-        return "CLAuthorizationStatus.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    extension CLAuthorizationStatus: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .authorizedAlways:
+                return "CLAuthorizationStatus.authorizedAlways"
+            case .authorizedWhenInUse:
+                return "CLAuthorizationStatus.authorizedWhenInUse"
+            case .denied:
+                return "CLAuthorizationStatus.denied"
+            case .notDetermined:
+                return "CLAuthorizationStatus.notDetermined"
+            case .restricted:
+                return "CLAuthorizationStatus.restricted"
+            @unknown default:
+                return "CLAuthorizationStatus.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  extension CLDeviceOrientation: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .faceUp:
-        return "CLDeviceOrientation.faceUp"
-      case .faceDown:
-        return "CLDeviceOrientation.faceDown"
-      case .landscapeLeft:
-        return "CLDeviceOrientation.landscapeLeft"
-      case .landscapeRight:
-        return "CLDeviceOrientation.landscapeRight"
-      case .portrait:
-        return "CLDeviceOrientation.portrait"
-      case .portraitUpsideDown:
-        return "CLDeviceOrientation.portraitUpsideDown"
-      case .unknown:
-        return "CLDeviceOrientation.unknown"
-      @unknown default:
-        return "CLDeviceOrientation.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    extension CLDeviceOrientation: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .faceUp:
+                return "CLDeviceOrientation.faceUp"
+            case .faceDown:
+                return "CLDeviceOrientation.faceDown"
+            case .landscapeLeft:
+                return "CLDeviceOrientation.landscapeLeft"
+            case .landscapeRight:
+                return "CLDeviceOrientation.landscapeRight"
+            case .portrait:
+                return "CLDeviceOrientation.portrait"
+            case .portraitUpsideDown:
+                return "CLDeviceOrientation.portraitUpsideDown"
+            case .unknown:
+                return "CLDeviceOrientation.unknown"
+            @unknown default:
+                return "CLDeviceOrientation.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  #if compiler(>=5.3)
-    @available(iOS 7, macOS 10.15, *)
+    #if compiler(>=5.3)
+        @available(iOS 7, macOS 10.15, *)
+        @available(tvOS, unavailable)
+        @available(watchOS, unavailable)
+        extension CLProximity: CustomDumpStringConvertible {
+            public var customDumpDescription: String {
+                switch self {
+                case .far:
+                    return "CLProximity.far"
+                case .immediate:
+                    return "CLProximity.immediate"
+                case .near:
+                    return "CLProximity.near"
+                case .unknown:
+                    return "CLProximity.unknown"
+                @unknown default:
+                    return "CLProximity.(@unknown default, rawValue: \(self.rawValue))"
+                }
+            }
+        }
+    #endif
+
+    @available(iOS 7, macOS 10, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    extension CLProximity: CustomDumpStringConvertible {
-      public var customDumpDescription: String {
-        switch self {
-        case .far:
-          return "CLProximity.far"
-        case .immediate:
-          return "CLProximity.immediate"
-        case .near:
-          return "CLProximity.near"
-        case .unknown:
-          return "CLProximity.unknown"
-        @unknown default:
-          return "CLProximity.(@unknown default, rawValue: \(self.rawValue))"
+    extension CLRegionState: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .inside:
+                return "CLRegionState.inside"
+            case .outside:
+                return "CLRegionState.outside"
+            case .unknown:
+                return "CLRegionState.unknown"
+            }
         }
-      }
     }
-  #endif
-
-  @available(iOS 7, macOS 10, *)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  extension CLRegionState: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .inside:
-        return "CLRegionState.inside"
-      case .outside:
-        return "CLRegionState.outside"
-      case .unknown:
-        return "CLRegionState.unknown"
-      }
-    }
-  }
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/CoreMotion.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/CoreMotion.swift
@@ -1,91 +1,92 @@
 #if canImport(CoreMotion)
-  import CoreMotion
+    import CoreMotion
 
-  @available(iOS 11, watchOS 4, *)
-  extension CMAuthorizationStatus: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .authorized:
-        return "CMAuthorizationStatus.authorized"
-      case .denied:
-        return "CMAuthorizationStatus.denied"
-      case .notDetermined:
-        return "CMAuthorizationStatus.notDetermined"
-      case .restricted:
-        return "CMAuthorizationStatus.restricted"
-      @unknown default:
-        return "CMAuthorizationStatus.(@unknown default, rawValue: \(self.rawValue))"
-      }
-    }
-  }
-
-  #if compiler(>=5.4)
-    extension CMDeviceMotion.SensorLocation: CustomDumpStringConvertible {
-      public var customDumpDescription: String {
-        switch self {
-        case .default:
-          return "CMDeviceMotion.SensorLocation.default"
-        case .headphoneLeft:
-          return "CMDeviceMotion.SensorLocation.headphoneLeft"
-        case .headphoneRight:
-          return "CMDeviceMotion.SensorLocation.headphoneRight"
-        @unknown default:
-          return "CMDeviceMotion.SensorLocation.(@unknown default, rawValue: \(self.rawValue))"
+    @available(iOS 11, watchOS 4, *)
+    extension CMAuthorizationStatus: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .authorized:
+                return "CMAuthorizationStatus.authorized"
+            case .denied:
+                return "CMAuthorizationStatus.denied"
+            case .notDetermined:
+                return "CMAuthorizationStatus.notDetermined"
+            case .restricted:
+                return "CMAuthorizationStatus.restricted"
+            @unknown default:
+                return "CMAuthorizationStatus.(@unknown default, rawValue: \(self.rawValue))"
+            }
         }
-      }
     }
-  #endif
 
-  #if compiler(>=5.5)
-    @available(iOS, unavailable)
-    @available(macOS, unavailable)
-    @available(tvOS, unavailable)
-    @available(watchOS 7.2, *)
-    extension CMFallDetectionEvent.UserResolution: CustomDumpStringConvertible {
-      public var customDumpDescription: String {
-        switch self {
-        case .confirmed:
-          return "CMFallDetectionEvent.UserResolution.confirmed"
-        case .dismissed:
-          return "CMFallDetectionEvent.UserResolution.dismissed"
-        case .rejected:
-          return "CMFallDetectionEvent.UserResolution.rejected"
-        case .unresponsive:
-          return "CMFallDetectionEvent.UserResolution.unresponsive"
-        @unknown default:
-          return
-            "CMFallDetectionEvent.UserResolution.(@unknown default, rawValue: \(self.rawValue))"
+    #if compiler(>=5.4)
+        extension CMDeviceMotion.SensorLocation: CustomDumpStringConvertible {
+            public var customDumpDescription: String {
+                switch self {
+                case .default:
+                    return "CMDeviceMotion.SensorLocation.default"
+                case .headphoneLeft:
+                    return "CMDeviceMotion.SensorLocation.headphoneLeft"
+                case .headphoneRight:
+                    return "CMDeviceMotion.SensorLocation.headphoneRight"
+                @unknown default:
+                    return
+                        "CMDeviceMotion.SensorLocation.(@unknown default, rawValue: \(self.rawValue))"
+                }
+            }
         }
-      }
-    }
-  #endif
+    #endif
 
-  extension CMMotionActivityConfidence: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .high:
-        return "CMMotionActivityConfidence.high"
-      case .low:
-        return "CMMotionActivityConfidence.low"
-      case .medium:
-        return "CMMotionActivityConfidence.medium"
-      @unknown default:
-        return "CMMotionActivityConfidence.(@unknown default, rawValue: \(self.rawValue))"
-      }
-    }
-  }
+    #if compiler(>=5.5)
+        @available(iOS, unavailable)
+        @available(macOS, unavailable)
+        @available(tvOS, unavailable)
+        @available(watchOS 7.2, *)
+        extension CMFallDetectionEvent.UserResolution: CustomDumpStringConvertible {
+            public var customDumpDescription: String {
+                switch self {
+                case .confirmed:
+                    return "CMFallDetectionEvent.UserResolution.confirmed"
+                case .dismissed:
+                    return "CMFallDetectionEvent.UserResolution.dismissed"
+                case .rejected:
+                    return "CMFallDetectionEvent.UserResolution.rejected"
+                case .unresponsive:
+                    return "CMFallDetectionEvent.UserResolution.unresponsive"
+                @unknown default:
+                    return
+                        "CMFallDetectionEvent.UserResolution.(@unknown default, rawValue: \(self.rawValue))"
+                }
+            }
+        }
+    #endif
 
-  @available(iOS 10, watchOS 3, *)
-  extension CMPedometerEventType: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .pause:
-        return "CMPedometerEventType.pause"
-      case .resume:
-        return "CMPedometerEventType.resume"
-      @unknown default:
-        return "CMPedometerEventType.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    extension CMMotionActivityConfidence: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .high:
+                return "CMMotionActivityConfidence.high"
+            case .low:
+                return "CMMotionActivityConfidence.low"
+            case .medium:
+                return "CMMotionActivityConfidence.medium"
+            @unknown default:
+                return "CMMotionActivityConfidence.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
+
+    @available(iOS 10, watchOS 3, *)
+    extension CMPedometerEventType: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .pause:
+                return "CMPedometerEventType.pause"
+            case .resume:
+                return "CMPedometerEventType.resume"
+            @unknown default:
+                return "CMPedometerEventType.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
+    }
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/Foundation.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/Foundation.swift
@@ -1,317 +1,318 @@
 import Foundation
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+    import FoundationNetworking
 #endif
 
 // NB: Xcode 13 does not include macOS 12 SDK
 // NB: Swift 5.5 does not include AttributedString on other platforms (yet)
 #if compiler(>=5.5) && !targetEnvironment(macCatalyst) && (os(iOS) || os(tvOS) || os(watchOS))
-  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-  extension AttributedString: CustomDumpRepresentable {
-    public var customDumpValue: Any {
-      NSAttributedString(self).string
+    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+    extension AttributedString: CustomDumpRepresentable {
+        public var customDumpValue: Any {
+            NSAttributedString(self).string
+        }
     }
-  }
 #endif
 
 extension Calendar: CustomDumpReflectable {
-  public var customDumpMirror: Mirror {
-    .init(
-      self,
-      children: [
-        "identifier": self.identifier,
-        "locale": self.locale as Any,
-        "timeZone": self.timeZone,
-        "firstWeekday": self.firstWeekday,
-        "minimumDaysInFirstWeek": self.minimumDaysInFirstWeek,
-      ],
-      displayStyle: .struct
-    )
-  }
+    public var customDumpMirror: Mirror {
+        .init(
+            self,
+            children: [
+                "identifier": self.identifier,
+                "locale": self.locale as Any,
+                "timeZone": self.timeZone,
+                "firstWeekday": self.firstWeekday,
+                "minimumDaysInFirstWeek": self.minimumDaysInFirstWeek,
+            ],
+            displayStyle: .struct
+        )
+    }
 }
 
 extension Data: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    "Data(\(Self.formatter.string(fromByteCount: .init(self.count))))"
-  }
+    public var customDumpDescription: String {
+        "Data(\(Self.formatter.string(fromByteCount: .init(self.count))))"
+    }
 
-  private static let formatter: ByteCountFormatter = {
-    let formatter = ByteCountFormatter()
-    formatter.allowedUnits = .useBytes
-    return formatter
-  }()
+    private static let formatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = .useBytes
+        return formatter
+    }()
 }
 
 extension Date: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    "Date(\(Self.formatter.string(from: self)))"
-  }
+    public var customDumpDescription: String {
+        "Date(\(Self.formatter.string(from: self)))"
+    }
 
-  private static let formatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
-    formatter.timeZone = TimeZone(secondsFromGMT: 0)!
-    return formatter
-  }()
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)!
+        return formatter
+    }()
 }
 
 extension Decimal: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    self.description
-  }
+    public var customDumpDescription: String {
+        self.description
+    }
 }
 
 extension Locale: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    "Locale(\(self.identifier))"
-  }
+    public var customDumpDescription: String {
+        "Locale(\(self.identifier))"
+    }
 }
 
 extension NSAttributedString: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self.string
-  }
+    public var customDumpValue: Any {
+        self.string
+    }
 }
 
 extension NSCalendar: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as Calendar
-  }
+    public var customDumpValue: Any {
+        self as Calendar
+    }
 }
 
 extension NSData: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as Data
-  }
+    public var customDumpValue: Any {
+        self as Data
+    }
 }
 
 extension NSDate: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as Date
-  }
+    public var customDumpValue: Any {
+        self as Date
+    }
 }
 
 extension NSError: CustomDumpReflectable {
-  public var customDumpMirror: Mirror {
-    let swiftError = self as Error
-    guard type(of: swiftError) is NSError.Type else {
-      return Mirror(reflecting: swiftError)
+    public var customDumpMirror: Mirror {
+        let swiftError = self as Error
+        guard type(of: swiftError) is NSError.Type else {
+            return Mirror(reflecting: swiftError)
+        }
+        return Mirror(
+            self,
+            children: [
+                "domain": self.domain,
+                "code": self.code,
+                "userInfo": self.userInfo,
+            ],
+            displayStyle: .class
+        )
     }
-    return Mirror(
-      self,
-      children: [
-        "domain": self.domain,
-        "code": self.code,
-        "userInfo": self.userInfo,
-      ],
-      displayStyle: .class
-    )
-  }
 }
 
 // NB: `NSException` in unavailable on Linux
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-  extension NSException: CustomDumpReflectable {
-    public var customDumpMirror: Mirror {
-      .init(
-        self,
-        children: [
-          "name": self.name,
-          "reason": self.reason as Any,
-          "userInfo": self.userInfo as Any,
-        ],
-        displayStyle: .class
-      )
+    extension NSException: CustomDumpReflectable {
+        public var customDumpMirror: Mirror {
+            .init(
+                self,
+                children: [
+                    "name": self.name,
+                    "reason": self.reason as Any,
+                    "userInfo": self.userInfo as Any,
+                ],
+                displayStyle: .class
+            )
+        }
     }
-  }
 #endif
 
 extension NSExceptionName: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    self.rawValue
-  }
+    public var customDumpDescription: String {
+        self.rawValue
+    }
 }
 
 // NB: `NSExpression` in unavailable on Linux
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-  extension NSExpression: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      self.debugDescription
+    extension NSExpression: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            self.debugDescription
+        }
     }
-  }
 #endif
 
 extension NSIndexPath: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as IndexPath
-  }
+    public var customDumpValue: Any {
+        self as IndexPath
+    }
 }
 
 extension NSIndexSet: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as IndexSet
-  }
+    public var customDumpValue: Any {
+        self as IndexSet
+    }
 }
 
 extension NSLocale: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as Locale
-  }
+    public var customDumpValue: Any {
+        self as Locale
+    }
 }
 
 @available(iOS 10, macOS 10.12, tvOS 10, watchOS 3, *)
 extension NSMeasurement: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as Measurement
-  }
+    public var customDumpValue: Any {
+        self as Measurement
+    }
 }
 
 extension NSNotification: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as Notification
-  }
+    public var customDumpValue: Any {
+        self as Notification
+    }
 }
 
 extension NSOrderedSet: CustomDumpReflectable {
-  public var customDumpMirror: Mirror {
-    .init(
-      self,
-      unlabeledChildren: self.array,
-      displayStyle: .collection
-    )
-  }
+    public var customDumpMirror: Mirror {
+        .init(
+            self,
+            unlabeledChildren: self.array,
+            displayStyle: .collection
+        )
+    }
 }
 
 extension NSPredicate: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    self.debugDescription
-  }
+    public var customDumpDescription: String {
+        self.debugDescription
+    }
 }
 
 extension NSRange: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    Range(self) as Any
-  }
+    public var customDumpValue: Any {
+        Range(self) as Any
+    }
 }
 
 extension NSString: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as String
-  }
+    public var customDumpValue: Any {
+        self as String
+    }
 }
 
 extension NSTimeZone: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-      return self as TimeZone
-    #else
-      // NB: Cannot cast directly to `TimeZone` on Linux
-      return TimeZone(identifier: self.name) as Any
-    #endif
-  }
+    public var customDumpValue: Any {
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+            return self as TimeZone
+        #else
+            // NB: Cannot cast directly to `TimeZone` on Linux
+            return TimeZone(identifier: self.name) as Any
+        #endif
+    }
 }
 
 extension NSURL: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as URL
-  }
+    public var customDumpValue: Any {
+        self as URL
+    }
 }
 
 extension NSURLComponents: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as URLComponents
-  }
+    public var customDumpValue: Any {
+        self as URLComponents
+    }
 }
 
 extension NSURLQueryItem: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as URLQueryItem
-  }
+    public var customDumpValue: Any {
+        self as URLQueryItem
+    }
 }
 
 extension NSURLRequest: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as URLRequest
-  }
+    public var customDumpValue: Any {
+        self as URLRequest
+    }
 }
 
 extension NSUUID: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    self as UUID
-  }
+    public var customDumpValue: Any {
+        self as UUID
+    }
 }
 
 extension NSValue: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    self.debugDescription
-  }
+    public var customDumpDescription: String {
+        self.debugDescription
+    }
 }
 
 extension TimeZone: CustomDumpReflectable {
-  public var customDumpMirror: Mirror {
-    .init(
-      self,
-      children: [
-        "identifier": self.identifier,
-        "abbreviation": self.abbreviation() as Any,
-        "secondsFromGMT": self.secondsFromGMT(),
-        "isDaylightSavingTime": self.isDaylightSavingTime(),
-      ],
-      displayStyle: .struct
-    )
-  }
+    public var customDumpMirror: Mirror {
+        .init(
+            self,
+            children: [
+                "identifier": self.identifier,
+                "abbreviation": self.abbreviation() as Any,
+                "secondsFromGMT": self.secondsFromGMT(),
+                "isDaylightSavingTime": self.isDaylightSavingTime(),
+            ],
+            displayStyle: .struct
+        )
+    }
 }
 
 extension URL: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    "URL(\(self.absoluteString))"
-  }
+    public var customDumpDescription: String {
+        "URL(\(self.absoluteString))"
+    }
 }
 
 extension URLRequest.NetworkServiceType: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    switch self { #if canImport(FoundationNetworking)
-      case .background:
-        return "URLRequest.NetworkServiceType.background"
-      case .default:
-        return "URLRequest.NetworkServiceType.default"
-      case .networkServiceTypeCallSignaling:
-        return "URLRequest.NetworkServiceType.networkServiceTypeCallSignaling"
-      case .video:
-        return "URLRequest.NetworkServiceType.video"
-      case .voice:
-        return "URLRequest.NetworkServiceType.voice"
-      case .voip:
-        return "URLRequest.NetworkServiceType.voip"
-    #else
-      case .avStreaming:
-        return "URLRequest.NetworkServiceType.avStreaming"
-      case .background:
-        return "URLRequest.NetworkServiceType.background"
-      case .callSignaling:
-        return "URLRequest.NetworkServiceType.callSignaling"
-      case .default:
-        return "URLRequest.NetworkServiceType.default"
-      case .responsiveAV:
-        return "URLRequest.NetworkServiceType.responsiveAV"
-      case .responsiveData:
-        return "URLRequest.NetworkServiceType.responsiveData"
-      case .video:
-        return "URLRequest.NetworkServiceType.video"
-      case .voice:
-        return "URLRequest.NetworkServiceType.voice"
-      case .voip:
-        return "URLRequest.NetworkServiceType.voip"
-      @unknown default:
-        return "URLRequest.NetworkServiceType.(@unknown default, rawValue: \(self.rawValue))"
-    #endif
+    public var customDumpDescription: String {
+        switch self { #if canImport(FoundationNetworking)
+            case .background:
+                return "URLRequest.NetworkServiceType.background"
+            case .default:
+                return "URLRequest.NetworkServiceType.default"
+            case .networkServiceTypeCallSignaling:
+                return "URLRequest.NetworkServiceType.networkServiceTypeCallSignaling"
+            case .video:
+                return "URLRequest.NetworkServiceType.video"
+            case .voice:
+                return "URLRequest.NetworkServiceType.voice"
+            case .voip:
+                return "URLRequest.NetworkServiceType.voip"
+        #else
+            case .avStreaming:
+                return "URLRequest.NetworkServiceType.avStreaming"
+            case .background:
+                return "URLRequest.NetworkServiceType.background"
+            case .callSignaling:
+                return "URLRequest.NetworkServiceType.callSignaling"
+            case .default:
+                return "URLRequest.NetworkServiceType.default"
+            case .responsiveAV:
+                return "URLRequest.NetworkServiceType.responsiveAV"
+            case .responsiveData:
+                return "URLRequest.NetworkServiceType.responsiveData"
+            case .video:
+                return "URLRequest.NetworkServiceType.video"
+            case .voice:
+                return "URLRequest.NetworkServiceType.voice"
+            case .voip:
+                return "URLRequest.NetworkServiceType.voip"
+            @unknown default:
+                return
+                    "URLRequest.NetworkServiceType.(@unknown default, rawValue: \(self.rawValue))"
+        #endif
+        }
     }
-  }
 }
 
 extension UUID: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    "UUID(\(self.uuidString))"
-  }
+    public var customDumpDescription: String {
+        "UUID(\(self.uuidString))"
+    }
 }

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/GameKit.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/GameKit.swift
@@ -1,114 +1,116 @@
 #if canImport(GameKit)
-  import GameKit
+    import GameKit
 
-  #if !os(watchOS)
-    #if compiler(>=5.5)
-      @available(iOS 14, macOS 11, macCatalyst 14, tvOS 14, *)
-      extension GKAccessPoint.Location: CustomDumpStringConvertible {
-        public var customDumpDescription: String {
-          switch self {
-          case .bottomLeading:
-            return "GKAccessPoint.Location.bottomLeading"
-          case .bottomTrailing:
-            return "GKAccessPoint.Location.bottomTrailing"
-          case .topLeading:
-            return "GKAccessPoint.Location.topLeading"
-          case .topTrailing:
-            return "GKAccessPoint.Location.topTrailing"
-          @unknown default:
-            return "GKAccessPoint.Location.(@unknown default, rawValue: \(self.rawValue))"
-          }
+    #if !os(watchOS)
+        #if compiler(>=5.5)
+            @available(iOS 14, macOS 11, macCatalyst 14, tvOS 14, *)
+            extension GKAccessPoint.Location: CustomDumpStringConvertible {
+                public var customDumpDescription: String {
+                    switch self {
+                    case .bottomLeading:
+                        return "GKAccessPoint.Location.bottomLeading"
+                    case .bottomTrailing:
+                        return "GKAccessPoint.Location.bottomTrailing"
+                    case .topLeading:
+                        return "GKAccessPoint.Location.topLeading"
+                    case .topTrailing:
+                        return "GKAccessPoint.Location.topTrailing"
+                    @unknown default:
+                        return
+                            "GKAccessPoint.Location.(@unknown default, rawValue: \(self.rawValue))"
+                    }
+                }
+            }
+        #endif
+
+        @available(iOS 5, macCatalyst 13, macOS 10.8, tvOS 9, *)
+        extension GKPlayer.PhotoSize: CustomDumpStringConvertible {
+            public var customDumpDescription: String {
+                switch self {
+                case .normal:
+                    return "GKPlayer.PhotoSize.normal"
+                case .small:
+                    return "GKPlayer.PhotoSize.small"
+                @unknown default:
+                    return "GKPlayer.PhotoSize.(@unknown default, rawValue: \(self.rawValue))"
+                }
+            }
         }
-      }
     #endif
 
-    @available(iOS 5, macCatalyst 13, macOS 10.8, tvOS 9, *)
-    extension GKPlayer.PhotoSize: CustomDumpStringConvertible {
-      public var customDumpDescription: String {
-        switch self {
-        case .normal:
-          return "GKPlayer.PhotoSize.normal"
-        case .small:
-          return "GKPlayer.PhotoSize.small"
-        @unknown default:
-          return "GKPlayer.PhotoSize.(@unknown default, rawValue: \(self.rawValue))"
+    @available(iOS 5, macCatalyst 13, macOS 10.8, tvOS 9, watchOS 3, *)
+    @available(watchOS, unavailable)
+    extension GKTurnBasedMatch.Outcome: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .customRange:
+                return "GKTurnBasedMatch.Outcome.customRange"
+            case .first:
+                return "GKTurnBasedMatch.Outcome.first"
+            case .fourth:
+                return "GKTurnBasedMatch.Outcome.fourth"
+            case .lost:
+                return "GKTurnBasedMatch.Outcome.lost"
+            case .none:
+                return "GKTurnBasedMatch.Outcome.none"
+            case .quit:
+                return "GKTurnBasedMatch.Outcome.quit"
+            case .second:
+                return "GKTurnBasedMatch.Outcome.second"
+            case .tied:
+                return "GKTurnBasedMatch.Outcome.tied"
+            case .timeExpired:
+                return "GKTurnBasedMatch.Outcome.timeExpired"
+            case .third:
+                return "GKTurnBasedMatch.Outcome.third"
+            case .won:
+                return "GKTurnBasedMatch.Outcome.won"
+            @unknown default:
+                return "GKTurnBasedMatch.Outcome.(@unknown default, rawValue: \(self.rawValue))"
+            }
         }
-      }
     }
-  #endif
 
-  @available(iOS 5, macCatalyst 13, macOS 10.8, tvOS 9, watchOS 3, *)
-  @available(watchOS, unavailable)
-  extension GKTurnBasedMatch.Outcome: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .customRange:
-        return "GKTurnBasedMatch.Outcome.customRange"
-      case .first:
-        return "GKTurnBasedMatch.Outcome.first"
-      case .fourth:
-        return "GKTurnBasedMatch.Outcome.fourth"
-      case .lost:
-        return "GKTurnBasedMatch.Outcome.lost"
-      case .none:
-        return "GKTurnBasedMatch.Outcome.none"
-      case .quit:
-        return "GKTurnBasedMatch.Outcome.quit"
-      case .second:
-        return "GKTurnBasedMatch.Outcome.second"
-      case .tied:
-        return "GKTurnBasedMatch.Outcome.tied"
-      case .timeExpired:
-        return "GKTurnBasedMatch.Outcome.timeExpired"
-      case .third:
-        return "GKTurnBasedMatch.Outcome.third"
-      case .won:
-        return "GKTurnBasedMatch.Outcome.won"
-      @unknown default:
-        return "GKTurnBasedMatch.Outcome.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 5, macCatalyst 13, macOS 10.8, tvOS 9, watchOS 3, *)
+    @available(watchOS, unavailable)
+    extension GKTurnBasedMatch.Status: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .ended:
+                return "GKTurnBasedMatch.Status.ended"
+            case .matching:
+                return "GKTurnBasedMatch.Status.matching"
+            case .open:
+                return "GKTurnBasedMatch.Status.open"
+            case .unknown:
+                return "GKTurnBasedMatch.Status.unknown"
+            @unknown default:
+                return "GKTurnBasedMatch.Status.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  @available(iOS 5, macCatalyst 13, macOS 10.8, tvOS 9, watchOS 3, *)
-  @available(watchOS, unavailable)
-  extension GKTurnBasedMatch.Status: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .ended:
-        return "GKTurnBasedMatch.Status.ended"
-      case .matching:
-        return "GKTurnBasedMatch.Status.matching"
-      case .open:
-        return "GKTurnBasedMatch.Status.open"
-      case .unknown:
-        return "GKTurnBasedMatch.Status.unknown"
-      @unknown default:
-        return "GKTurnBasedMatch.Status.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 5, macCatalyst 13, macOS 10.8, tvOS 9, watchOS 3, *)
+    @available(watchOS, unavailable)
+    extension GKTurnBasedParticipant.Status: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .active:
+                return "GKTurnBasedParticipant.Status.active"
+            case .declined:
+                return "GKTurnBasedParticipant.Status.declined"
+            case .done:
+                return "GKTurnBasedParticipant.Status.done"
+            case .invited:
+                return "GKTurnBasedParticipant.Status.invited"
+            case .matching:
+                return "GKTurnBasedParticipant.Status.matching"
+            case .unknown:
+                return "GKTurnBasedParticipant.Status.unknown"
+            @unknown default:
+                return
+                    "GKTurnBasedParticipant.Status.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
-
-  @available(iOS 5, macCatalyst 13, macOS 10.8, tvOS 9, watchOS 3, *)
-  @available(watchOS, unavailable)
-  extension GKTurnBasedParticipant.Status: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .active:
-        return "GKTurnBasedParticipant.Status.active"
-      case .declined:
-        return "GKTurnBasedParticipant.Status.declined"
-      case .done:
-        return "GKTurnBasedParticipant.Status.done"
-      case .invited:
-        return "GKTurnBasedParticipant.Status.invited"
-      case .matching:
-        return "GKTurnBasedParticipant.Status.matching"
-      case .unknown:
-        return "GKTurnBasedParticipant.Status.unknown"
-      @unknown default:
-        return "GKTurnBasedParticipant.Status.(@unknown default, rawValue: \(self.rawValue))"
-      }
-    }
-  }
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/KeyPath.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/KeyPath.swift
@@ -1,835 +1,837 @@
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-  extension AnyKeyPath: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      guard let name = keyPathToName[self] else {
-        func reflectName() -> String {
-          var namedKeyPaths = Reflection.allNamedKeyPaths(forUnderlyingTypeOf: Self.rootType)
-          while !namedKeyPaths.isEmpty {
-            let (name, keyPath) = namedKeyPaths.removeFirst()
-            if keyPath == self {
-              return #"\\#(typeName(Self.rootType)).\#(name)"#
+    extension AnyKeyPath: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            guard let name = keyPathToName[self] else {
+                func reflectName() -> String {
+                    var namedKeyPaths = Reflection.allNamedKeyPaths(
+                        forUnderlyingTypeOf: Self.rootType)
+                    while !namedKeyPaths.isEmpty {
+                        let (name, keyPath) = namedKeyPaths.removeFirst()
+                        if keyPath == self {
+                            return #"\\#(typeName(Self.rootType)).\#(name)"#
+                        }
+                        let valueType = type(of: keyPath).valueType
+                        let valueNamedKeyPaths = Reflection.allNamedKeyPaths(
+                            forUnderlyingTypeOf: valueType)
+                        for (valueName, valueKeyPath) in valueNamedKeyPaths {
+                            if let appendedKeyPath = keyPath.appending(path: valueKeyPath) {
+                                namedKeyPaths.append(("\(name).\(valueName)", appendedKeyPath))
+                            }
+                        }
+                    }
+                    return String(describing: type(of: self))
+                }
+                let name = reflectName()
+                keyPathToName[self] = name
+                return name
             }
-            let valueType = type(of: keyPath).valueType
-            let valueNamedKeyPaths = Reflection.allNamedKeyPaths(forUnderlyingTypeOf: valueType)
-            for (valueName, valueKeyPath) in valueNamedKeyPaths {
-              if let appendedKeyPath = keyPath.appending(path: valueKeyPath) {
-                namedKeyPaths.append(("\(name).\(valueName)", appendedKeyPath))
-              }
+            return name
+        }
+    }
+
+    private var keyPathToName: [AnyKeyPath: String] = [:]
+
+    // The source code below was extracted from the "KeyPath Reflection" branch of Apple's
+    // "Swift Evolution Staging" package:
+    //
+    // https://github.com/apple/swift-evolution-staging/tree/reflection
+
+    //===----------------------------------------------------------------------===//
+    //
+    // This source file is part of the Swift.org open source project
+    //
+    // Copyright (c) 2020 Apple Inc. and the Swift project authors
+    // Licensed under Apache License v2.0 with Runtime Library Exception
+    //
+    // See https://swift.org/LICENSE.txt for license information
+    // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+    //
+    //===----------------------------------------------------------------------===//
+
+    private protocol RelativePointer {
+        associatedtype Pointee
+
+        var offset: Int32 { get }
+
+        func address(from ptr: UnsafeRawPointer) -> UnsafePointer<Pointee>
+        func pointee(from ptr: UnsafeRawPointer) -> Pointee?
+    }
+
+    extension RelativePointer {
+        fileprivate func address(from ptr: UnsafeRawPointer) -> UnsafePointer<Pointee> {
+            let newPtr = UnsafeRawPointer(
+                bitPattern: UInt(bitPattern: ptr) &+ UInt(bitPattern: Int(offset)))!
+            return newPtr.assumingMemoryBound(to: Pointee.self)
+        }
+    }
+
+    private struct RelativeDirectPointer<Pointee>: RelativePointer {
+        let offset: Int32
+
+        func pointee(from ptr: UnsafeRawPointer) -> Pointee? {
+            guard offset != 0 else {
+                return nil
             }
-          }
-          return String(describing: type(of: self))
+
+            return address(from: ptr).pointee
         }
-        let name = reflectName()
-        keyPathToName[self] = name
-        return name
-      }
-      return name
-    }
-  }
-
-  private var keyPathToName: [AnyKeyPath: String] = [:]
-
-  // The source code below was extracted from the "KeyPath Reflection" branch of Apple's
-  // "Swift Evolution Staging" package:
-  //
-  // https://github.com/apple/swift-evolution-staging/tree/reflection
-
-  //===----------------------------------------------------------------------===//
-  //
-  // This source file is part of the Swift.org open source project
-  //
-  // Copyright (c) 2020 Apple Inc. and the Swift project authors
-  // Licensed under Apache License v2.0 with Runtime Library Exception
-  //
-  // See https://swift.org/LICENSE.txt for license information
-  // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-  //
-  //===----------------------------------------------------------------------===//
-
-  private protocol RelativePointer {
-    associatedtype Pointee
-
-    var offset: Int32 { get }
-
-    func address(from ptr: UnsafeRawPointer) -> UnsafePointer<Pointee>
-    func pointee(from ptr: UnsafeRawPointer) -> Pointee?
-  }
-
-  extension RelativePointer {
-    fileprivate func address(from ptr: UnsafeRawPointer) -> UnsafePointer<Pointee> {
-      let newPtr = UnsafeRawPointer(
-        bitPattern: UInt(bitPattern: ptr) &+ UInt(bitPattern: Int(offset)))!
-      return newPtr.assumingMemoryBound(to: Pointee.self)
-    }
-  }
-
-  private struct RelativeDirectPointer<Pointee>: RelativePointer {
-    let offset: Int32
-
-    func pointee(from ptr: UnsafeRawPointer) -> Pointee? {
-      guard offset != 0 else {
-        return nil
-      }
-
-      return address(from: ptr).pointee
-    }
-  }
-
-  extension UnsafeRawPointer {
-    fileprivate func relativeDirect<T>(as type: T.Type) -> UnsafePointer<T> {
-      let relativePointer = RelativeDirectPointer<T>(
-        offset: load(as: Int32.self)
-      )
-      return relativePointer.address(from: self)
-    }
-  }
-
-  private struct RelativeIndirectPointer<T>: RelativePointer {
-    typealias Pointee = UnsafePointer<T>
-
-    let offset: Int32
-
-    func pointee(from ptr: UnsafeRawPointer) -> Pointee? {
-      guard offset != 0 else {
-        return nil
-      }
-
-      return address(from: ptr).pointee
-    }
-  }
-
-  private struct RelativeIndirectablePointer<Pointee>: RelativePointer {
-    let offset: Int32
-
-    func address(from ptr: UnsafeRawPointer) -> UnsafePointer<Pointee> {
-      UnsafePointer<Pointee>((ptr + Int(offset & ~1))._rawValue)
     }
 
-    func pointee(from ptr: UnsafeRawPointer) -> Pointee? {
-      guard offset != 0 else {
-        return nil
-      }
-
-      if offset & 1 == 1 {
-        let pointer = UnsafeRawPointer(address(from: ptr))
-          .load(as: UnsafePointer<Pointee>.self)
-        return pointer.pointee
-      } else {
-        return address(from: ptr).pointee
-      }
-    }
-  }
-
-  //===----------------------------------------------------------------------===//
-  // Metadata Structures
-  //===----------------------------------------------------------------------===//
-
-  // MetadataKind is the discriminator value found at the start of all metadata
-  // records to determine what kind is a metadata.
-  private enum MetadataKind: Int {
-    case `class` = 0
-    case `struct` = 512
-  }
-
-  // Metadata refers to the runtime representation of a type in Swift. This
-  // protocol is the generic version handed out by various methods to retrieve
-  // metadata from types.
-  private protocol Metadata {
-    // The required backing pointer which points at the metadata record.
-    var pointer: UnsafeRawPointer { get }
-
-    // The discriminator which determines what kind of metadata this is.
-    var kind: MetadataKind { get }
-  }
-
-  extension Metadata {
-    // The type representation of the metadata.
-    fileprivate var type: Any.Type {
-      unsafeBitCast(pointer, to: Any.Type.self)
-    }
-  }
-
-  // Given an arbitrary type of anything, produce the metadata that represents
-  // said type.
-  // FIXME: Right now this only supports structs and class types, but in the
-  // future if we ever want to produce keypaths for tuples, enums, etc. handle
-  // that here.
-  private func getMetadata(for type: Any.Type) -> Metadata? {
-    let pointer = unsafeBitCast(type, to: UnsafeRawPointer.self)
-    let int = pointer.load(as: Int.self)
-
-    guard let kind = MetadataKind(rawValue: int) else {
-      // If the metadata kind is greater than 2047, then it's an ISA pointer
-      // meaning we have some class metadata.
-      guard int > 2047 else {
-        return nil
-      }
-
-      return ClassMetadata(pointer: pointer)
+    extension UnsafeRawPointer {
+        fileprivate func relativeDirect<T>(as type: T.Type) -> UnsafePointer<T> {
+            let relativePointer = RelativeDirectPointer<T>(
+                offset: load(as: Int32.self)
+            )
+            return relativePointer.address(from: self)
+        }
     }
 
-    switch kind {
-    case .class:
-      return ClassMetadata(pointer: pointer)
-    case .struct:
-      return StructMetadata(pointer: pointer)
-    }
-  }
+    private struct RelativeIndirectPointer<T>: RelativePointer {
+        typealias Pointee = UnsafePointer<T>
 
-  // Type Metadata
+        let offset: Int32
 
-  // Type Metadata is a more specialized metadata in that only struct, class, and
-  // enum types conform to. There's more detail about the type and its properties
-  // in the context descriptors, the generic types that make up said type, etc.
-  private protocol TypeMetadata: Metadata {}
+        func pointee(from ptr: UnsafeRawPointer) -> Pointee? {
+            guard offset != 0 else {
+                return nil
+            }
 
-  extension TypeMetadata {
-    // The context descriptors describes more in detail about the type. Some of
-    // this information includes number of properties, the property names, the
-    // name of this type, generic requirements, etc.
-    fileprivate var contextDescriptor: TypeContextDescriptor {
-      switch self {
-      case let structMetadata as StructMetadata:
-        return structMetadata.descriptor
-      case let classMetadata as ClassMetadata:
-        return classMetadata.descriptor
-      default:
-        fatalError("TypeMetadata conformance we don't know about?")
-      }
+            return address(from: ptr).pointee
+        }
     }
 
-    // An array of integers that represent the offset to a certain field. This
-    // corresponds to the index of fields in the field descriptor.
-    fileprivate var fieldOffsets: [Int] {
-      switch self {
-      case let structMetadata as StructMetadata:
-        return structMetadata.fieldOffsets
-      case let classMetadata as ClassMetadata:
-        return classMetadata.fieldOffsets
-      default:
-        fatalError("TypeMetadata conformance we don't know about?")
-      }
-    }
+    private struct RelativeIndirectablePointer<Pointee>: RelativePointer {
+        let offset: Int32
 
-    // The pointer to the beginning of this type's generic arguments.
-    fileprivate var genericArgumentPointer: UnsafeRawPointer {
-      switch self {
-      case is StructMetadata:
-        return pointer + MemoryLayout<_StructMetadata>.size
-      case let classMetadata as ClassMetadata:
-        let descriptor = classMetadata.descriptor
-
-        guard !descriptor.typeFlags.classHasResilientSuperclass else {
-          let memberOffset = descriptor.resilientBounds._immediateMembersOffset
-          return pointer + memberOffset
+        func address(from ptr: UnsafeRawPointer) -> UnsafePointer<Pointee> {
+            UnsafePointer<Pointee>((ptr + Int(offset & ~1))._rawValue)
         }
 
-        let negativeSize = descriptor.negativeSize
-        let positiveSize = descriptor.positiveSize
-        let numImmediateMembers = descriptor.numImmediateMembers
+        func pointee(from ptr: UnsafeRawPointer) -> Pointee? {
+            guard offset != 0 else {
+                return nil
+            }
 
-        if descriptor.typeFlags.classAreImmediateMembersNegative {
-          return pointer + MemoryLayout<Int>.size * -negativeSize
-        } else {
-          return pointer + MemoryLayout<Int>.size * (positiveSize - numImmediateMembers)
+            if offset & 1 == 1 {
+                let pointer = UnsafeRawPointer(address(from: ptr))
+                    .load(as: UnsafePointer<Pointee>.self)
+                return pointer.pointee
+            } else {
+                return address(from: ptr).pointee
+            }
         }
-      default:
-        fatalError("TypeMetadata conformance we don't know about?")
-      }
     }
 
-    // Given a mangled name (preferrably one of the property type name's), return
-    // the type as represented by the mangled name within this type's context.
-    fileprivate func type(of mangledName: UnsafePointer<CChar>) -> Any.Type? {
-      let type = _getTypeByMangledNameInContext(
-        UnsafePointer<UInt8>(mangledName._rawValue),
-        UInt(getSymbolicMangledNameLength(UnsafeRawPointer(mangledName))),
-        genericContext: contextDescriptor.pointer,
-        genericArguments: genericArgumentPointer
-      )
+    //===----------------------------------------------------------------------===//
+    // Metadata Structures
+    //===----------------------------------------------------------------------===//
 
-      return type
-    }
-  }
-
-  // Struct Metadata
-
-  // Struct Metadata refers to types whom are implemented via a struct. Consider
-  // the standard library type 'Int', it's implemented using a struct, so getting
-  // the type metadata for that type will return an instance of struct metadata.
-  private struct StructMetadata: TypeMetadata, LayoutWrapper {
-    typealias Layout = _StructMetadata
-
-    // The backing metadata pointer.
-    let pointer: UnsafeRawPointer
-
-    // The metadata discriminator.
-    var kind: MetadataKind {
-      .struct
+    // MetadataKind is the discriminator value found at the start of all metadata
+    // records to determine what kind is a metadata.
+    private enum MetadataKind: Int {
+        case `class` = 0
+        case `struct` = 512
     }
 
-    // The context descriptor of this struct.
-    var descriptor: StructDescriptor {
-      layout.descriptor
+    // Metadata refers to the runtime representation of a type in Swift. This
+    // protocol is the generic version handed out by various methods to retrieve
+    // metadata from types.
+    private protocol Metadata {
+        // The required backing pointer which points at the metadata record.
+        var pointer: UnsafeRawPointer { get }
+
+        // The discriminator which determines what kind of metadata this is.
+        var kind: MetadataKind { get }
     }
 
-    // An array of integers with the offsets for each stored field in this struct.
-    var fieldOffsets: [Int] {
-      let fieldOffsetVectorOffset = descriptor.fieldOffsetVectorOffset
-      let start = pointer + MemoryLayout<Int>.size * fieldOffsetVectorOffset
-      let buffer = UnsafeBufferPointer<UInt32>(
-        start: UnsafePointer<UInt32>(start._rawValue),
-        count: descriptor.numFields
-      )
-      return Array(buffer).map { Int($0) }
-    }
-  }
-
-  private struct _StructMetadata {
-    let kind: Int
-    let descriptor: StructDescriptor
-  }
-
-  // Class Metadata
-
-  // Class Metadata refers to types whom are implemented via a class. Consider
-  // the standard library type 'KeyPath', it's implemented using a class, so
-  // getting the type metadata for that type will return an instance of class
-  // metadata.
-  private struct ClassMetadata: TypeMetadata, LayoutWrapper {
-    typealias Layout = _ClassMetadata
-
-    // The backing metadata pointer.
-    let pointer: UnsafeRawPointer
-
-    // The metadata discriminator.
-    var kind: MetadataKind {
-      .class
+    extension Metadata {
+        // The type representation of the metadata.
+        fileprivate var type: Any.Type {
+            unsafeBitCast(pointer, to: Any.Type.self)
+        }
     }
 
-    // The context descriptor of this class.
-    var descriptor: ClassDescriptor {
-      layout._descriptor
+    // Given an arbitrary type of anything, produce the metadata that represents
+    // said type.
+    // FIXME: Right now this only supports structs and class types, but in the
+    // future if we ever want to produce keypaths for tuples, enums, etc. handle
+    // that here.
+    private func getMetadata(for type: Any.Type) -> Metadata? {
+        let pointer = unsafeBitCast(type, to: UnsafeRawPointer.self)
+        let int = pointer.load(as: Int.self)
+
+        guard let kind = MetadataKind(rawValue: int) else {
+            // If the metadata kind is greater than 2047, then it's an ISA pointer
+            // meaning we have some class metadata.
+            guard int > 2047 else {
+                return nil
+            }
+
+            return ClassMetadata(pointer: pointer)
+        }
+
+        switch kind {
+        case .class:
+            return ClassMetadata(pointer: pointer)
+        case .struct:
+            return StructMetadata(pointer: pointer)
+        }
     }
 
-    // An array of integers with the offsets for each stored field in this class.
-    var fieldOffsets: [Int] {
-      let fieldOffsetVectorOffset = descriptor.fieldOffsetVectorOffset
-      let start = pointer + MemoryLayout<Int>.size * fieldOffsetVectorOffset
-      let buffer = UnsafeBufferPointer<Int>(
-        start: UnsafePointer<Int>(start._rawValue),
-        count: descriptor.numFields
-      )
-      return Array(buffer)
+    // Type Metadata
+
+    // Type Metadata is a more specialized metadata in that only struct, class, and
+    // enum types conform to. There's more detail about the type and its properties
+    // in the context descriptors, the generic types that make up said type, etc.
+    private protocol TypeMetadata: Metadata {}
+
+    extension TypeMetadata {
+        // The context descriptors describes more in detail about the type. Some of
+        // this information includes number of properties, the property names, the
+        // name of this type, generic requirements, etc.
+        fileprivate var contextDescriptor: TypeContextDescriptor {
+            switch self {
+            case let structMetadata as StructMetadata:
+                return structMetadata.descriptor
+            case let classMetadata as ClassMetadata:
+                return classMetadata.descriptor
+            default:
+                fatalError("TypeMetadata conformance we don't know about?")
+            }
+        }
+
+        // An array of integers that represent the offset to a certain field. This
+        // corresponds to the index of fields in the field descriptor.
+        fileprivate var fieldOffsets: [Int] {
+            switch self {
+            case let structMetadata as StructMetadata:
+                return structMetadata.fieldOffsets
+            case let classMetadata as ClassMetadata:
+                return classMetadata.fieldOffsets
+            default:
+                fatalError("TypeMetadata conformance we don't know about?")
+            }
+        }
+
+        // The pointer to the beginning of this type's generic arguments.
+        fileprivate var genericArgumentPointer: UnsafeRawPointer {
+            switch self {
+            case is StructMetadata:
+                return pointer + MemoryLayout<_StructMetadata>.size
+            case let classMetadata as ClassMetadata:
+                let descriptor = classMetadata.descriptor
+
+                guard !descriptor.typeFlags.classHasResilientSuperclass else {
+                    let memberOffset = descriptor.resilientBounds._immediateMembersOffset
+                    return pointer + memberOffset
+                }
+
+                let negativeSize = descriptor.negativeSize
+                let positiveSize = descriptor.positiveSize
+                let numImmediateMembers = descriptor.numImmediateMembers
+
+                if descriptor.typeFlags.classAreImmediateMembersNegative {
+                    return pointer + MemoryLayout<Int>.size * -negativeSize
+                } else {
+                    return pointer + MemoryLayout<Int>.size * (positiveSize - numImmediateMembers)
+                }
+            default:
+                fatalError("TypeMetadata conformance we don't know about?")
+            }
+        }
+
+        // Given a mangled name (preferrably one of the property type name's), return
+        // the type as represented by the mangled name within this type's context.
+        fileprivate func type(of mangledName: UnsafePointer<CChar>) -> Any.Type? {
+            let type = _getTypeByMangledNameInContext(
+                UnsafePointer<UInt8>(mangledName._rawValue),
+                UInt(getSymbolicMangledNameLength(UnsafeRawPointer(mangledName))),
+                genericContext: contextDescriptor.pointer,
+                genericArguments: genericArgumentPointer
+            )
+
+            return type
+        }
     }
 
-    // The required size of instances of this type.
-    var instanceSize: Int {
-      Int(layout._instanceSize)
+    // Struct Metadata
+
+    // Struct Metadata refers to types whom are implemented via a struct. Consider
+    // the standard library type 'Int', it's implemented using a struct, so getting
+    // the type metadata for that type will return an instance of struct metadata.
+    private struct StructMetadata: TypeMetadata, LayoutWrapper {
+        typealias Layout = _StructMetadata
+
+        // The backing metadata pointer.
+        let pointer: UnsafeRawPointer
+
+        // The metadata discriminator.
+        var kind: MetadataKind {
+            .struct
+        }
+
+        // The context descriptor of this struct.
+        var descriptor: StructDescriptor {
+            layout.descriptor
+        }
+
+        // An array of integers with the offsets for each stored field in this struct.
+        var fieldOffsets: [Int] {
+            let fieldOffsetVectorOffset = descriptor.fieldOffsetVectorOffset
+            let start = pointer + MemoryLayout<Int>.size * fieldOffsetVectorOffset
+            let buffer = UnsafeBufferPointer<UInt32>(
+                start: UnsafePointer<UInt32>(start._rawValue),
+                count: descriptor.numFields
+            )
+            return Array(buffer).map { Int($0) }
+        }
     }
 
-    // The alignment mask of the address point for instances of this type.
-    var instanceAlignMask: Int {
-      Int(layout._instanceAlignMask)
+    private struct _StructMetadata {
+        let kind: Int
+        let descriptor: StructDescriptor
     }
-  }
 
-  private struct _ClassMetadata {
-    let _kind: Int
-    let _superclass: Any.Type?
-    let _reserved: (Int, Int)
-    let _rodata: Int
-    let _flags: UInt32
-    let _instanceAddressPoint: UInt32
-    let _instanceSize: UInt32
-    let _instanceAlignMask: UInt16
-    let _runtimeReserved: UInt16
-    let _classSize: UInt32
-    let _classAddressPoint: UInt32
-    let _descriptor: ClassDescriptor
-  }
+    // Class Metadata
 
-  //===----------------------------------------------------------------------===//
-  // Context Descriptor Structures
-  //===----------------------------------------------------------------------===//
+    // Class Metadata refers to types whom are implemented via a class. Consider
+    // the standard library type 'KeyPath', it's implemented using a class, so
+    // getting the type metadata for that type will return an instance of class
+    // metadata.
+    private struct ClassMetadata: TypeMetadata, LayoutWrapper {
+        typealias Layout = _ClassMetadata
 
-  // A context descriptor describes in entity in Swift who declares some context
-  // which other declarations can be declared within.
-  private protocol ContextDescriptor {
-    // The backing context descriptor pointer.
-    var pointer: UnsafeRawPointer { get }
-  }
+        // The backing metadata pointer.
+        let pointer: UnsafeRawPointer
 
-  extension ContextDescriptor {
-    // The base structural representation of a context descriptor.
-    fileprivate var _contextDescriptor: _ContextDescriptor {
-      pointer.load(as: _ContextDescriptor.self)
+        // The metadata discriminator.
+        var kind: MetadataKind {
+            .class
+        }
+
+        // The context descriptor of this class.
+        var descriptor: ClassDescriptor {
+            layout._descriptor
+        }
+
+        // An array of integers with the offsets for each stored field in this class.
+        var fieldOffsets: [Int] {
+            let fieldOffsetVectorOffset = descriptor.fieldOffsetVectorOffset
+            let start = pointer + MemoryLayout<Int>.size * fieldOffsetVectorOffset
+            let buffer = UnsafeBufferPointer<Int>(
+                start: UnsafePointer<Int>(start._rawValue),
+                count: descriptor.numFields
+            )
+            return Array(buffer)
+        }
+
+        // The required size of instances of this type.
+        var instanceSize: Int {
+            Int(layout._instanceSize)
+        }
+
+        // The alignment mask of the address point for instances of this type.
+        var instanceAlignMask: Int {
+            Int(layout._instanceAlignMask)
+        }
+    }
+
+    private struct _ClassMetadata {
+        let _kind: Int
+        let _superclass: Any.Type?
+        let _reserved: (Int, Int)
+        let _rodata: Int
+        let _flags: UInt32
+        let _instanceAddressPoint: UInt32
+        let _instanceSize: UInt32
+        let _instanceAlignMask: UInt16
+        let _runtimeReserved: UInt16
+        let _classSize: UInt32
+        let _classAddressPoint: UInt32
+        let _descriptor: ClassDescriptor
+    }
+
+    //===----------------------------------------------------------------------===//
+    // Context Descriptor Structures
+    //===----------------------------------------------------------------------===//
+
+    // A context descriptor describes in entity in Swift who declares some context
+    // which other declarations can be declared within.
+    private protocol ContextDescriptor {
+        // The backing context descriptor pointer.
+        var pointer: UnsafeRawPointer { get }
+    }
+
+    extension ContextDescriptor {
+        // The base structural representation of a context descriptor.
+        fileprivate var _contextDescriptor: _ContextDescriptor {
+            pointer.load(as: _ContextDescriptor.self)
+        }
+
+        // Flags that describe this context which include what kind it is, whether
+        // or not it's a generic context, whether or not it's unique, etc.
+        fileprivate var flags: ContextDescriptorFlags {
+            _contextDescriptor._flags
+        }
+    }
+
+    private struct _ContextDescriptor {
+        let _flags: ContextDescriptorFlags
+        let _parent: RelativeIndirectablePointer<_ContextDescriptor>
     }
 
     // Flags that describe this context which include what kind it is, whether
     // or not it's a generic context, whether or not it's unique, etc.
-    fileprivate var flags: ContextDescriptorFlags {
-      _contextDescriptor._flags
-    }
-  }
+    private struct ContextDescriptorFlags {
+        // The backing integer representation of these flags.
+        let bits: UInt32
 
-  private struct _ContextDescriptor {
-    let _flags: ContextDescriptorFlags
-    let _parent: RelativeIndirectablePointer<_ContextDescriptor>
-  }
-
-  // Flags that describe this context which include what kind it is, whether
-  // or not it's a generic context, whether or not it's unique, etc.
-  private struct ContextDescriptorFlags {
-    // The backing integer representation of these flags.
-    let bits: UInt32
-
-    // The reserved bits for other flags that are interpretted differently by
-    // conforming context descriptor types.
-    var kindSpecificFlags: UInt16 {
-      UInt16((bits >> 0x10) & 0xFFFF)
-    }
-  }
-
-  // Type Context Descriptor
-
-  // A type context descriptor is a refined context descriptor who describes a
-  // type in Swift. This includes structs, classes, and enums. Protocols also
-  // define a new type in Swift, but aren't considered type contexts.
-  private protocol TypeContextDescriptor: ContextDescriptor {
-    // The field descriptor that describes the stored representation of this type.
-    var fields: FieldDescriptor { get }
-  }
-
-  extension TypeContextDescriptor {
-    // The base structural representation of a type context descriptor.
-    fileprivate var _typeDescriptor: _TypeContextDescriptor {
-      pointer.load(as: _TypeContextDescriptor.self)
+        // The reserved bits for other flags that are interpretted differently by
+        // conforming context descriptor types.
+        var kindSpecificFlags: UInt16 {
+            UInt16((bits >> 0x10) & 0xFFFF)
+        }
     }
 
-    // The field descriptor that describes the stored representation of this type.
-    fileprivate var fields: FieldDescriptor {
-      let offset = pointer.advanced(by: MemoryLayout<Int32>.size * 4)
-      let address = UnsafeRawPointer(_typeDescriptor._fields.address(from: offset))
-      return FieldDescriptor(signedPointer: address)
+    // Type Context Descriptor
+
+    // A type context descriptor is a refined context descriptor who describes a
+    // type in Swift. This includes structs, classes, and enums. Protocols also
+    // define a new type in Swift, but aren't considered type contexts.
+    private protocol TypeContextDescriptor: ContextDescriptor {
+        // The field descriptor that describes the stored representation of this type.
+        var fields: FieldDescriptor { get }
+    }
+
+    extension TypeContextDescriptor {
+        // The base structural representation of a type context descriptor.
+        fileprivate var _typeDescriptor: _TypeContextDescriptor {
+            pointer.load(as: _TypeContextDescriptor.self)
+        }
+
+        // The field descriptor that describes the stored representation of this type.
+        fileprivate var fields: FieldDescriptor {
+            let offset = pointer.advanced(by: MemoryLayout<Int32>.size * 4)
+            let address = UnsafeRawPointer(_typeDescriptor._fields.address(from: offset))
+            return FieldDescriptor(signedPointer: address)
+        }
+
+        // Certain flags specific to types in Swift, such as whether or not a class
+        // has a resilient superclass.
+        fileprivate var typeFlags: TypeContextDescriptorFlags {
+            TypeContextDescriptorFlags(bits: flags.kindSpecificFlags)
+        }
+    }
+
+    private struct _TypeContextDescriptor {
+        let _base: _ContextDescriptor
+        let _name: RelativeDirectPointer<CChar>
+        let _accessor: RelativeDirectPointer<UnsafeRawPointer>
+        let _fields: RelativeDirectPointer<_FieldDescriptor>
     }
 
     // Certain flags specific to types in Swift, such as whether or not a class
     // has a resilient superclass.
-    fileprivate var typeFlags: TypeContextDescriptorFlags {
-      TypeContextDescriptorFlags(bits: flags.kindSpecificFlags)
-    }
-  }
-
-  private struct _TypeContextDescriptor {
-    let _base: _ContextDescriptor
-    let _name: RelativeDirectPointer<CChar>
-    let _accessor: RelativeDirectPointer<UnsafeRawPointer>
-    let _fields: RelativeDirectPointer<_FieldDescriptor>
-  }
-
-  // Certain flags specific to types in Swift, such as whether or not a class
-  // has a resilient superclass.
-  private struct TypeContextDescriptorFlags {
-    // The backing integer representation of these flags.
-    let bits: UInt16
-
-    // Whether or not the class's members are negative.
-    var classAreImmediateMembersNegative: Bool {
-      bits & 0x1000 != 0
-    }
-
-    // Whether or not the class has a resilient superclass.
-    var classHasResilientSuperclass: Bool {
-      bits & 0x2000 != 0
-    }
-  }
-
-  // Struct Descriptor
-
-  // A struct descriptor that describes some structure context.
-  private struct StructDescriptor: TypeContextDescriptor, PointerAuthenticatedLayoutWrapper {
-    typealias Layout = _StructDescriptor
-
-    // The backing context descriptor pointer.
-    let signedPointer: UnsafeRawPointer
-
-    // The offset to the field offset vector found in the metadata.
-    var fieldOffsetVectorOffset: Int {
-      Int(layout._fieldOffsetVectorOffset)
-    }
-
-    // The number of stored properties this struct has.
-    var numFields: Int {
-      Int(layout._numFields)
-    }
-  }
-
-  private struct _StructDescriptor {
-    let _base: _TypeContextDescriptor
-    let _numFields: UInt32
-    let _fieldOffsetVectorOffset: UInt32
-  }
-
-  // Class Descriptor
-
-  // A class descriptor that descibes some class context.
-  private struct ClassDescriptor: TypeContextDescriptor, PointerAuthenticatedLayoutWrapper {
-    typealias Layout = _ClassDescriptor
-
-    // The backing context descriptor pointer.
-    let signedPointer: UnsafeRawPointer
-
-    // The offset to the field offset vector found in the metadata.
-    var fieldOffsetVectorOffset: Int {
-      Int(layout._fieldOffsetVectorOffset)
-    }
-
-    // The negative size of the metadata objects in this class.
-    var negativeSize: Int {
-      assert(!typeFlags.classHasResilientSuperclass)
-      return Int(layout._negativeSizeOrResilientBounds)
-    }
-
-    // The number of stored properties this class defines.
-    var numFields: Int {
-      Int(layout._numFields)
-    }
-
-    // The total number of members this class defines (not including it's
-    // superclass, if it has one).
-    var numImmediateMembers: Int {
-      Int(layout._numImmediateMembers)
-    }
-
-    // The positive size of the metadata objects in this class.
-    var positiveSize: Int {
-      assert(!typeFlags.classHasResilientSuperclass)
-      return Int(layout._positiveSizeOrExtraFlags)
-    }
-
-    // The resilient bounds for this class.
-    var resilientBounds: _StoredClassMetadataBounds {
-      let addr = address(for: \._negativeSizeOrResilientBounds)
-      let pointer = UnsafeRawPointer(addr)
-      return pointer.relativeDirect(as: _StoredClassMetadataBounds.self).pointee
-    }
-  }
-
-  private struct _ClassDescriptor {
-    let _base: _TypeContextDescriptor
-    let _superclassMangledName: RelativeDirectPointer<CChar>
-    let _negativeSizeOrResilientBounds: Int32
-    let _positiveSizeOrExtraFlags: Int32
-    let _numImmediateMembers: UInt32
-    let _numFields: UInt32
-    let _fieldOffsetVectorOffset: UInt32
-  }
-
-  private struct _StoredClassMetadataBounds {
-    let _immediateMembersOffset: Int
-  }
-
-  // Field Descriptor
-
-  // A special descriptor that describes a type's fields.
-  private struct FieldDescriptor: PointerAuthenticatedLayoutWrapper {
-    typealias Layout = _FieldDescriptor
-
-    // The backing field descriptor pointer.
-    let signedPointer: UnsafeRawPointer
-
-    // The number of fields this type has. This could mean different things
-    // depending on what kind of type this is found under. For example, this is
-    // the number of stored properties found within a struct, but for enums this
-    // is the number of cases.
-    var numFields: Int {
-      Int(layout._numFields)
-    }
-
-    // An array of the field record information. Field record information contains
-    // things like it's mangled type, whether or not its a var, indirect, etc.
-    var records: [FieldRecord] {
-      var result = [FieldRecord]()
-      result.reserveCapacity(numFields)
-
-      for i in 0..<numFields {
-        let address = trailing + MemoryLayout<_FieldRecord>.size * i
-        result.append(FieldRecord(signedPointer: address))
-      }
-
-      return result
-    }
-  }
-
-  // A record that describes a single stored property or an enum case.
-  private struct FieldRecord: PointerAuthenticatedLayoutWrapper {
-    typealias Layout = _FieldRecord
-
-    // The backing field record pointer.
-    let signedPointer: UnsafeRawPointer
-
-    // The flags that describe this field record.
-    var flags: FieldRecordFlags {
-      layout._flags
-    }
-
-    // The mangled type name that demangles to the field's type.
-    var mangledTypeName: UnsafePointer<CChar> {
-      address(for: \._mangledTypeName)
-    }
-
-    // The name of the stored property/enum case.
-    var name: String {
-      String(cString: address(for: \._fieldName))
-    }
-  }
-
-  private struct _FieldDescriptor {
-    let _mangledTypeName: RelativeDirectPointer<CChar>
-    let _superclassMangledTypeName: RelativeDirectPointer<CChar>
-    let _kind: UInt16
-    let _recordSize: UInt16
-    let _numFields: UInt32
-  }
-
-  private struct _FieldRecord {
-    let _flags: FieldRecordFlags
-    let _mangledTypeName: RelativeDirectPointer<CChar>
-    let _fieldName: RelativeDirectPointer<CChar>
-  }
-
-  // The flags which describe a field record.
-  private struct FieldRecordFlags {
-    // The backing integer representation of these flags.
-    let bits: UInt32
-
-    // Whether or not this stored property is a var.
-    var isVar: Bool {
-      bits & 0x2 != 0
-    }
-  }
-
-  //===----------------------------------------------------------------------===//
-  // Misc. Utilities
-  //===----------------------------------------------------------------------===//
-
-  private protocol LayoutWrapper {
-    associatedtype Layout
-    var pointer: UnsafeRawPointer { get }
-  }
-
-  private protocol PointerAuthenticatedLayoutWrapper: LayoutWrapper {
-    var signedPointer: UnsafeRawPointer { get }
-  }
-
-  extension PointerAuthenticatedLayoutWrapper {
-    fileprivate var pointer: UnsafeRawPointer {
-      signedPointer
-    }
-  }
-
-  extension LayoutWrapper {
-    fileprivate var layout: Layout {
-      pointer.load(as: Layout.self)
-    }
-
-    fileprivate var trailing: UnsafeRawPointer {
-      pointer + MemoryLayout<Layout>.size
-    }
-
-    fileprivate func address<T>(for field: KeyPath<Layout, T>) -> UnsafePointer<T> {
-      let offset = MemoryLayout<Layout>.offset(of: field)!
-      return UnsafePointer<T>((pointer + offset)._rawValue)
-    }
-
-    fileprivate func address<T: RelativePointer, U>(
-      for field: KeyPath<Layout, T>
-    ) -> UnsafePointer<U> where T.Pointee == U {
-      let offset = MemoryLayout<Layout>.offset(of: field)!
-      return layout[keyPath: field].address(from: pointer + offset)
-    }
-  }
-
-  // This is a utility within KeyPath.swift in the standard library. If this
-  // gets moved into there, then this goes away, but will have to rethink if this
-  // goes into a different module.
-  private func getSymbolicMangledNameLength(_ base: UnsafeRawPointer) -> Int {
-    var end = base
-    while let current = Optional(end.load(as: UInt8.self)), current != 0 {
-      // Skip the current character
-      end = end + 1
-
-      // Skip over a symbolic reference
-      if current >= 0x1 && current <= 0x17 {
-        end += 4
-      } else if current >= 0x18 && current <= 0x1F {
-        end += MemoryLayout<Int>.size
-      }
-    }
-
-    return end - base
-  }
-
-  @_silgen_name("swift_allocObject")
-  internal func _allocObject(_: UnsafeMutableRawPointer, _: Int, _: Int) -> AnyObject?
-
-  // This is a utility within KeyPath.swift in the standard library. If this
-  // gets moved into there, then this goes away, but will have to rethink if this
-  // goes into a different module.
-  extension AnyKeyPath {
-    fileprivate static func _create(
-      capacityInBytes bytes: Int,
-      initializedBy body: (UnsafeMutableRawBufferPointer) -> Void
-    ) -> Self {
-      assert(
-        bytes > 0 && bytes % 4 == 0,
-        "capacity must be multiple of 4 bytes")
-      let metadata = getMetadata(for: self) as! ClassMetadata
-      var size = metadata.instanceSize
-
-      let tailStride = MemoryLayout<Int32>.stride
-      let tailAlignMask = MemoryLayout<Int32>.alignment - 1
-
-      size += tailAlignMask
-      size &= ~tailAlignMask
-      size += tailStride * (bytes / 4)
-
-      let alignment = metadata.instanceAlignMask | tailAlignMask
-
-      let object = _allocObject(
-        UnsafeMutableRawPointer(mutating: metadata.pointer),
-        size,
-        alignment
-      )
-
-      guard object != nil else {
-        fatalError("Allocating \(self) instance failed for keypath reflection")
-      }
-
-      // This memory layout of Int by 2 is the size of a heap object which object
-      // points to. Tail members appear immediately afterwards.
-      let base =
-        unsafeBitCast(object, to: UnsafeMutableRawPointer.self) + MemoryLayout<Int>.size * 2
-
-      // The first word is the kvc string pointer. Set it to 0 (nil).
-      base.storeBytes(of: 0, as: Int.self)
-
-      // Return an offseted base after the kvc string pointer.
-      let newBase = base + MemoryLayout<Int>.size
-      let newBytes = bytes - MemoryLayout<Int>.size
-
-      body(UnsafeMutableRawBufferPointer(start: newBase, count: newBytes))
-
-      return unsafeBitCast(object, to: self)
-    }
-  }
-
-  // Helper struct to represent the keypath buffer header. This structure is also
-  // found within KeyPath.swift, so if this gets moved there this goes away.
-  private struct KeyPathBufferHeader {
-    let bits: UInt32
-
-    init(hasReferencePrefix: Bool, isTrivial: Bool, size: UInt32) {
-      var bits = size
-
-      if hasReferencePrefix {
-        bits |= 0x4000_0000
-      }
-
-      if isTrivial {
-        bits |= 0x8000_0000
-      }
-
-      self.bits = bits
-    }
-  }
-
-  // This initializes the raw keypath buffer with the field offset information.
-  private func instantiateKeyPathBuffer(
-    _ metadata: TypeMetadata,
-    _ leafIndex: Int,
-    _ data: UnsafeMutableRawBufferPointer
-  ) {
-    let header = KeyPathBufferHeader(
-      hasReferencePrefix: false,
-      isTrivial: true,
-      size: UInt32(MemoryLayout<UInt32>.size)
-    )
-
-    data.storeBytes(of: header, as: KeyPathBufferHeader.self)
-
-    var componentBits = UInt32(metadata.fieldOffsets[leafIndex])
-    componentBits |= metadata.kind == .struct ? 1 << 24 : 3 << 24
-
-    data.storeBytes(
-      of: componentBits,
-      toByteOffset: MemoryLayout<Int>.size,
-      as: UInt32.self
-    )
-  }
-
-  // Returns a concrete type for which this keypath is going to be given a root
-  // and leaf type.
-  private func getKeyPathType(
-    from root: TypeMetadata,
-    for leaf: FieldRecord
-  ) -> AnyKeyPath.Type {
-    let leafType = root.type(of: leaf.mangledTypeName)!
-
-    func openRoot<Root>(_: Root.Type) -> AnyKeyPath.Type {
-      func openLeaf<Value>(_: Value.Type) -> AnyKeyPath.Type {
-        if leaf.flags.isVar {
-          return root.kind == .class
-            ? ReferenceWritableKeyPath<Root, Value>.self
-            : WritableKeyPath<Root, Value>.self
+    private struct TypeContextDescriptorFlags {
+        // The backing integer representation of these flags.
+        let bits: UInt16
+
+        // Whether or not the class's members are negative.
+        var classAreImmediateMembersNegative: Bool {
+            bits & 0x1000 != 0
         }
-        return KeyPath<Root, Value>.self
-      }
-      return _openExistential(leafType, do: openLeaf)
-    }
-    return _openExistential(root.type, do: openRoot)
-  }
 
-  // Given a root type and a leaf index, create a concrete keypath object at
-  // runtime.
-  private func createKeyPath(root: TypeMetadata, leaf: Int) -> AnyKeyPath {
-    let field = root.contextDescriptor.fields.records[leaf]
-
-    let keyPathTy = getKeyPathType(from: root, for: field)
-    let size = MemoryLayout<Int>.size * 3
-    let instance = keyPathTy._create(capacityInBytes: size) {
-      instantiateKeyPathBuffer(root, leaf, $0)
+        // Whether or not the class has a resilient superclass.
+        var classHasResilientSuperclass: Bool {
+            bits & 0x2000 != 0
+        }
     }
 
-    let heapObj = UnsafeRawPointer(Unmanaged.passUnretained(instance).toOpaque())
-    let keyPath = unsafeBitCast(heapObj, to: AnyKeyPath.self)
-    return keyPath
-  }
+    // Struct Descriptor
 
-  private enum Reflection {
-    /// Returns the collection of all named key paths of this type.
-    ///
-    /// - Parameter value: A value of any type to return the stored key paths of.
-    /// - Returns: An array of tuples with both the name and partial key path
-    ///            for this value.
-    static func allNamedKeyPaths(
-      forUnderlyingTypeOf type: Any.Type
-    ) -> [(name: String, keyPath: AnyKeyPath)] {
-      guard let metadata = getMetadata(for: type) as? TypeMetadata else {
-        return []
-      }
+    // A struct descriptor that describes some structure context.
+    private struct StructDescriptor: TypeContextDescriptor, PointerAuthenticatedLayoutWrapper {
+        typealias Layout = _StructDescriptor
 
-      var result = [(name: String, keyPath: AnyKeyPath)]()
-      result.reserveCapacity(metadata.contextDescriptor.fields.numFields)
+        // The backing context descriptor pointer.
+        let signedPointer: UnsafeRawPointer
 
-      for i in 0..<metadata.contextDescriptor.fields.numFields {
-        let name = metadata.contextDescriptor.fields.records[i].name
-        let keyPath = createKeyPath(root: metadata, leaf: i)
-        result.append((name: name, keyPath: keyPath))
-      }
+        // The offset to the field offset vector found in the metadata.
+        var fieldOffsetVectorOffset: Int {
+            Int(layout._fieldOffsetVectorOffset)
+        }
 
-      return result
+        // The number of stored properties this struct has.
+        var numFields: Int {
+            Int(layout._numFields)
+        }
     }
-  }
+
+    private struct _StructDescriptor {
+        let _base: _TypeContextDescriptor
+        let _numFields: UInt32
+        let _fieldOffsetVectorOffset: UInt32
+    }
+
+    // Class Descriptor
+
+    // A class descriptor that descibes some class context.
+    private struct ClassDescriptor: TypeContextDescriptor, PointerAuthenticatedLayoutWrapper {
+        typealias Layout = _ClassDescriptor
+
+        // The backing context descriptor pointer.
+        let signedPointer: UnsafeRawPointer
+
+        // The offset to the field offset vector found in the metadata.
+        var fieldOffsetVectorOffset: Int {
+            Int(layout._fieldOffsetVectorOffset)
+        }
+
+        // The negative size of the metadata objects in this class.
+        var negativeSize: Int {
+            assert(!typeFlags.classHasResilientSuperclass)
+            return Int(layout._negativeSizeOrResilientBounds)
+        }
+
+        // The number of stored properties this class defines.
+        var numFields: Int {
+            Int(layout._numFields)
+        }
+
+        // The total number of members this class defines (not including it's
+        // superclass, if it has one).
+        var numImmediateMembers: Int {
+            Int(layout._numImmediateMembers)
+        }
+
+        // The positive size of the metadata objects in this class.
+        var positiveSize: Int {
+            assert(!typeFlags.classHasResilientSuperclass)
+            return Int(layout._positiveSizeOrExtraFlags)
+        }
+
+        // The resilient bounds for this class.
+        var resilientBounds: _StoredClassMetadataBounds {
+            let addr = address(for: \._negativeSizeOrResilientBounds)
+            let pointer = UnsafeRawPointer(addr)
+            return pointer.relativeDirect(as: _StoredClassMetadataBounds.self).pointee
+        }
+    }
+
+    private struct _ClassDescriptor {
+        let _base: _TypeContextDescriptor
+        let _superclassMangledName: RelativeDirectPointer<CChar>
+        let _negativeSizeOrResilientBounds: Int32
+        let _positiveSizeOrExtraFlags: Int32
+        let _numImmediateMembers: UInt32
+        let _numFields: UInt32
+        let _fieldOffsetVectorOffset: UInt32
+    }
+
+    private struct _StoredClassMetadataBounds {
+        let _immediateMembersOffset: Int
+    }
+
+    // Field Descriptor
+
+    // A special descriptor that describes a type's fields.
+    private struct FieldDescriptor: PointerAuthenticatedLayoutWrapper {
+        typealias Layout = _FieldDescriptor
+
+        // The backing field descriptor pointer.
+        let signedPointer: UnsafeRawPointer
+
+        // The number of fields this type has. This could mean different things
+        // depending on what kind of type this is found under. For example, this is
+        // the number of stored properties found within a struct, but for enums this
+        // is the number of cases.
+        var numFields: Int {
+            Int(layout._numFields)
+        }
+
+        // An array of the field record information. Field record information contains
+        // things like it's mangled type, whether or not its a var, indirect, etc.
+        var records: [FieldRecord] {
+            var result = [FieldRecord]()
+            result.reserveCapacity(numFields)
+
+            for i in 0..<numFields {
+                let address = trailing + MemoryLayout<_FieldRecord>.size * i
+                result.append(FieldRecord(signedPointer: address))
+            }
+
+            return result
+        }
+    }
+
+    // A record that describes a single stored property or an enum case.
+    private struct FieldRecord: PointerAuthenticatedLayoutWrapper {
+        typealias Layout = _FieldRecord
+
+        // The backing field record pointer.
+        let signedPointer: UnsafeRawPointer
+
+        // The flags that describe this field record.
+        var flags: FieldRecordFlags {
+            layout._flags
+        }
+
+        // The mangled type name that demangles to the field's type.
+        var mangledTypeName: UnsafePointer<CChar> {
+            address(for: \._mangledTypeName)
+        }
+
+        // The name of the stored property/enum case.
+        var name: String {
+            String(cString: address(for: \._fieldName))
+        }
+    }
+
+    private struct _FieldDescriptor {
+        let _mangledTypeName: RelativeDirectPointer<CChar>
+        let _superclassMangledTypeName: RelativeDirectPointer<CChar>
+        let _kind: UInt16
+        let _recordSize: UInt16
+        let _numFields: UInt32
+    }
+
+    private struct _FieldRecord {
+        let _flags: FieldRecordFlags
+        let _mangledTypeName: RelativeDirectPointer<CChar>
+        let _fieldName: RelativeDirectPointer<CChar>
+    }
+
+    // The flags which describe a field record.
+    private struct FieldRecordFlags {
+        // The backing integer representation of these flags.
+        let bits: UInt32
+
+        // Whether or not this stored property is a var.
+        var isVar: Bool {
+            bits & 0x2 != 0
+        }
+    }
+
+    //===----------------------------------------------------------------------===//
+    // Misc. Utilities
+    //===----------------------------------------------------------------------===//
+
+    private protocol LayoutWrapper {
+        associatedtype Layout
+        var pointer: UnsafeRawPointer { get }
+    }
+
+    private protocol PointerAuthenticatedLayoutWrapper: LayoutWrapper {
+        var signedPointer: UnsafeRawPointer { get }
+    }
+
+    extension PointerAuthenticatedLayoutWrapper {
+        fileprivate var pointer: UnsafeRawPointer {
+            signedPointer
+        }
+    }
+
+    extension LayoutWrapper {
+        fileprivate var layout: Layout {
+            pointer.load(as: Layout.self)
+        }
+
+        fileprivate var trailing: UnsafeRawPointer {
+            pointer + MemoryLayout<Layout>.size
+        }
+
+        fileprivate func address<T>(for field: KeyPath<Layout, T>) -> UnsafePointer<T> {
+            let offset = MemoryLayout<Layout>.offset(of: field)!
+            return UnsafePointer<T>((pointer + offset)._rawValue)
+        }
+
+        fileprivate func address<T: RelativePointer, U>(
+            for field: KeyPath<Layout, T>
+        ) -> UnsafePointer<U> where T.Pointee == U {
+            let offset = MemoryLayout<Layout>.offset(of: field)!
+            return layout[keyPath: field].address(from: pointer + offset)
+        }
+    }
+
+    // This is a utility within KeyPath.swift in the standard library. If this
+    // gets moved into there, then this goes away, but will have to rethink if this
+    // goes into a different module.
+    private func getSymbolicMangledNameLength(_ base: UnsafeRawPointer) -> Int {
+        var end = base
+        while let current = Optional(end.load(as: UInt8.self)), current != 0 {
+            // Skip the current character
+            end = end + 1
+
+            // Skip over a symbolic reference
+            if current >= 0x1 && current <= 0x17 {
+                end += 4
+            } else if current >= 0x18 && current <= 0x1F {
+                end += MemoryLayout<Int>.size
+            }
+        }
+
+        return end - base
+    }
+
+    @_silgen_name("swift_allocObject")
+    internal func _allocObject(_: UnsafeMutableRawPointer, _: Int, _: Int) -> AnyObject?
+
+    // This is a utility within KeyPath.swift in the standard library. If this
+    // gets moved into there, then this goes away, but will have to rethink if this
+    // goes into a different module.
+    extension AnyKeyPath {
+        fileprivate static func _create(
+            capacityInBytes bytes: Int,
+            initializedBy body: (UnsafeMutableRawBufferPointer) -> Void
+        ) -> Self {
+            assert(
+                bytes > 0 && bytes % 4 == 0,
+                "capacity must be multiple of 4 bytes")
+            let metadata = getMetadata(for: self) as! ClassMetadata
+            var size = metadata.instanceSize
+
+            let tailStride = MemoryLayout<Int32>.stride
+            let tailAlignMask = MemoryLayout<Int32>.alignment - 1
+
+            size += tailAlignMask
+            size &= ~tailAlignMask
+            size += tailStride * (bytes / 4)
+
+            let alignment = metadata.instanceAlignMask | tailAlignMask
+
+            let object = _allocObject(
+                UnsafeMutableRawPointer(mutating: metadata.pointer),
+                size,
+                alignment
+            )
+
+            guard object != nil else {
+                fatalError("Allocating \(self) instance failed for keypath reflection")
+            }
+
+            // This memory layout of Int by 2 is the size of a heap object which object
+            // points to. Tail members appear immediately afterwards.
+            let base =
+                unsafeBitCast(object, to: UnsafeMutableRawPointer.self) + MemoryLayout<Int>.size * 2
+
+            // The first word is the kvc string pointer. Set it to 0 (nil).
+            base.storeBytes(of: 0, as: Int.self)
+
+            // Return an offseted base after the kvc string pointer.
+            let newBase = base + MemoryLayout<Int>.size
+            let newBytes = bytes - MemoryLayout<Int>.size
+
+            body(UnsafeMutableRawBufferPointer(start: newBase, count: newBytes))
+
+            return unsafeBitCast(object, to: self)
+        }
+    }
+
+    // Helper struct to represent the keypath buffer header. This structure is also
+    // found within KeyPath.swift, so if this gets moved there this goes away.
+    private struct KeyPathBufferHeader {
+        let bits: UInt32
+
+        init(hasReferencePrefix: Bool, isTrivial: Bool, size: UInt32) {
+            var bits = size
+
+            if hasReferencePrefix {
+                bits |= 0x4000_0000
+            }
+
+            if isTrivial {
+                bits |= 0x8000_0000
+            }
+
+            self.bits = bits
+        }
+    }
+
+    // This initializes the raw keypath buffer with the field offset information.
+    private func instantiateKeyPathBuffer(
+        _ metadata: TypeMetadata,
+        _ leafIndex: Int,
+        _ data: UnsafeMutableRawBufferPointer
+    ) {
+        let header = KeyPathBufferHeader(
+            hasReferencePrefix: false,
+            isTrivial: true,
+            size: UInt32(MemoryLayout<UInt32>.size)
+        )
+
+        data.storeBytes(of: header, as: KeyPathBufferHeader.self)
+
+        var componentBits = UInt32(metadata.fieldOffsets[leafIndex])
+        componentBits |= metadata.kind == .struct ? 1 << 24 : 3 << 24
+
+        data.storeBytes(
+            of: componentBits,
+            toByteOffset: MemoryLayout<Int>.size,
+            as: UInt32.self
+        )
+    }
+
+    // Returns a concrete type for which this keypath is going to be given a root
+    // and leaf type.
+    private func getKeyPathType(
+        from root: TypeMetadata,
+        for leaf: FieldRecord
+    ) -> AnyKeyPath.Type {
+        let leafType = root.type(of: leaf.mangledTypeName)!
+
+        func openRoot<Root>(_: Root.Type) -> AnyKeyPath.Type {
+            func openLeaf<Value>(_: Value.Type) -> AnyKeyPath.Type {
+                if leaf.flags.isVar {
+                    return root.kind == .class
+                        ? ReferenceWritableKeyPath<Root, Value>.self
+                        : WritableKeyPath<Root, Value>.self
+                }
+                return KeyPath<Root, Value>.self
+            }
+            return _openExistential(leafType, do: openLeaf)
+        }
+        return _openExistential(root.type, do: openRoot)
+    }
+
+    // Given a root type and a leaf index, create a concrete keypath object at
+    // runtime.
+    private func createKeyPath(root: TypeMetadata, leaf: Int) -> AnyKeyPath {
+        let field = root.contextDescriptor.fields.records[leaf]
+
+        let keyPathTy = getKeyPathType(from: root, for: field)
+        let size = MemoryLayout<Int>.size * 3
+        let instance = keyPathTy._create(capacityInBytes: size) {
+            instantiateKeyPathBuffer(root, leaf, $0)
+        }
+
+        let heapObj = UnsafeRawPointer(Unmanaged.passUnretained(instance).toOpaque())
+        let keyPath = unsafeBitCast(heapObj, to: AnyKeyPath.self)
+        return keyPath
+    }
+
+    private enum Reflection {
+        /// Returns the collection of all named key paths of this type.
+        ///
+        /// - Parameter value: A value of any type to return the stored key paths of.
+        /// - Returns: An array of tuples with both the name and partial key path
+        ///            for this value.
+        static func allNamedKeyPaths(
+            forUnderlyingTypeOf type: Any.Type
+        ) -> [(name: String, keyPath: AnyKeyPath)] {
+            guard let metadata = getMetadata(for: type) as? TypeMetadata else {
+                return []
+            }
+
+            var result = [(name: String, keyPath: AnyKeyPath)]()
+            result.reserveCapacity(metadata.contextDescriptor.fields.numFields)
+
+            for i in 0..<metadata.contextDescriptor.fields.numFields {
+                let name = metadata.contextDescriptor.fields.records[i].name
+                let keyPath = createKeyPath(root: metadata, leaf: i)
+                result.append((name: name, keyPath: keyPath))
+            }
+
+            return result
+        }
+    }
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/Photos.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/Photos.swift
@@ -1,38 +1,38 @@
 #if canImport(Photos)
-  import Photos
+    import Photos
 
-  @available(iOS 14, macCatalyst 14, macOS 11, tvOS 14, *)
-  extension PHAccessLevel: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .addOnly:
-        return "PHAccessLevel.addOnly"
-      case .readWrite:
-        return "PHAccessLevel.readWrite"
-      @unknown default:
-        return "PHAccessLevel.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 14, macCatalyst 14, macOS 11, tvOS 14, *)
+    extension PHAccessLevel: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .addOnly:
+                return "PHAccessLevel.addOnly"
+            case .readWrite:
+                return "PHAccessLevel.readWrite"
+            @unknown default:
+                return "PHAccessLevel.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  @available(iOS 8, macCatalyst 13, macOS 10.13, tvOS 10, *)
-  extension PHAuthorizationStatus: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .authorized:
-        return "PHAuthorizationStatus.authorized"
-      case .denied:
-        return "PHAuthorizationStatus.denied"
-      case .notDetermined:
-        return "PHAuthorizationStatus.notDetermined"
-      case .restricted:
-        return "PHAuthorizationStatus.restricted"
-      case .limited:
-        return "PHAuthorizationStatus.limited"
-      @unknown default:
-        return "PHAuthorizationStatus.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 8, macCatalyst 13, macOS 10.13, tvOS 10, *)
+    extension PHAuthorizationStatus: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .authorized:
+                return "PHAuthorizationStatus.authorized"
+            case .denied:
+                return "PHAuthorizationStatus.denied"
+            case .notDetermined:
+                return "PHAuthorizationStatus.notDetermined"
+            case .restricted:
+                return "PHAuthorizationStatus.restricted"
+            case .limited:
+                return "PHAuthorizationStatus.limited"
+            @unknown default:
+                return "PHAuthorizationStatus.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/Speech.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/Speech.swift
@@ -1,60 +1,60 @@
 #if canImport(Speech)
-  import Speech
+    import Speech
 
-  @available(iOS 10, macOS 10.15, *)
-  extension SFSpeechRecognizerAuthorizationStatus: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .authorized:
-        return "SFSpeechRecognizerAuthorizationStatus.authorized"
-      case .denied:
-        return "SFSpeechRecognizerAuthorizationStatus.denied"
-      case .notDetermined:
-        return "SFSpeechRecognizerAuthorizationStatus.notDetermined"
-      case .restricted:
-        return "SFSpeechRecognizerAuthorizationStatus.restricted"
-      @unknown default:
-        return
-          "SFSpeechRecognizerAuthorizationStatus.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 10, macOS 10.15, *)
+    extension SFSpeechRecognizerAuthorizationStatus: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .authorized:
+                return "SFSpeechRecognizerAuthorizationStatus.authorized"
+            case .denied:
+                return "SFSpeechRecognizerAuthorizationStatus.denied"
+            case .notDetermined:
+                return "SFSpeechRecognizerAuthorizationStatus.notDetermined"
+            case .restricted:
+                return "SFSpeechRecognizerAuthorizationStatus.restricted"
+            @unknown default:
+                return
+                    "SFSpeechRecognizerAuthorizationStatus.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  @available(iOS 10, macOS 10.15, *)
-  extension SFSpeechRecognitionTaskHint: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .confirmation:
-        return "SFSpeechRecognitionTaskHint.confirmation"
-      case .dictation:
-        return "SFSpeechRecognitionTaskHint.dictation"
-      case .search:
-        return "SFSpeechRecognitionTaskHint.search"
-      case .unspecified:
-        return "SFSpeechRecognitionTaskHint.unspecified"
-      @unknown default:
-        return "SFSpeechRecognitionTaskHint.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 10, macOS 10.15, *)
+    extension SFSpeechRecognitionTaskHint: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .confirmation:
+                return "SFSpeechRecognitionTaskHint.confirmation"
+            case .dictation:
+                return "SFSpeechRecognitionTaskHint.dictation"
+            case .search:
+                return "SFSpeechRecognitionTaskHint.search"
+            case .unspecified:
+                return "SFSpeechRecognitionTaskHint.unspecified"
+            @unknown default:
+                return "SFSpeechRecognitionTaskHint.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  @available(iOS 10, macOS 10.15, *)
-  extension SFSpeechRecognitionTaskState: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .canceling:
-        return "SFSpeechRecognitionTaskState.canceling"
-      case .completed:
-        return "SFSpeechRecognitionTaskState.completed"
-      case .finishing:
-        return "SFSpeechRecognitionTaskState.finishing"
-      case .running:
-        return "SFSpeechRecognitionTaskState.running"
-      case .starting:
-        return "SFSpeechRecognitionTaskState.starting"
-      @unknown default:
-        return "SFSpeechRecognitionTaskState.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 10, macOS 10.15, *)
+    extension SFSpeechRecognitionTaskState: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .canceling:
+                return "SFSpeechRecognitionTaskState.canceling"
+            case .completed:
+                return "SFSpeechRecognitionTaskState.completed"
+            case .finishing:
+                return "SFSpeechRecognitionTaskState.finishing"
+            case .running:
+                return "SFSpeechRecognitionTaskState.running"
+            case .starting:
+                return "SFSpeechRecognitionTaskState.starting"
+            @unknown default:
+                return "SFSpeechRecognitionTaskState.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/StoreKit.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/StoreKit.swift
@@ -1,41 +1,41 @@
 #if canImport(StoreKit)
-  import StoreKit
+    import StoreKit
 
-  @available(iOS 3, macCatalyst 13, macOS 10.7, tvOS 9, watchOS 6.2, *)
-  extension SKPaymentTransactionState: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .purchasing:
-        return "SKPaymentTransactionState.purchasing"
-      case .purchased:
-        return "SKPaymentTransactionState.purchased"
-      case .failed:
-        return "SKPaymentTransactionState.failed"
-      case .restored:
-        return "SKPaymentTransactionState.restored"
-      case .deferred:
-        return "SKPaymentTransactionState.deferred"
-      @unknown default:
-        return "SKPaymentTransactionState.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 3, macCatalyst 13, macOS 10.7, tvOS 9, watchOS 6.2, *)
+    extension SKPaymentTransactionState: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .purchasing:
+                return "SKPaymentTransactionState.purchasing"
+            case .purchased:
+                return "SKPaymentTransactionState.purchased"
+            case .failed:
+                return "SKPaymentTransactionState.failed"
+            case .restored:
+                return "SKPaymentTransactionState.restored"
+            case .deferred:
+                return "SKPaymentTransactionState.deferred"
+            @unknown default:
+                return "SKPaymentTransactionState.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  @available(iOS 11.2, macCatalyst 13, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
-  extension SKProduct.PeriodUnit: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .day:
-        return "SKProduct.PeriodUnit.day"
-      case .week:
-        return "SKProduct.PeriodUnit.week"
-      case .month:
-        return "SKProduct.PeriodUnit.month"
-      case .year:
-        return "SKProduct.PeriodUnit.year"
-      @unknown default:
-        return "SKProduct.PeriodUnit.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 11.2, macCatalyst 13, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+    extension SKProduct.PeriodUnit: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .day:
+                return "SKProduct.PeriodUnit.day"
+            case .week:
+                return "SKProduct.PeriodUnit.week"
+            case .month:
+                return "SKProduct.PeriodUnit.month"
+            case .year:
+                return "SKProduct.PeriodUnit.year"
+            @unknown default:
+                return "SKProduct.PeriodUnit.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/Swift.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/Swift.swift
@@ -1,24 +1,24 @@
 extension Character: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    String(self)
-  }
+    public var customDumpValue: Any {
+        String(self)
+    }
 }
 
 extension ObjectIdentifier: CustomDumpStringConvertible {
-  public var customDumpDescription: String {
-    self.debugDescription
-      .replacingOccurrences(of: "0x0*", with: "0x", options: .regularExpression)
-  }
+    public var customDumpDescription: String {
+        self.debugDescription
+            .replacingOccurrences(of: "0x0*", with: "0x", options: .regularExpression)
+    }
 }
 
 extension StaticString: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    "\(self)"
-  }
+    public var customDumpValue: Any {
+        "\(self)"
+    }
 }
 
 extension UnicodeScalar: CustomDumpRepresentable {
-  public var customDumpValue: Any {
-    String(self)
-  }
+    public var customDumpValue: Any {
+        String(self)
+    }
 }

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/SwiftUI.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/SwiftUI.swift
@@ -1,76 +1,77 @@
 #if canImport(SwiftUI)
-  import SwiftUI
+    import SwiftUI
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  extension Animation: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .easeIn:
-        return "Animation.easeIn"
-      case .easeInOut:
-        return "Animation.easeInOut"
-      case .easeOut:
-        return "Animation.easeOut"
-      case .interactiveSpring():
-        return "Animation.interactiveSpring()"
-      case .linear:
-        return "Animation.linear"
-      case .spring():
-        return "Animation.spring()"
-      default:
-        let base = _customDump(
-          Mirror(reflecting: self).children.first?.value as Any,
-          name: nil,
-          indent: 2,
-          maxDepth: .max
-        )
-        return """
-          Animation(
-          \(base)
-          )
-          """
-      }
-    }
-  }
-
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-  extension LocalizedStringKey: CustomDumpRepresentable {
-    public var customDumpValue: Any {
-      self.formatted()
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    extension Animation: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .easeIn:
+                return "Animation.easeIn"
+            case .easeInOut:
+                return "Animation.easeInOut"
+            case .easeOut:
+                return "Animation.easeOut"
+            case .interactiveSpring():
+                return "Animation.interactiveSpring()"
+            case .linear:
+                return "Animation.linear"
+            case .spring():
+                return "Animation.spring()"
+            default:
+                let base = _customDump(
+                    Mirror(reflecting: self).children.first?.value as Any,
+                    name: nil,
+                    indent: 2,
+                    maxDepth: .max
+                )
+                return """
+                    Animation(
+                    \(base)
+                    )
+                    """
+            }
+        }
     }
 
-    private func formatted(
-      locale: Locale? = nil,
-      tableName: String? = nil,
-      bundle: Bundle? = nil,
-      comment: StaticString? = nil
-    ) -> String {
-      let children = Array(Mirror(reflecting: self).children)
-      let key = children[0].value as! String
-      let arguments: [CVarArg] = Array(Mirror(reflecting: children[2].value).children)
-        .compactMap {
-          let children = Array(Mirror(reflecting: $0.value).children)
-          let value: Any
-          let formatter: Formatter?
-          // `LocalizedStringKey.FormatArgument` differs depending on OS/platform.
-          if children[0].label == "storage" {
-            (value, formatter) =
-              Array(Mirror(reflecting: children[0].value).children)[0].value as! (Any, Formatter?)
-          } else {
-            value = children[0].value
-            formatter = children[1].value as? Formatter
-          }
-          return formatter?.string(for: value) ?? value as! CVarArg
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    extension LocalizedStringKey: CustomDumpRepresentable {
+        public var customDumpValue: Any {
+            self.formatted()
         }
 
-      let format = NSLocalizedString(
-        key,
-        tableName: tableName,
-        bundle: bundle ?? .main,
-        value: "",
-        comment: comment.map(String.init) ?? ""
-      )
-      return String(format: format, locale: locale, arguments: arguments)
+        private func formatted(
+            locale: Locale? = nil,
+            tableName: String? = nil,
+            bundle: Bundle? = nil,
+            comment: StaticString? = nil
+        ) -> String {
+            let children = Array(Mirror(reflecting: self).children)
+            let key = children[0].value as! String
+            let arguments: [CVarArg] = Array(Mirror(reflecting: children[2].value).children)
+                .compactMap {
+                    let children = Array(Mirror(reflecting: $0.value).children)
+                    let value: Any
+                    let formatter: Formatter?
+                    // `LocalizedStringKey.FormatArgument` differs depending on OS/platform.
+                    if children[0].label == "storage" {
+                        (value, formatter) =
+                            Array(Mirror(reflecting: children[0].value).children)[0].value
+                            as! (Any, Formatter?)
+                    } else {
+                        value = children[0].value
+                        formatter = children[1].value as? Formatter
+                    }
+                    return formatter?.string(for: value) ?? value as! CVarArg
+                }
+
+            let format = NSLocalizedString(
+                key,
+                tableName: tableName,
+                bundle: bundle ?? .main,
+                value: "",
+                comment: comment.map(String.init) ?? ""
+            )
+            return String(format: format, locale: locale, arguments: arguments)
+        }
     }
-  }
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/UIKit.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/UIKit.swift
@@ -1,123 +1,124 @@
 #if canImport(UIKit)
-  import UIKit
+    import UIKit
 
-  #if !os(watchOS)
-    @available(iOS 3.2, macCatalyst 13, tvOS 9, *)
-    @available(watchOS, unavailable)
-    extension UIGestureRecognizer.State: CustomDumpStringConvertible {
-      public var customDumpDescription: String {
-        switch self {
-        case .began:
-          return "UIGestureRecognizer.State.began"
-        case .cancelled:
-          return "UIGestureRecognizer.State.cancelled"
-        case .changed:
-          return "UIGestureRecognizer.State.changed"
-        case .ended:
-          return "UIGestureRecognizer.State.ended"
-        case .failed:
-          return "UIGestureRecognizer.State.failed"
-        case .possible:
-          return "UIGestureRecognizer.State.possible"
-        @unknown default:
-          return "UIGestureRecognizer.State.(@unknown default, rawValue: \(self.rawValue))"
-        }
-      }
-    }
-
-    @available(iOS 11, macCatalyst 13, tvOS 11, *)
-    @available(watchOS, unavailable)
-    extension UIScrollView.ContentInsetAdjustmentBehavior: CustomDumpStringConvertible {
-      public var customDumpDescription: String {
-        switch self {
-        case .always:
-          return "UIScrollView.ContentInsetAdjustmentBehavior.always"
-        case .automatic:
-          return "UIScrollView.ContentInsetAdjustmentBehavior.automatic"
-        case .never:
-          return "UIScrollView.ContentInsetAdjustmentBehavior.never"
-        case .scrollableAxes:
-          return "UIScrollView.ContentInsetAdjustmentBehavior.scrollableAxes"
-        @unknown default:
-          return
-            "UIScrollView.ContentInsetAdjustmentBehavior.(@unknown default, rawValue: \(self.rawValue))"
-        }
-      }
-    }
-
-    @available(iOS 12, macCatalyst 13, tvOS 10, *)
-    @available(watchOS, unavailable)
-    extension UIUserInterfaceStyle: CustomDumpStringConvertible {
-      public var customDumpDescription: String {
-        switch self {
-        case .dark:
-          return "UIUserInterfaceStyle.dark"
-        case .light:
-          return "UIUserInterfaceStyle.light"
-        case .unspecified:
-          return "UIUserInterfaceStyle.unspecified"
-        @unknown default:
-          return "UIUserInterfaceStyle.(@unknown default, rawValue: \(self.rawValue))"
-        }
-      }
-    }
-
-    @available(iOS 2, macCatalyst 13, tvOS 9, *)
-    @available(watchOS, unavailable)
-    extension UIControl.State: CustomDumpReflectable {
-      public var customDumpMirror: Mirror {
-        struct Option: CustomDumpStringConvertible {
-          var rawValue: UIControl.State
-
-          var customDumpDescription: String {
-            switch self.rawValue {
-            case .application:
-              return "UIControl.State.application"
-            case .disabled:
-              return "UIControl.State.disabled"
-            case .focused:
-              return "UIControl.State.focused"
-            case .highlighted:
-              return "UIControl.State.highlighted"
-            case .normal:
-              return "UIControl.State.normal"
-            case .reserved:
-              return "UIControl.State.reserved"
-            case .selected:
-              return "UIControl.State.selected"
-            default:
-              return "UIControl.State(rawValue: \(self.rawValue))"
+    #if !os(watchOS)
+        @available(iOS 3.2, macCatalyst 13, tvOS 9, *)
+        @available(watchOS, unavailable)
+        extension UIGestureRecognizer.State: CustomDumpStringConvertible {
+            public var customDumpDescription: String {
+                switch self {
+                case .began:
+                    return "UIGestureRecognizer.State.began"
+                case .cancelled:
+                    return "UIGestureRecognizer.State.cancelled"
+                case .changed:
+                    return "UIGestureRecognizer.State.changed"
+                case .ended:
+                    return "UIGestureRecognizer.State.ended"
+                case .failed:
+                    return "UIGestureRecognizer.State.failed"
+                case .possible:
+                    return "UIGestureRecognizer.State.possible"
+                @unknown default:
+                    return
+                        "UIGestureRecognizer.State.(@unknown default, rawValue: \(self.rawValue))"
+                }
             }
-          }
         }
 
-        var options = self
-        var children: [Option] = []
-        let allCases: [UIControl.State] = [
-          .application,
-          .disabled,
-          .focused,
-          .highlighted,
-          .normal,
-          .reserved,
-          .selected,
-        ]
-        for option in allCases {
-          if options.contains(option) {
-            children.append(.init(rawValue: option))
-            options.subtract(option)
-          }
-        }
-        if !options.isEmpty {
-          children.append(.init(rawValue: options))
+        @available(iOS 11, macCatalyst 13, tvOS 11, *)
+        @available(watchOS, unavailable)
+        extension UIScrollView.ContentInsetAdjustmentBehavior: CustomDumpStringConvertible {
+            public var customDumpDescription: String {
+                switch self {
+                case .always:
+                    return "UIScrollView.ContentInsetAdjustmentBehavior.always"
+                case .automatic:
+                    return "UIScrollView.ContentInsetAdjustmentBehavior.automatic"
+                case .never:
+                    return "UIScrollView.ContentInsetAdjustmentBehavior.never"
+                case .scrollableAxes:
+                    return "UIScrollView.ContentInsetAdjustmentBehavior.scrollableAxes"
+                @unknown default:
+                    return
+                        "UIScrollView.ContentInsetAdjustmentBehavior.(@unknown default, rawValue: \(self.rawValue))"
+                }
+            }
         }
 
-        return .init(
-          self,
-          unlabeledChildren: children,
-          displayStyle: .set
-        )
-      }
-    }
-  #endif
+        @available(iOS 12, macCatalyst 13, tvOS 10, *)
+        @available(watchOS, unavailable)
+        extension UIUserInterfaceStyle: CustomDumpStringConvertible {
+            public var customDumpDescription: String {
+                switch self {
+                case .dark:
+                    return "UIUserInterfaceStyle.dark"
+                case .light:
+                    return "UIUserInterfaceStyle.light"
+                case .unspecified:
+                    return "UIUserInterfaceStyle.unspecified"
+                @unknown default:
+                    return "UIUserInterfaceStyle.(@unknown default, rawValue: \(self.rawValue))"
+                }
+            }
+        }
+
+        @available(iOS 2, macCatalyst 13, tvOS 9, *)
+        @available(watchOS, unavailable)
+        extension UIControl.State: CustomDumpReflectable {
+            public var customDumpMirror: Mirror {
+                struct Option: CustomDumpStringConvertible {
+                    var rawValue: UIControl.State
+
+                    var customDumpDescription: String {
+                        switch self.rawValue {
+                        case .application:
+                            return "UIControl.State.application"
+                        case .disabled:
+                            return "UIControl.State.disabled"
+                        case .focused:
+                            return "UIControl.State.focused"
+                        case .highlighted:
+                            return "UIControl.State.highlighted"
+                        case .normal:
+                            return "UIControl.State.normal"
+                        case .reserved:
+                            return "UIControl.State.reserved"
+                        case .selected:
+                            return "UIControl.State.selected"
+                        default:
+                            return "UIControl.State(rawValue: \(self.rawValue))"
+                        }
+                    }
+                }
+
+                var options = self
+                var children: [Option] = []
+                let allCases: [UIControl.State] = [
+                    .application,
+                    .disabled,
+                    .focused,
+                    .highlighted,
+                    .normal,
+                    .reserved,
+                    .selected,
+                ]
+                for option in allCases {
+                    if options.contains(option) {
+                        children.append(.init(rawValue: option))
+                        options.subtract(option)
+                    }
+                }
+                if !options.isEmpty {
+                    children.append(.init(rawValue: options))
+                }
+
+                return .init(
+                    self,
+                    unlabeledChildren: children,
+                    displayStyle: .set
+                )
+            }
+        }
+    #endif
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/UserNotifications.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/UserNotifications.swift
@@ -1,238 +1,243 @@
 #if canImport(UserNotifications)
-import UserNotifications
+    import UserNotifications
 
-@available(iOS 10, macOS 10.14, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
-extension UNAlertStyle: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-        switch self {
-        case .alert:
-            return "UNAlertStyle.alert"
-        case .banner:
-            return "UNAlertStyle.banner"
-        case .none:
-            return "UNAlertStyle.none"
-        @unknown default:
-            return "UNAlertStyle.(@unknown default, rawValue: \(self.rawValue))"
-        }
-    }
-}
-
-@available(iOS 10, macOS 10.14, tvOS 10, watchOS 3, *)
-extension UNAuthorizationOptions: CustomDumpReflectable {
-    public var customDumpMirror: Mirror {
-        struct Option: CustomDumpStringConvertible {
-            var rawValue: UNAuthorizationOptions
-            
-            var customDumpDescription: String {
-                switch self.rawValue {
-                case .alert:
-                    return "UNAuthorizationOptions.alert"
-                case .badge:
-                    return "UNAuthorizationOptions.badge"
-                case .carPlay:
-                    return "UNAuthorizationOptions.carPlay"
-                case .sound:
-                    return "UNAuthorizationOptions.sound"
-                default:
-                    
-                    if #available(iOS 13.0, *) {
-                        #if os(iOS) || os(watchOS)
-                        if self.rawValue == .announcement {
-                            return "UNAuthorizationOptions.announcement"
-                        }
-                        #endif
-                    }
-                    if #available(iOS 12.0, *) {
-                        if self.rawValue == .criticalAlert {
-                            return "UNAuthorizationOptions.criticalAlert"
-                        }
-                        if self.rawValue == .providesAppNotificationSettings {
-                            return "UNAuthorizationOptions.providesAppNotificationSettings"
-                        }
-                        if self.rawValue == .provisional {
-                            return "UNAuthorizationOptions.provisional"
-                        }
-                    }
-                    return "UNAuthorizationOptions(rawValue: \(self.rawValue))"
-                }
+    @available(iOS 10, macOS 10.14, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    extension UNAlertStyle: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .alert:
+                return "UNAlertStyle.alert"
+            case .banner:
+                return "UNAlertStyle.banner"
+            case .none:
+                return "UNAlertStyle.none"
+            @unknown default:
+                return "UNAlertStyle.(@unknown default, rawValue: \(self.rawValue))"
             }
         }
-        
-        var options = self
-        var children: [Option] = []
-        var allCases: [UNAuthorizationOptions] = [
-            .alert
-        ]
-        
-        #if os(iOS) || os(watchOS)
-        if #available(iOS 13.0, *) {
-            allCases.append(.announcement)
-        }
-        #endif
-        
-        if #available(iOS 12.0, *) {
+    }
+
+    @available(iOS 10, macOS 10.14, tvOS 10, watchOS 3, *)
+    extension UNAuthorizationOptions: CustomDumpReflectable {
+        public var customDumpMirror: Mirror {
+            struct Option: CustomDumpStringConvertible {
+                var rawValue: UNAuthorizationOptions
+
+                var customDumpDescription: String {
+                    switch self.rawValue {
+                    case .alert:
+                        return "UNAuthorizationOptions.alert"
+                    case .badge:
+                        return "UNAuthorizationOptions.badge"
+                    case .carPlay:
+                        return "UNAuthorizationOptions.carPlay"
+                    case .sound:
+                        return "UNAuthorizationOptions.sound"
+                    default:
+
+                        if #available(iOS 13.0, *) {
+                            #if os(iOS) || os(watchOS)
+                                if self.rawValue == .announcement {
+                                    return "UNAuthorizationOptions.announcement"
+                                }
+                            #endif
+                        }
+                        if #available(iOS 12.0, *) {
+                            if self.rawValue == .criticalAlert {
+                                return "UNAuthorizationOptions.criticalAlert"
+                            }
+                            if self.rawValue == .providesAppNotificationSettings {
+                                return "UNAuthorizationOptions.providesAppNotificationSettings"
+                            }
+                            if self.rawValue == .provisional {
+                                return "UNAuthorizationOptions.provisional"
+                            }
+                        }
+                        return "UNAuthorizationOptions(rawValue: \(self.rawValue))"
+                    }
+                }
+            }
+
+            var options = self
+            var children: [Option] = []
+            var allCases: [UNAuthorizationOptions] = [
+                .alert
+            ]
+
+            #if os(iOS) || os(watchOS)
+                if #available(iOS 13.0, *) {
+                    allCases.append(.announcement)
+                }
+            #endif
+
+            if #available(iOS 12.0, *) {
+                allCases.append(contentsOf: [
+                    .criticalAlert,
+                    .providesAppNotificationSettings,
+                    .provisional,
+                ])
+            }
+
             allCases.append(contentsOf: [
-                .criticalAlert,
-                .providesAppNotificationSettings,
-                .provisional
+                .badge,
+                .carPlay,
+                .sound,
             ])
+
+            for option in allCases {
+                if options.contains(option) {
+                    children.append(.init(rawValue: option))
+                    options.subtract(option)
+                }
+            }
+            if !options.isEmpty {
+                children.append(.init(rawValue: options))
+            }
+
+            return .init(
+                self,
+                unlabeledChildren: children,
+                displayStyle: .set
+            )
         }
-        
-        allCases.append(contentsOf: [
-            .badge,
-            .carPlay,
-            .sound,
-        ])
-        
-        for option in allCases {
-            if options.contains(option) {
-                children.append(.init(rawValue: option))
-                options.subtract(option)
+    }
+
+    @available(iOS 10, macOS 10.14, tvOS 10, watchOS 3, *)
+    extension UNAuthorizationStatus: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .authorized:
+                return "UNAuthorizationStatus.authorized"
+            case .denied:
+                return "UNAuthorizationStatus.denied"
+            case .ephemeral:
+                return "UNAuthorizationStatus.ephemeral"
+            case .notDetermined:
+                return "UNAuthorizationStatus.notDetermined"
+            case .provisional:
+                return "UNAuthorizationStatus.provisional"
+            @unknown default:
+                return "UNAuthorizationStatus.(@unknown default, rawValue: \(self.rawValue))"
             }
         }
-        if !options.isEmpty {
-            children.append(.init(rawValue: options))
-        }
-        
-        return .init(
-            self,
-            unlabeledChildren: children,
-            displayStyle: .set
-        )
     }
-}
 
-@available(iOS 10, macOS 10.14, tvOS 10, watchOS 3, *)
-extension UNAuthorizationStatus: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-        switch self {
-        case .authorized:
-            return "UNAuthorizationStatus.authorized"
-        case .denied:
-            return "UNAuthorizationStatus.denied"
-        case .ephemeral:
-            return "UNAuthorizationStatus.ephemeral"
-        case .notDetermined:
-            return "UNAuthorizationStatus.notDetermined"
-        case .provisional:
-            return "UNAuthorizationStatus.provisional"
-        @unknown default:
-            return "UNAuthorizationStatus.(@unknown default, rawValue: \(self.rawValue))"
-        }
-    }
-}
-
-// NB: Xcode 13 does not include macOS 12 SDK
-#if compiler(>=5.5) && !os(macOS) && !targetEnvironment(macCatalyst)
-@available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-extension UNNotificationInterruptionLevel: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-        switch self {
-        case .active:
-            return "UNNotificationInterruptionLevel.active"
-        case .critical:
-            return "UNNotificationInterruptionLevel.critical"
-        case .passive:
-            return "UNNotificationInterruptionLevel.passive"
-        case .timeSensitive:
-            return "UNNotificationInterruptionLevel.timeSensitive"
-        @unknown default:
-            return "UNNotificationInterruptionLevel.(@unknown default, rawValue: \(self.rawValue))"
-        }
-    }
-}
-#endif
-
-@available(iOS 10, macOS 10.14, tvOS 10, watchOS 3, *)
-extension UNNotificationPresentationOptions: CustomDumpReflectable {
-    public var customDumpMirror: Mirror {
-        struct Option: CustomDumpStringConvertible {
-            var rawValue: UNNotificationPresentationOptions
-            var customDumpDescription: String {
-                if self.rawValue == .alert {
-                    return "UNNotificationPresentationOptions.alert"
-                } else if self.rawValue == .badge {
-                    return "UNNotificationPresentationOptions.badge"
-                } else if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *), self.rawValue == .banner {
-                    return "UNNotificationPresentationOptions.banner"
-                } else if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *), self.rawValue == .list {
-                    return "UNNotificationPresentationOptions.list"
-                } else if self.rawValue == .sound {
-                    return "UNNotificationPresentationOptions.sound"
-                } else {
-                    return "UNNotificationPresentationOptions(rawValue: \(self.rawValue))"
+    // NB: Xcode 13 does not include macOS 12 SDK
+    #if compiler(>=5.5) && !os(macOS) && !targetEnvironment(macCatalyst)
+        @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+        extension UNNotificationInterruptionLevel: CustomDumpStringConvertible {
+            public var customDumpDescription: String {
+                switch self {
+                case .active:
+                    return "UNNotificationInterruptionLevel.active"
+                case .critical:
+                    return "UNNotificationInterruptionLevel.critical"
+                case .passive:
+                    return "UNNotificationInterruptionLevel.passive"
+                case .timeSensitive:
+                    return "UNNotificationInterruptionLevel.timeSensitive"
+                @unknown default:
+                    return
+                        "UNNotificationInterruptionLevel.(@unknown default, rawValue: \(self.rawValue))"
                 }
             }
         }
-        
-        var options = self
-        var children: [Option] = []
-        var allCases: [UNNotificationPresentationOptions] = [
-            .alert,
-            .badge,
-        ]
-        appendBannerList(&allCases)
-        allCases.append(.sound)
-        for option in allCases {
-            if options.contains(option) {
-                children.append(.init(rawValue: option))
-                options.subtract(option)
+    #endif
+
+    @available(iOS 10, macOS 10.14, tvOS 10, watchOS 3, *)
+    extension UNNotificationPresentationOptions: CustomDumpReflectable {
+        public var customDumpMirror: Mirror {
+            struct Option: CustomDumpStringConvertible {
+                var rawValue: UNNotificationPresentationOptions
+                var customDumpDescription: String {
+                    if self.rawValue == .alert {
+                        return "UNNotificationPresentationOptions.alert"
+                    } else if self.rawValue == .badge {
+                        return "UNNotificationPresentationOptions.badge"
+                    } else if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *),
+                        self.rawValue == .banner
+                    {
+                        return "UNNotificationPresentationOptions.banner"
+                    } else if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *),
+                        self.rawValue == .list
+                    {
+                        return "UNNotificationPresentationOptions.list"
+                    } else if self.rawValue == .sound {
+                        return "UNNotificationPresentationOptions.sound"
+                    } else {
+                        return "UNNotificationPresentationOptions(rawValue: \(self.rawValue))"
+                    }
+                }
+            }
+
+            var options = self
+            var children: [Option] = []
+            var allCases: [UNNotificationPresentationOptions] = [
+                .alert,
+                .badge,
+            ]
+            appendBannerList(&allCases)
+            allCases.append(.sound)
+            for option in allCases {
+                if options.contains(option) {
+                    children.append(.init(rawValue: option))
+                    options.subtract(option)
+                }
+            }
+            if !options.isEmpty {
+                children.append(.init(rawValue: options))
+            }
+
+            return .init(
+                self,
+                unlabeledChildren: children,
+                displayStyle: .set
+            )
+        }
+
+        // NB: Workaround for Xcode 13.2's new, experimental build system.
+        //
+        //     defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
+        private func appendBannerList(_ allCases: inout [UNNotificationPresentationOptions]) {
+            if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
+                allCases.append(contentsOf: [.banner, .list])
             }
         }
-        if !options.isEmpty {
-            children.append(.init(rawValue: options))
-        }
-        
-        return .init(
-            self,
-            unlabeledChildren: children,
-            displayStyle: .set
-        )
     }
-    
-    // NB: Workaround for Xcode 13.2's new, experimental build system.
-    //
-    //     defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
-    private func appendBannerList(_ allCases: inout [UNNotificationPresentationOptions]) {
-        if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
-            allCases.append(contentsOf: [.banner, .list])
-        }
-    }
-}
 
-@available(iOS 10, macOS 10.14, tvOS 10, watchOS 3, *)
-extension UNNotificationSetting: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-        switch self {
-        case .disabled:
-            return "UNNotificationSetting.disabled"
-        case .enabled:
-            return "UNNotificationSetting.enabled"
-        case .notSupported:
-            return "UNNotificationSetting.notSupported"
-        @unknown default:
-            return "UNNotificationSetting.(@unknown default, rawValue: \(self.rawValue))"
+    @available(iOS 10, macOS 10.14, tvOS 10, watchOS 3, *)
+    extension UNNotificationSetting: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .disabled:
+                return "UNNotificationSetting.disabled"
+            case .enabled:
+                return "UNNotificationSetting.enabled"
+            case .notSupported:
+                return "UNNotificationSetting.notSupported"
+            @unknown default:
+                return "UNNotificationSetting.(@unknown default, rawValue: \(self.rawValue))"
+            }
         }
     }
-}
 
-@available(iOS 11, macOS 10.14, *)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
-extension UNShowPreviewsSetting: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-        switch self {
-        case .always:
-            return "UNShowPreviewsSetting.always"
-        case .never:
-            return "UNShowPreviewsSetting.never"
-        case .whenAuthenticated:
-            return "UNShowPreviewsSetting.whenAuthenticated"
-        @unknown default:
-            return "UNShowPreviewsSetting.(@unknown default, rawValue: \(self.rawValue))"
+    @available(iOS 11, macOS 10.14, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    extension UNShowPreviewsSetting: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .always:
+                return "UNShowPreviewsSetting.always"
+            case .never:
+                return "UNShowPreviewsSetting.never"
+            case .whenAuthenticated:
+                return "UNShowPreviewsSetting.whenAuthenticated"
+            @unknown default:
+                return "UNShowPreviewsSetting.(@unknown default, rawValue: \(self.rawValue))"
+            }
         }
     }
-}
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/Conformances/UserNotificationsUI.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Conformances/UserNotificationsUI.swift
@@ -1,41 +1,41 @@
 #if canImport(UserNotificationsUI)
-  import UserNotificationsUI
+    import UserNotificationsUI
 
-  @available(iOS 10, macCatalyst 14, macOS 11, *)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  extension UNNotificationContentExtensionMediaPlayPauseButtonType: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .default:
-        return "UNNotificationContentExtensionMediaPlayPauseButtonType.default"
-      case .none:
-        return "UNNotificationContentExtensionMediaPlayPauseButtonType.none"
-      case .overlay:
-        return "UNNotificationContentExtensionMediaPlayPauseButtonType.overlay"
-      @unknown default:
-        return
-          "UNNotificationContentExtensionMediaPlayPauseButtonType.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 10, macCatalyst 14, macOS 11, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    extension UNNotificationContentExtensionMediaPlayPauseButtonType: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .default:
+                return "UNNotificationContentExtensionMediaPlayPauseButtonType.default"
+            case .none:
+                return "UNNotificationContentExtensionMediaPlayPauseButtonType.none"
+            case .overlay:
+                return "UNNotificationContentExtensionMediaPlayPauseButtonType.overlay"
+            @unknown default:
+                return
+                    "UNNotificationContentExtensionMediaPlayPauseButtonType.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 
-  @available(iOS 10, macCatalyst 14, macOS 11, *)
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  extension UNNotificationContentExtensionResponseOption: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      switch self {
-      case .dismiss:
-        return "UNNotificationContentExtensionResponseOption.dismiss"
-      case .dismissAndForwardAction:
-        return "UNNotificationContentExtensionResponseOption.dismissAndForwardAction"
-      case .doNotDismiss:
-        return "UNNotificationContentExtensionResponseOption.doNotDismiss"
-      @unknown default:
-        return
-          "UNNotificationContentExtensionResponseOption.(@unknown default, rawValue: \(self.rawValue))"
-      }
+    @available(iOS 10, macCatalyst 14, macOS 11, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    extension UNNotificationContentExtensionResponseOption: CustomDumpStringConvertible {
+        public var customDumpDescription: String {
+            switch self {
+            case .dismiss:
+                return "UNNotificationContentExtensionResponseOption.dismiss"
+            case .dismissAndForwardAction:
+                return "UNNotificationContentExtensionResponseOption.dismissAndForwardAction"
+            case .doNotDismiss:
+                return "UNNotificationContentExtensionResponseOption.doNotDismiss"
+            @unknown default:
+                return
+                    "UNNotificationContentExtensionResponseOption.(@unknown default, rawValue: \(self.rawValue))"
+            }
+        }
     }
-  }
 #endif

--- a/Sources/RxComposableArchitecture/CustomDump/CustomDumpDiff.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/CustomDumpDiff.swift
@@ -26,528 +26,535 @@
 /// - Returns: A string describing any difference detected between values, or `nil` if no difference
 ///   is detected.
 public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String? {
-  var visitedItems: Set<ObjectIdentifier> = []
+    var visitedItems: Set<ObjectIdentifier> = []
 
-  func diffHelp(
-    _ lhs: Any,
-    _ rhs: Any,
-    lhsName: String?,
-    rhsName: String?,
-    separator: String,
-    indent: Int
-  ) -> String {
-    let rhsName = rhsName ?? lhsName
-    guard !isMirrorEqual(lhs, rhs) else {
-      return _customDump(lhs, name: rhsName, indent: indent, maxDepth: 0)
-        .appending(separator)
-        .indenting(with: format.both + " ")
-    }
-
-    let lhsMirror = Mirror(customDumpReflecting: lhs)
-    let rhsMirror = Mirror(customDumpReflecting: rhs)
-    var out = ""
-
-    func diffEverything() {
-      var lhs = _customDump(lhs, name: lhsName, indent: indent, maxDepth: .max)
-      var rhs = _customDump(rhs, name: rhsName, indent: indent, maxDepth: .max)
-      if lhs == rhs {
-        if lhsMirror.subjectType != rhsMirror.subjectType {
-          lhs.append(" as \(typeName(lhsMirror.subjectType))")
-          rhs.append(" as \(typeName(rhsMirror.subjectType))")
+    func diffHelp(
+        _ lhs: Any,
+        _ rhs: Any,
+        lhsName: String?,
+        rhsName: String?,
+        separator: String,
+        indent: Int
+    ) -> String {
+        let rhsName = rhsName ?? lhsName
+        guard !isMirrorEqual(lhs, rhs) else {
+            return _customDump(lhs, name: rhsName, indent: indent, maxDepth: 0)
+                .appending(separator)
+                .indenting(with: format.both + " ")
         }
-      }
-      lhs.append(separator)
-      rhs.append(separator)
 
-      print(
-        lhs.indenting(with: format.first + " "),
-        to: &out
-      )
-      print(
-        rhs.indenting(with: format.second + " "),
-        terminator: "",
-        to: &out
-      )
-    }
+        let lhsMirror = Mirror(customDumpReflecting: lhs)
+        let rhsMirror = Mirror(customDumpReflecting: rhs)
+        var out = ""
 
-    guard lhsMirror.subjectType == rhsMirror.subjectType
-    else {
-      diffEverything()
-      return out
-    }
+        func diffEverything() {
+            var lhs = _customDump(lhs, name: lhsName, indent: indent, maxDepth: .max)
+            var rhs = _customDump(rhs, name: rhsName, indent: indent, maxDepth: .max)
+            if lhs == rhs {
+                if lhsMirror.subjectType != rhsMirror.subjectType {
+                    lhs.append(" as \(typeName(lhsMirror.subjectType))")
+                    rhs.append(" as \(typeName(rhsMirror.subjectType))")
+                }
+            }
+            lhs.append(separator)
+            rhs.append(separator)
 
-    func diffChildren(
-      _ lhsMirror: Mirror,
-      _ rhsMirror: Mirror,
-      prefix: String,
-      suffix: String,
-      elementIndent: Int,
-      elementSeparator: String,
-      collapseUnchanged: Bool,
-      areEquivalent: (Mirror.Child, Mirror.Child) -> Bool = { $0.label == $1.label },
-      areInIncreasingOrder: ((Mirror.Child, Mirror.Child) -> Bool)? = nil,
-      _ transform: (inout Mirror.Child, Int) -> Void = { _, _ in }
-    ) {
-      var lhsChildren = Array(lhsMirror.children)
-      var rhsChildren = Array(rhsMirror.children)
-
-      guard !isMirrorEqual(lhsChildren, rhsChildren)
-      else {
-        print(
-          "// Not equal but no difference detected:"
-            .indenting(by: indent)
-            .indenting(with: format.both + " "),
-          to: &out
-        )
-        print(
-          _customDump(
-            lhs,
-            name: lhsName,
-            indent: indent,
-            maxDepth: 0
-          )
-          .indenting(with: format.first + " "),
-          to: &out
-        )
-        print(
-          _customDump(
-            rhs,
-            name: rhsName,
-            indent: indent,
-            maxDepth: 0
-          )
-          .indenting(with: format.second + " "),
-          terminator: "",
-          to: &out
-        )
-        return
-      }
-
-      guard !lhsMirror.isSingleValueContainer && !rhsMirror.isSingleValueContainer
-      else {
-        print(
-          _customDump(
-            lhs,
-            name: lhsName,
-            indent: indent,
-            maxDepth: .max
-          )
-          .indenting(with: format.first + " "),
-          to: &out
-        )
-        print(
-          _customDump(
-            rhs,
-            name: rhsName,
-            indent: indent,
-            maxDepth: .max
-          )
-          .indenting(with: format.second + " "),
-          terminator: "",
-          to: &out
-        )
-        return
-      }
-
-      let name = rhsName.map { "\($0): " } ?? ""
-      print(
-        name
-          .appending(prefix)
-          .indenting(by: indent)
-          .indenting(with: format.both + " "),
-        to: &out
-      )
-
-      if let areInIncreasingOrder = areInIncreasingOrder {
-        lhsChildren.sort(by: areInIncreasingOrder)
-        rhsChildren.sort(by: areInIncreasingOrder)
-      }
-
-      let difference = rhsChildren.differenceCompatibility(from: lhsChildren, by: areEquivalent)
-
-      var lhsOffset = 0
-      var rhsOffset = 0
-      var unchangedBuffer: [Mirror.Child] = []
-
-      func flushUnchanged() {
-        guard collapseUnchanged else { return }
-        if areInIncreasingOrder == nil && unchangedBuffer.count == 1 {
-          let child = unchangedBuffer[0]
-          print(
-            _customDump(
-              child.value,
-              name: child.label,
-              indent: indent + elementIndent,
-              maxDepth: 0
+            print(
+                lhs.indenting(with: format.first + " "),
+                to: &out
             )
-            .indenting(with: format.both + " "),
-            terminator: rhsOffset - 1 == rhsChildren.count - 1 ? "\n" : "\(elementSeparator)\n",
-            to: &out
-          )
-        } else if areInIncreasingOrder != nil && unchangedBuffer.count == 1
-          || unchangedBuffer.count > 1
-        {
-          print(
-            "… (\(unchangedBuffer.count) unchanged)"
-              .indenting(by: indent + elementIndent)
-              .indenting(with: format.both + " "),
-            terminator: rhsOffset - 1 == rhsChildren.count - 1 ? "\n" : "\(elementSeparator)\n",
-            to: &out
-          )
-        }
-        unchangedBuffer.removeAll()
-      }
-
-      while lhsOffset < lhsChildren.count || rhsOffset < rhsChildren.count {
-        let isRemoval = difference.removals.contains(where: { $0.offset == lhsOffset })
-        let isInsertion = difference.insertions.contains(where: { $0.offset == rhsOffset })
-
-        if collapseUnchanged,
-          !isRemoval,
-          !isInsertion,
-          isMirrorEqual(lhsChildren[lhsOffset], rhsChildren[rhsOffset])
-        {
-          var child = rhsChildren[rhsOffset]
-          transform(&child, rhsOffset)
-          unchangedBuffer.append(child)
-          lhsOffset += 1
-          rhsOffset += 1
-          continue
-        }
-
-        if areInIncreasingOrder == nil {
-          flushUnchanged()
-        }
-
-        switch (isRemoval, isInsertion) {
-        case (true, true), (false, false):
-          var lhsChild = lhsChildren[lhsOffset]
-          var rhsChild = rhsChildren[rhsOffset]
-          transform(&lhsChild, isRemoval ? lhsOffset : rhsOffset)
-          transform(&rhsChild, rhsOffset)
-          print(
-            diffHelp(
-              lhsChild.value,
-              rhsChild.value,
-              lhsName: lhsChild.label,
-              rhsName: rhsChild.label,
-              separator: lhsOffset == lhsChildren.count - 1 && rhsOffset == rhsChildren.count - 1
-                ? ""
-                : elementSeparator,
-              indent: indent + elementIndent
-            ),
-            to: &out
-          )
-          lhsOffset += 1
-          rhsOffset += 1
-          continue
-
-        case (true, false):
-          var lhsChild = lhsChildren[lhsOffset]
-          transform(&lhsChild, lhsOffset)
-          print(
-            _customDump(
-              lhsChild.value,
-              name: lhsChild.label,
-              indent: indent + elementIndent,
-              maxDepth: .max
+            print(
+                rhs.indenting(with: format.second + " "),
+                terminator: "",
+                to: &out
             )
-            .indenting(with: format.first + " "),
-            terminator: lhsOffset == lhsChildren.count - 1 ? "\n" : "\(elementSeparator)\n",
-            to: &out
-          )
-          lhsOffset += 1
-
-        case (false, true):
-          var rhsChild = rhsChildren[rhsOffset]
-          transform(&rhsChild, rhsOffset)
-          print(
-            _customDump(
-              rhsChild.value,
-              name: rhsChild.label,
-              indent: indent + elementIndent,
-              maxDepth: .max
-            )
-            .indenting(with: format.second + " "),
-            terminator: rhsOffset == rhsChildren.count - 1 && unchangedBuffer.isEmpty
-              ? "\n"
-              : "\(elementSeparator)\n",
-            to: &out
-          )
-          rhsOffset += 1
         }
-      }
 
-      flushUnchanged()
+        guard lhsMirror.subjectType == rhsMirror.subjectType
+        else {
+            diffEverything()
+            return out
+        }
 
-      print(
-        suffix
-          .indenting(by: indent)
-          .indenting(with: format.both + " "),
-        terminator: separator,
-        to: &out
-      )
+        func diffChildren(
+            _ lhsMirror: Mirror,
+            _ rhsMirror: Mirror,
+            prefix: String,
+            suffix: String,
+            elementIndent: Int,
+            elementSeparator: String,
+            collapseUnchanged: Bool,
+            areEquivalent: (Mirror.Child, Mirror.Child) -> Bool = { $0.label == $1.label },
+            areInIncreasingOrder: ((Mirror.Child, Mirror.Child) -> Bool)? = nil,
+            _ transform: (inout Mirror.Child, Int) -> Void = { _, _ in }
+        ) {
+            var lhsChildren = Array(lhsMirror.children)
+            var rhsChildren = Array(rhsMirror.children)
+
+            guard !isMirrorEqual(lhsChildren, rhsChildren)
+            else {
+                print(
+                    "// Not equal but no difference detected:"
+                        .indenting(by: indent)
+                        .indenting(with: format.both + " "),
+                    to: &out
+                )
+                print(
+                    _customDump(
+                        lhs,
+                        name: lhsName,
+                        indent: indent,
+                        maxDepth: 0
+                    )
+                    .indenting(with: format.first + " "),
+                    to: &out
+                )
+                print(
+                    _customDump(
+                        rhs,
+                        name: rhsName,
+                        indent: indent,
+                        maxDepth: 0
+                    )
+                    .indenting(with: format.second + " "),
+                    terminator: "",
+                    to: &out
+                )
+                return
+            }
+
+            guard !lhsMirror.isSingleValueContainer && !rhsMirror.isSingleValueContainer
+            else {
+                print(
+                    _customDump(
+                        lhs,
+                        name: lhsName,
+                        indent: indent,
+                        maxDepth: .max
+                    )
+                    .indenting(with: format.first + " "),
+                    to: &out
+                )
+                print(
+                    _customDump(
+                        rhs,
+                        name: rhsName,
+                        indent: indent,
+                        maxDepth: .max
+                    )
+                    .indenting(with: format.second + " "),
+                    terminator: "",
+                    to: &out
+                )
+                return
+            }
+
+            let name = rhsName.map { "\($0): " } ?? ""
+            print(
+                name
+                    .appending(prefix)
+                    .indenting(by: indent)
+                    .indenting(with: format.both + " "),
+                to: &out
+            )
+
+            if let areInIncreasingOrder = areInIncreasingOrder {
+                lhsChildren.sort(by: areInIncreasingOrder)
+                rhsChildren.sort(by: areInIncreasingOrder)
+            }
+
+            let difference = rhsChildren.differenceCompatibility(
+                from: lhsChildren, by: areEquivalent)
+
+            var lhsOffset = 0
+            var rhsOffset = 0
+            var unchangedBuffer: [Mirror.Child] = []
+
+            func flushUnchanged() {
+                guard collapseUnchanged else { return }
+                if areInIncreasingOrder == nil && unchangedBuffer.count == 1 {
+                    let child = unchangedBuffer[0]
+                    print(
+                        _customDump(
+                            child.value,
+                            name: child.label,
+                            indent: indent + elementIndent,
+                            maxDepth: 0
+                        )
+                        .indenting(with: format.both + " "),
+                        terminator: rhsOffset - 1 == rhsChildren.count - 1
+                            ? "\n" : "\(elementSeparator)\n",
+                        to: &out
+                    )
+                } else if areInIncreasingOrder != nil && unchangedBuffer.count == 1
+                    || unchangedBuffer.count > 1
+                {
+                    print(
+                        "… (\(unchangedBuffer.count) unchanged)"
+                            .indenting(by: indent + elementIndent)
+                            .indenting(with: format.both + " "),
+                        terminator: rhsOffset - 1 == rhsChildren.count - 1
+                            ? "\n" : "\(elementSeparator)\n",
+                        to: &out
+                    )
+                }
+                unchangedBuffer.removeAll()
+            }
+
+            while lhsOffset < lhsChildren.count || rhsOffset < rhsChildren.count {
+                let isRemoval = difference.removals.contains(where: { $0.offset == lhsOffset })
+                let isInsertion = difference.insertions.contains(where: { $0.offset == rhsOffset })
+
+                if collapseUnchanged,
+                    !isRemoval,
+                    !isInsertion,
+                    isMirrorEqual(lhsChildren[lhsOffset], rhsChildren[rhsOffset])
+                {
+                    var child = rhsChildren[rhsOffset]
+                    transform(&child, rhsOffset)
+                    unchangedBuffer.append(child)
+                    lhsOffset += 1
+                    rhsOffset += 1
+                    continue
+                }
+
+                if areInIncreasingOrder == nil {
+                    flushUnchanged()
+                }
+
+                switch (isRemoval, isInsertion) {
+                case (true, true), (false, false):
+                    var lhsChild = lhsChildren[lhsOffset]
+                    var rhsChild = rhsChildren[rhsOffset]
+                    transform(&lhsChild, isRemoval ? lhsOffset : rhsOffset)
+                    transform(&rhsChild, rhsOffset)
+                    print(
+                        diffHelp(
+                            lhsChild.value,
+                            rhsChild.value,
+                            lhsName: lhsChild.label,
+                            rhsName: rhsChild.label,
+                            separator: lhsOffset == lhsChildren.count - 1
+                                && rhsOffset == rhsChildren.count - 1
+                                ? ""
+                                : elementSeparator,
+                            indent: indent + elementIndent
+                        ),
+                        to: &out
+                    )
+                    lhsOffset += 1
+                    rhsOffset += 1
+                    continue
+
+                case (true, false):
+                    var lhsChild = lhsChildren[lhsOffset]
+                    transform(&lhsChild, lhsOffset)
+                    print(
+                        _customDump(
+                            lhsChild.value,
+                            name: lhsChild.label,
+                            indent: indent + elementIndent,
+                            maxDepth: .max
+                        )
+                        .indenting(with: format.first + " "),
+                        terminator: lhsOffset == lhsChildren.count - 1
+                            ? "\n" : "\(elementSeparator)\n",
+                        to: &out
+                    )
+                    lhsOffset += 1
+
+                case (false, true):
+                    var rhsChild = rhsChildren[rhsOffset]
+                    transform(&rhsChild, rhsOffset)
+                    print(
+                        _customDump(
+                            rhsChild.value,
+                            name: rhsChild.label,
+                            indent: indent + elementIndent,
+                            maxDepth: .max
+                        )
+                        .indenting(with: format.second + " "),
+                        terminator: rhsOffset == rhsChildren.count - 1 && unchangedBuffer.isEmpty
+                            ? "\n"
+                            : "\(elementSeparator)\n",
+                        to: &out
+                    )
+                    rhsOffset += 1
+                }
+            }
+
+            flushUnchanged()
+
+            print(
+                suffix
+                    .indenting(by: indent)
+                    .indenting(with: format.both + " "),
+                terminator: separator,
+                to: &out
+            )
+        }
+
+        switch (lhs, lhsMirror.displayStyle, rhs, rhsMirror.displayStyle) {
+        case (is CustomDumpStringConvertible, _, is CustomDumpStringConvertible, _):
+            diffEverything()
+
+        case let (lhs as CustomDumpRepresentable, _, rhs as CustomDumpRepresentable, _):
+            out.write(
+                diffHelp(
+                    lhs.customDumpValue,
+                    rhs.customDumpValue,
+                    lhsName: lhsName,
+                    rhsName: rhsName,
+                    separator: separator,
+                    indent: indent
+                )
+            )
+
+        case let (lhs as AnyObject, .class?, rhs as AnyObject, .class?):
+            let lhsItem = ObjectIdentifier(lhs)
+            let rhsItem = ObjectIdentifier(rhs)
+            let subjectType = typeName(lhsMirror.subjectType)
+            if visitedItems.contains(lhsItem) || visitedItems.contains(rhsItem) {
+                print(
+                    "\(lhsName.map { "\($0): " } ?? "")\(subjectType)(↩︎)"
+                        .indenting(by: indent)
+                        .indenting(with: format.first + " "),
+                    to: &out
+                )
+                print(
+                    "\(rhsName.map { "\($0): " } ?? "")\(subjectType)(↩︎)"
+                        .indenting(by: indent)
+                        .indenting(with: format.second + " "),
+                    terminator: "",
+                    to: &out
+                )
+            } else {
+                let showObjectIdentifiers =
+                    lhsItem != rhsItem
+                    && isMirrorEqual(Array(lhsMirror.children), Array(rhsMirror.children))
+                let lhsMirror =
+                    showObjectIdentifiers
+                    ? Mirror(
+                        lhs, children: [("_", lhsItem)] + lhsMirror.children, displayStyle: .class)
+                    : lhsMirror
+                let rhsMirror =
+                    showObjectIdentifiers
+                    ? Mirror(
+                        rhs, children: [("_", rhsItem)] + rhsMirror.children, displayStyle: .class)
+                    : rhsMirror
+                visitedItems.insert(lhsItem)
+                diffChildren(
+                    lhsMirror,
+                    rhsMirror,
+                    prefix: "\(subjectType)(",
+                    suffix: ")",
+                    elementIndent: 2,
+                    elementSeparator: ",",
+                    collapseUnchanged: false
+                )
+            }
+
+        case (_, .collection?, _, .collection?):
+            diffChildren(
+                lhsMirror,
+                rhsMirror,
+                prefix: "[",
+                suffix: "]",
+                elementIndent: 2,
+                elementSeparator: ",",
+                collapseUnchanged: true,
+                areEquivalent: {
+                    isIdentityEqual($0.value, $1.value) || isMirrorEqual($0.value, $1.value)
+                },
+                { $0.label = "[\($1)]" }
+            )
+
+        case (_, .dictionary?, _, .dictionary?):
+            diffChildren(
+                lhsMirror,
+                rhsMirror,
+                prefix: "[",
+                suffix: "]",
+                elementIndent: 2,
+                elementSeparator: ",",
+                collapseUnchanged: true,
+                areEquivalent: {
+                    guard
+                        let lhs = $0.value as? (key: AnyHashable, value: Any),
+                        let rhs = $1.value as? (key: AnyHashable, value: Any)
+                    else {
+                        return isMirrorEqual($0.value, $1.value)
+                    }
+                    return lhs.key == rhs.key
+                },
+                areInIncreasingOrder: {
+                    guard
+                        let lhs = $0.value as? (key: AnyHashable, value: Any),
+                        let rhs = $1.value as? (key: AnyHashable, value: Any)
+                    else {
+                        return _customDump($0.value, name: nil, indent: 0, maxDepth: 1)
+                            < _customDump($1.value, name: nil, indent: 0, maxDepth: 1)
+                    }
+                    return _customDump(lhs.key.base, name: nil, indent: 0, maxDepth: 1)
+                        < _customDump(rhs.key.base, name: nil, indent: 0, maxDepth: 1)
+                }
+            ) { child, _ in
+                guard let pair = child.value as? (key: AnyHashable, value: Any) else { return }
+                child = (
+                    _customDump(pair.key.base, name: nil, indent: 0, maxDepth: 1),
+                    pair.value
+                )
+            }
+
+        case (_, .enum?, _, .enum?):
+            guard
+                let lhsChild = lhsMirror.children.first,
+                let rhsChild = rhsMirror.children.first,
+                let caseName = lhsChild.label,
+                caseName == rhsChild.label
+            else {
+                diffEverything()
+                break
+            }
+            let lhsChildMirror = Mirror(customDumpReflecting: lhsChild.value)
+            let rhsChildMirror = Mirror(customDumpReflecting: rhsChild.value)
+            let lhsAssociatedValuesMirror =
+                lhsChildMirror.displayStyle == .tuple
+                ? lhsChildMirror
+                : Mirror(lhs, unlabeledChildren: [lhsChild.value], displayStyle: .tuple)
+            let rhsAssociatedValuesMirror =
+                rhsChildMirror.displayStyle == .tuple
+                ? rhsChildMirror
+                : Mirror(rhs, unlabeledChildren: [rhsChild.value], displayStyle: .tuple)
+
+            let subjectType = typeName(lhsMirror.subjectType)
+            diffChildren(
+                lhsAssociatedValuesMirror,
+                rhsAssociatedValuesMirror,
+                prefix: "\(subjectType).\(caseName)(",
+                suffix: ")",
+                elementIndent: 2,
+                elementSeparator: ",",
+                collapseUnchanged: false,
+                { child, _ in
+                    if child.label?.first == "." {
+                        child.label = nil
+                    }
+                }
+            )
+
+        case (_, .optional?, _, .optional?):
+            guard
+                let lhsValue = lhsMirror.children.first?.value,
+                let rhsValue = rhsMirror.children.first?.value
+            else {
+                diffEverything()
+                break
+            }
+
+            out.write(
+                diffHelp(
+                    lhsValue,
+                    rhsValue,
+                    lhsName: lhsName,
+                    rhsName: rhsName,
+                    separator: separator,
+                    indent: indent
+                )
+            )
+
+        case (_, .set?, _, .set?):
+            diffChildren(
+                lhsMirror,
+                rhsMirror,
+                prefix: "Set([",
+                suffix: "])",
+                elementIndent: 2,
+                elementSeparator: ",",
+                collapseUnchanged: true,
+                areEquivalent: {
+                    isIdentityEqual($0.value, $1.value) || isMirrorEqual($0.value, $1.value)
+                },
+                areInIncreasingOrder: {
+                    _customDump($0.value, name: nil, indent: 0, maxDepth: 1)
+                        < _customDump($1.value, name: nil, indent: 0, maxDepth: 1)
+                }
+            )
+
+        case (_, .struct?, _, .struct?):
+            diffChildren(
+                lhsMirror,
+                rhsMirror,
+                prefix: "\(typeName(lhsMirror.subjectType))(",
+                suffix: ")",
+                elementIndent: 2,
+                elementSeparator: ",",
+                collapseUnchanged: false
+            )
+
+        case (_, .tuple?, _, .tuple?):
+            diffChildren(
+                lhsMirror,
+                rhsMirror,
+                prefix: "(",
+                suffix: ")",
+                elementIndent: 2,
+                elementSeparator: ",",
+                collapseUnchanged: false,
+                { child, _ in
+                    if child.label?.first == "." {
+                        child.label = nil
+                    }
+                }
+            )
+
+        default:
+            if let lhs = stringFromStringProtocol(lhs),
+                let rhs = stringFromStringProtocol(rhs),
+                lhs.contains(where: \.isNewline) || rhs.contains(where: \.isNewline)
+            {
+                let lhsMirror = Mirror(
+                    customDumpReflecting:
+                        lhs.isEmpty
+                        ? []
+                        : lhs
+                            .split(separator: "\n", omittingEmptySubsequences: false)
+                            .map(Line.init(rawValue:))
+                )
+                let rhsMirror = Mirror(
+                    customDumpReflecting:
+                        rhs.isEmpty
+                        ? []
+                        : rhs
+                            .split(separator: "\n", omittingEmptySubsequences: false)
+                            .map(Line.init(rawValue:))
+                )
+                let hashes = String(repeating: "#", count: max(lhs.hashCount, rhs.hashCount))
+                diffChildren(
+                    lhsMirror,
+                    rhsMirror,
+                    prefix: "\(hashes)\"\"\"",
+                    suffix: rhsName != nil ? "  \"\"\"\(hashes)" : "\"\"\"\(hashes)",
+                    elementIndent: rhsName != nil ? 2 : 0,
+                    elementSeparator: "",
+                    collapseUnchanged: false,
+                    areEquivalent: {
+                        isIdentityEqual($0.value, $1.value) || isMirrorEqual($0.value, $1.value)
+                    }
+                )
+            } else {
+                diffEverything()
+            }
+        }
+
+        return out
     }
 
-    switch (lhs, lhsMirror.displayStyle, rhs, rhsMirror.displayStyle) {
-    case (is CustomDumpStringConvertible, _, is CustomDumpStringConvertible, _):
-      diffEverything()
+    guard !isMirrorEqual(lhs, rhs) else { return nil }
 
-    case let (lhs as CustomDumpRepresentable, _, rhs as CustomDumpRepresentable, _):
-      out.write(
-        diffHelp(
-          lhs.customDumpValue,
-          rhs.customDumpValue,
-          lhsName: lhsName,
-          rhsName: rhsName,
-          separator: separator,
-          indent: indent
-        )
-      )
-
-    case let (lhs as AnyObject, .class?, rhs as AnyObject, .class?):
-      let lhsItem = ObjectIdentifier(lhs)
-      let rhsItem = ObjectIdentifier(rhs)
-      let subjectType = typeName(lhsMirror.subjectType)
-      if visitedItems.contains(lhsItem) || visitedItems.contains(rhsItem) {
-        print(
-          "\(lhsName.map { "\($0): " } ?? "")\(subjectType)(↩︎)"
-            .indenting(by: indent)
-            .indenting(with: format.first + " "),
-          to: &out
-        )
-        print(
-          "\(rhsName.map { "\($0): " } ?? "")\(subjectType)(↩︎)"
-            .indenting(by: indent)
-            .indenting(with: format.second + " "),
-          terminator: "",
-          to: &out
-        )
-      } else {
-        let showObjectIdentifiers =
-          lhsItem != rhsItem
-          && isMirrorEqual(Array(lhsMirror.children), Array(rhsMirror.children))
-        let lhsMirror =
-          showObjectIdentifiers
-          ? Mirror(lhs, children: [("_", lhsItem)] + lhsMirror.children, displayStyle: .class)
-          : lhsMirror
-        let rhsMirror =
-          showObjectIdentifiers
-          ? Mirror(rhs, children: [("_", rhsItem)] + rhsMirror.children, displayStyle: .class)
-          : rhsMirror
-        visitedItems.insert(lhsItem)
-        diffChildren(
-          lhsMirror,
-          rhsMirror,
-          prefix: "\(subjectType)(",
-          suffix: ")",
-          elementIndent: 2,
-          elementSeparator: ",",
-          collapseUnchanged: false
-        )
-      }
-
-    case (_, .collection?, _, .collection?):
-      diffChildren(
-        lhsMirror,
-        rhsMirror,
-        prefix: "[",
-        suffix: "]",
-        elementIndent: 2,
-        elementSeparator: ",",
-        collapseUnchanged: true,
-        areEquivalent: {
-          isIdentityEqual($0.value, $1.value) || isMirrorEqual($0.value, $1.value)
-        },
-        { $0.label = "[\($1)]" }
-      )
-
-    case (_, .dictionary?, _, .dictionary?):
-      diffChildren(
-        lhsMirror,
-        rhsMirror,
-        prefix: "[",
-        suffix: "]",
-        elementIndent: 2,
-        elementSeparator: ",",
-        collapseUnchanged: true,
-        areEquivalent: {
-          guard
-            let lhs = $0.value as? (key: AnyHashable, value: Any),
-            let rhs = $1.value as? (key: AnyHashable, value: Any)
-          else {
-            return isMirrorEqual($0.value, $1.value)
-          }
-          return lhs.key == rhs.key
-        },
-        areInIncreasingOrder: {
-          guard
-            let lhs = $0.value as? (key: AnyHashable, value: Any),
-            let rhs = $1.value as? (key: AnyHashable, value: Any)
-          else {
-            return _customDump($0.value, name: nil, indent: 0, maxDepth: 1)
-              < _customDump($1.value, name: nil, indent: 0, maxDepth: 1)
-          }
-          return _customDump(lhs.key.base, name: nil, indent: 0, maxDepth: 1)
-            < _customDump(rhs.key.base, name: nil, indent: 0, maxDepth: 1)
-        }
-      ) { child, _ in
-        guard let pair = child.value as? (key: AnyHashable, value: Any) else { return }
-        child = (
-          _customDump(pair.key.base, name: nil, indent: 0, maxDepth: 1),
-          pair.value
-        )
-      }
-
-    case (_, .enum?, _, .enum?):
-      guard
-        let lhsChild = lhsMirror.children.first,
-        let rhsChild = rhsMirror.children.first,
-        let caseName = lhsChild.label,
-        caseName == rhsChild.label
-      else {
-        diffEverything()
-        break
-      }
-      let lhsChildMirror = Mirror(customDumpReflecting: lhsChild.value)
-      let rhsChildMirror = Mirror(customDumpReflecting: rhsChild.value)
-      let lhsAssociatedValuesMirror =
-        lhsChildMirror.displayStyle == .tuple
-        ? lhsChildMirror
-        : Mirror(lhs, unlabeledChildren: [lhsChild.value], displayStyle: .tuple)
-      let rhsAssociatedValuesMirror =
-        rhsChildMirror.displayStyle == .tuple
-        ? rhsChildMirror
-        : Mirror(rhs, unlabeledChildren: [rhsChild.value], displayStyle: .tuple)
-
-      let subjectType = typeName(lhsMirror.subjectType)
-      diffChildren(
-        lhsAssociatedValuesMirror,
-        rhsAssociatedValuesMirror,
-        prefix: "\(subjectType).\(caseName)(",
-        suffix: ")",
-        elementIndent: 2,
-        elementSeparator: ",",
-        collapseUnchanged: false,
-        { child, _ in
-          if child.label?.first == "." {
-            child.label = nil
-          }
-        }
-      )
-
-    case (_, .optional?, _, .optional?):
-      guard
-        let lhsValue = lhsMirror.children.first?.value,
-        let rhsValue = rhsMirror.children.first?.value
-      else {
-        diffEverything()
-        break
-      }
-
-      out.write(
-        diffHelp(
-          lhsValue,
-          rhsValue,
-          lhsName: lhsName,
-          rhsName: rhsName,
-          separator: separator,
-          indent: indent
-        )
-      )
-
-    case (_, .set?, _, .set?):
-      diffChildren(
-        lhsMirror,
-        rhsMirror,
-        prefix: "Set([",
-        suffix: "])",
-        elementIndent: 2,
-        elementSeparator: ",",
-        collapseUnchanged: true,
-        areEquivalent: {
-          isIdentityEqual($0.value, $1.value) || isMirrorEqual($0.value, $1.value)
-        },
-        areInIncreasingOrder: {
-          _customDump($0.value, name: nil, indent: 0, maxDepth: 1)
-            < _customDump($1.value, name: nil, indent: 0, maxDepth: 1)
-        }
-      )
-
-    case (_, .struct?, _, .struct?):
-      diffChildren(
-        lhsMirror,
-        rhsMirror,
-        prefix: "\(typeName(lhsMirror.subjectType))(",
-        suffix: ")",
-        elementIndent: 2,
-        elementSeparator: ",",
-        collapseUnchanged: false
-      )
-
-    case (_, .tuple?, _, .tuple?):
-      diffChildren(
-        lhsMirror,
-        rhsMirror,
-        prefix: "(",
-        suffix: ")",
-        elementIndent: 2,
-        elementSeparator: ",",
-        collapseUnchanged: false,
-        { child, _ in
-          if child.label?.first == "." {
-            child.label = nil
-          }
-        }
-      )
-
-    default:
-      if let lhs = stringFromStringProtocol(lhs),
-        let rhs = stringFromStringProtocol(rhs),
-        lhs.contains(where: \.isNewline) || rhs.contains(where: \.isNewline)
-      {
-        let lhsMirror = Mirror(
-          customDumpReflecting:
-            lhs.isEmpty
-            ? []
-            : lhs
-              .split(separator: "\n", omittingEmptySubsequences: false)
-              .map(Line.init(rawValue:))
-        )
-        let rhsMirror = Mirror(
-          customDumpReflecting:
-            rhs.isEmpty
-            ? []
-            : rhs
-              .split(separator: "\n", omittingEmptySubsequences: false)
-              .map(Line.init(rawValue:))
-        )
-        let hashes = String(repeating: "#", count: max(lhs.hashCount, rhs.hashCount))
-        diffChildren(
-          lhsMirror,
-          rhsMirror,
-          prefix: "\(hashes)\"\"\"",
-          suffix: rhsName != nil ? "  \"\"\"\(hashes)" : "\"\"\"\(hashes)",
-          elementIndent: rhsName != nil ? 2 : 0,
-          elementSeparator: "",
-          collapseUnchanged: false,
-          areEquivalent: {
-            isIdentityEqual($0.value, $1.value) || isMirrorEqual($0.value, $1.value)
-          }
-        )
-      } else {
-        diffEverything()
-      }
-    }
-
-    return out
-  }
-
-  guard !isMirrorEqual(lhs, rhs) else { return nil }
-
-  var diff = diffHelp(lhs, rhs, lhsName: nil, rhsName: nil, separator: "", indent: 0)
-  if diff.last == "\n" { diff.removeLast() }
-  return diff
+    var diff = diffHelp(lhs, rhs, lhsName: nil, rhsName: nil, separator: "", indent: 0)
+    if diff.last == "\n" { diff.removeLast() }
+    return diff
 }
 
 /// Describes how to format a difference between two values when using ``diff(_:_:format:)``.
@@ -561,52 +568,52 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
 /// This type comes with two pre-configured formats that you will probably want to use for most
 /// situations: ``DiffFormat/default`` and ``DiffFormat/proportional``.
 public struct DiffFormat {
-  /// A string prepended to lines that only appear in the string representation of the first value,
-  /// e.g. a "removal."
-  public var first: String
+    /// A string prepended to lines that only appear in the string representation of the first value,
+    /// e.g. a "removal."
+    public var first: String
 
-  /// A string prepended to lines that only appear in the string representation of the second value,
-  /// e.g. an "insertion."
-  public var second: String
+    /// A string prepended to lines that only appear in the string representation of the second value,
+    /// e.g. an "insertion."
+    public var second: String
 
-  /// A string prepended to lines that appear in the string representation of both values, e.g.
-  /// something "unchanged."
-  public var both: String
+    /// A string prepended to lines that appear in the string representation of both values, e.g.
+    /// something "unchanged."
+    public var both: String
 
-  public init(
-    first: String,
-    second: String,
-    both: String
-  ) {
-    self.first = first
-    self.second = second
-    self.both = both
-  }
+    public init(
+        first: String,
+        second: String,
+        both: String
+    ) {
+        self.first = first
+        self.second = second
+        self.both = both
+    }
 
-  /// The default format for ``diff(_:_:format:)`` output, appropriate for where monospaced fonts
-  /// are used, e.g. console output.
-  ///
-  /// Uses ascii characters for removals (hyphen "-"), insertions (plus "+"), and unchanged (space
-  /// " ").
-  public static let `default` = Self(first: "-", second: "+", both: " ")
+    /// The default format for ``diff(_:_:format:)`` output, appropriate for where monospaced fonts
+    /// are used, e.g. console output.
+    ///
+    /// Uses ascii characters for removals (hyphen "-"), insertions (plus "+"), and unchanged (space
+    /// " ").
+    public static let `default` = Self(first: "-", second: "+", both: " ")
 
-  /// A diff format appropriate for where proportional (non-monospaced) fonts are used, e.g. Xcode's
-  /// failure overlays.
-  ///
-  /// Uses ascii plus ("+") for insertions, unicode minus sign ("−") for removals, and unicode
-  /// figure space (" ") for unchanged. These three characters are more likely to render with equal
-  /// widths in proportional fonts.
-  public static let proportional = Self(first: "\u{2212}", second: "+", both: "\u{2007}")
+    /// A diff format appropriate for where proportional (non-monospaced) fonts are used, e.g. Xcode's
+    /// failure overlays.
+    ///
+    /// Uses ascii plus ("+") for insertions, unicode minus sign ("−") for removals, and unicode
+    /// figure space (" ") for unchanged. These three characters are more likely to render with equal
+    /// widths in proportional fonts.
+    public static let proportional = Self(first: "\u{2212}", second: "+", both: "\u{2007}")
 }
 
 private struct Line: CustomDumpStringConvertible, Identifiable {
-  var rawValue: Substring
+    var rawValue: Substring
 
-  var id: Substring {
-    self.rawValue
-  }
+    var id: Substring {
+        self.rawValue
+    }
 
-  var customDumpDescription: String {
-    .init(self.rawValue)
-  }
+    var customDumpDescription: String {
+        .init(self.rawValue)
+    }
 }

--- a/Sources/RxComposableArchitecture/CustomDump/CustomDumpReflectable.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/CustomDumpReflectable.swift
@@ -120,12 +120,12 @@
 /// []
 /// ```
 public protocol CustomDumpReflectable {
-  /// The custom dump mirror for this instance.
-  var customDumpMirror: Mirror { get }
+    /// The custom dump mirror for this instance.
+    var customDumpMirror: Mirror { get }
 }
 
 extension Mirror {
-  init(customDumpReflecting subject: Any) {
-    self = (subject as? CustomDumpReflectable)?.customDumpMirror ?? Mirror(reflecting: subject)
-  }
+    init(customDumpReflecting subject: Any) {
+        self = (subject as? CustomDumpReflectable)?.customDumpMirror ?? Mirror(reflecting: subject)
+    }
 }

--- a/Sources/RxComposableArchitecture/CustomDump/CustomDumpRepresentable.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/CustomDumpRepresentable.swift
@@ -21,6 +21,6 @@
 /// "deadbeef"
 /// ```
 public protocol CustomDumpRepresentable {
-  /// The custom dump value for this instance.
-  var customDumpValue: Any { get }
+    /// The custom dump value for this instance.
+    var customDumpValue: Any { get }
 }

--- a/Sources/RxComposableArchitecture/CustomDump/CustomDumpStringConvertible.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/CustomDumpStringConvertible.swift
@@ -61,6 +61,6 @@
 /// <redacted>
 /// ```
 public protocol CustomDumpStringConvertible {
-  /// The custom dump description for this instance.
-  var customDumpDescription: String { get }
+    /// The custom dump description for this instance.
+    var customDumpDescription: String { get }
 }

--- a/Sources/RxComposableArchitecture/CustomDump/Dump.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Dump.swift
@@ -25,15 +25,15 @@
 /// - Returns: The instance passed as `value`.
 @discardableResult
 public func customDump<T>(
-  _ value: T,
-  name: String? = nil,
-  indent: Int = 0,
-  maxDepth: Int = .max
+    _ value: T,
+    name: String? = nil,
+    indent: Int = 0,
+    maxDepth: Int = .max
 ) -> T {
-  var target = ""
-  let value = customDump(value, to: &target, name: name, indent: indent, maxDepth: maxDepth)
-  print(target)
-  return value
+    var target = ""
+    let value = customDump(value, to: &target, name: name, indent: indent, maxDepth: maxDepth)
+    print(target)
+    return value
 }
 
 /// Dumps the given value's contents using its mirror to the specified output stream.
@@ -50,204 +50,211 @@ public func customDump<T>(
 /// - Returns: The instance passed as `value`.
 @discardableResult
 public func customDump<T, TargetStream>(
-  _ value: T,
-  to target: inout TargetStream,
-  name: String? = nil,
-  indent: Int = 0,
-  maxDepth: Int = .max
-) -> T where TargetStream: TextOutputStream {
-
-  var visitedItems: Set<ObjectIdentifier> = []
-
-  func customDumpHelp<T, TargetStream>(
     _ value: T,
     to target: inout TargetStream,
-    name: String?,
-    indent: Int,
-    maxDepth: Int
-  ) where TargetStream: TextOutputStream {
-    if T.self is AnyObject.Type, withUnsafeBytes(of: value, { $0.allSatisfy { $0 == 0 } }) {
-      target.write((name.map { "\($0): " } ?? "").appending("(null pointer)").indenting(by: indent))
-      return
-    }
+    name: String? = nil,
+    indent: Int = 0,
+    maxDepth: Int = .max
+) -> T where TargetStream: TextOutputStream {
 
-    let mirror = Mirror(customDumpReflecting: value)
-    var out = ""
+    var visitedItems: Set<ObjectIdentifier> = []
 
-    func dumpChildren(
-      of mirror: Mirror,
-      prefix: String,
-      suffix: String,
-      by areInIncreasingOrder: ((Mirror.Child, Mirror.Child) -> Bool)? = nil,
-      _ transform: (inout Mirror.Child, Int) -> Void = { _, _ in }
-    ) {
-      out.write(prefix)
-      if !mirror.children.isEmpty {
-        if mirror.isSingleValueContainer {
-          var childOut = ""
-          let child = mirror.children.first!
-          customDumpHelp(
-            child.value, to: &childOut, name: child.label, indent: 0, maxDepth: maxDepth - 1
-          )
-          if childOut.contains("\n") {
-            if maxDepth == 0 {
-              out.write("…")
-            } else {
-              out.write("\n")
-              out.write(childOut.indenting(by: 2))
-              out.write("\n")
+    func customDumpHelp<T, TargetStream>(
+        _ value: T,
+        to target: inout TargetStream,
+        name: String?,
+        indent: Int,
+        maxDepth: Int
+    ) where TargetStream: TextOutputStream {
+        if T.self is AnyObject.Type, withUnsafeBytes(of: value, { $0.allSatisfy { $0 == 0 } }) {
+            target.write(
+                (name.map { "\($0): " } ?? "").appending("(null pointer)").indenting(by: indent))
+            return
+        }
+
+        let mirror = Mirror(customDumpReflecting: value)
+        var out = ""
+
+        func dumpChildren(
+            of mirror: Mirror,
+            prefix: String,
+            suffix: String,
+            by areInIncreasingOrder: ((Mirror.Child, Mirror.Child) -> Bool)? = nil,
+            _ transform: (inout Mirror.Child, Int) -> Void = { _, _ in }
+        ) {
+            out.write(prefix)
+            if !mirror.children.isEmpty {
+                if mirror.isSingleValueContainer {
+                    var childOut = ""
+                    let child = mirror.children.first!
+                    customDumpHelp(
+                        child.value, to: &childOut, name: child.label, indent: 0,
+                        maxDepth: maxDepth - 1
+                    )
+                    if childOut.contains("\n") {
+                        if maxDepth == 0 {
+                            out.write("…")
+                        } else {
+                            out.write("\n")
+                            out.write(childOut.indenting(by: 2))
+                            out.write("\n")
+                        }
+                    } else {
+                        out.write(childOut)
+                    }
+                } else if maxDepth == 0 {
+                    out.write("…")
+                } else {
+                    out.write("\n")
+                    var children = Array(mirror.children)
+                    if let areInIncreasingOrder = areInIncreasingOrder {
+                        children.sort(by: areInIncreasingOrder)
+                    }
+                    for (offset, var child) in children.enumerated() {
+                        transform(&child, offset)
+                        customDumpHelp(
+                            child.value, to: &out, name: child.label, indent: 2,
+                            maxDepth: maxDepth - 1)
+                        if offset != children.count - 1 {
+                            out.write(",")
+                        }
+                        out.write("\n")
+                    }
+                }
             }
-          } else {
-            out.write(childOut)
-          }
-        } else if maxDepth == 0 {
-          out.write("…")
-        } else {
-          out.write("\n")
-          var children = Array(mirror.children)
-          if let areInIncreasingOrder = areInIncreasingOrder {
-            children.sort(by: areInIncreasingOrder)
-          }
-          for (offset, var child) in children.enumerated() {
-            transform(&child, offset)
+            out.write(suffix)
+        }
+
+        switch (value, mirror.displayStyle) {
+        case let (value as Any.Type, _):
+            out.write("\(typeName(value)).self")
+
+        case let (value as CustomDumpStringConvertible, _):
+            out.write(value.customDumpDescription)
+
+        case let (value as CustomDumpRepresentable, _):
             customDumpHelp(
-              child.value, to: &out, name: child.label, indent: 2, maxDepth: maxDepth - 1)
-            if offset != children.count - 1 {
-              out.write(",")
+                value.customDumpValue, to: &out, name: nil, indent: 0, maxDepth: maxDepth - 1)
+
+        case let (value as AnyObject, .class?):
+            let item = ObjectIdentifier(value)
+            if visitedItems.contains(item) {
+                out.write("\(typeName(mirror.subjectType))(↩︎)")
+            } else {
+                visitedItems.insert(item)
+                dumpChildren(of: mirror, prefix: "\(typeName(mirror.subjectType))(", suffix: ")")
             }
-            out.write("\n")
-          }
+
+        case (_, .collection?):
+            dumpChildren(of: mirror, prefix: "[", suffix: "]", { $0.label = "[\($1)]" })
+
+        case (_, .dictionary?):
+            if mirror.children.isEmpty {
+                out.write("[:]")
+            } else {
+                dumpChildren(
+                    of: mirror,
+                    prefix: "[", suffix: "]",
+                    by: {
+                        guard
+                            let (lhsKey, _) = $0.value as? (key: AnyHashable, value: Any),
+                            let (rhsKey, _) = $1.value as? (key: AnyHashable, value: Any)
+                        else { return false }
+
+                        return _customDump(lhsKey.base, name: nil, indent: 0, maxDepth: 1)
+                            < _customDump(rhsKey.base, name: nil, indent: 0, maxDepth: 1)
+                    },
+                    { child, _ in
+                        guard let pair = child.value as? (key: AnyHashable, value: Any) else {
+                            return
+                        }
+                        let key = _customDump(
+                            pair.key.base, name: nil, indent: 0, maxDepth: maxDepth - 1)
+                        child = (key, pair.value)
+                    })
+            }
+
+        case (_, .enum?):
+            out.write("\(typeName(mirror.subjectType)).")
+            if let child = mirror.children.first {
+                let childMirror = Mirror(customDumpReflecting: child.value)
+                let associatedValuesMirror =
+                    childMirror.displayStyle == .tuple
+                    ? childMirror
+                    : Mirror(value, unlabeledChildren: [child.value], displayStyle: .tuple)
+                dumpChildren(
+                    of: associatedValuesMirror,
+                    prefix: "\(child.label ?? "@unknown")(",
+                    suffix: ")",
+                    { child, _ in
+                        if child.label?.first == "." {
+                            child.label = nil
+                        }
+                    }
+                )
+            } else {
+                out.write("\(value)")
+            }
+
+        case (_, .optional?):
+            if let value = mirror.children.first?.value {
+                customDumpHelp(value, to: &out, name: nil, indent: 0, maxDepth: maxDepth)
+            } else {
+                out.write("nil")
+            }
+
+        case (_, .set?):
+            dumpChildren(
+                of: mirror,
+                prefix: "Set([", suffix: "])",
+                by: {
+                    _customDump($0.value, name: nil, indent: 0, maxDepth: 1)
+                        < _customDump($1.value, name: nil, indent: 0, maxDepth: 1)
+                })
+
+        case (_, .struct?):
+            dumpChildren(of: mirror, prefix: "\(typeName(mirror.subjectType))(", suffix: ")")
+
+        case (_, .tuple?):
+            dumpChildren(
+                of: mirror,
+                prefix: "(",
+                suffix: ")",
+                { child, _ in
+                    if child.label?.first == "." {
+                        child.label = nil
+                    }
+                })
+
+        default:
+            if let value = stringFromStringProtocol(value) {
+                if value.contains(where: \.isNewline) {
+                    if maxDepth == 0 {
+                        out.write("\"…\"")
+                    } else {
+                        let hashes = String(repeating: "#", count: value.hashCount)
+                        out.write("\(hashes)\"\"\"")
+                        out.write("\n")
+                        print(value.indenting(by: name != nil ? 2 : 0), to: &out)
+                        out.write(name != nil ? "  \"\"\"\(hashes)" : "\"\"\"\(hashes)")
+                    }
+                } else {
+                    out.write(value.debugDescription)
+                }
+            } else {
+                out.write("\(value)")
+            }
         }
-      }
-      out.write(suffix)
+
+        target.write((name.map { "\($0): " } ?? "").appending(out).indenting(by: indent))
     }
 
-    switch (value, mirror.displayStyle) {
-    case let (value as Any.Type, _):
-      out.write("\(typeName(value)).self")
-
-    case let (value as CustomDumpStringConvertible, _):
-      out.write(value.customDumpDescription)
-
-    case let (value as CustomDumpRepresentable, _):
-      customDumpHelp(value.customDumpValue, to: &out, name: nil, indent: 0, maxDepth: maxDepth - 1)
-
-    case let (value as AnyObject, .class?):
-      let item = ObjectIdentifier(value)
-      if visitedItems.contains(item) {
-        out.write("\(typeName(mirror.subjectType))(↩︎)")
-      } else {
-        visitedItems.insert(item)
-        dumpChildren(of: mirror, prefix: "\(typeName(mirror.subjectType))(", suffix: ")")
-      }
-
-    case (_, .collection?):
-      dumpChildren(of: mirror, prefix: "[", suffix: "]", { $0.label = "[\($1)]" })
-
-    case (_, .dictionary?):
-      if mirror.children.isEmpty {
-        out.write("[:]")
-      } else {
-        dumpChildren(
-          of: mirror,
-          prefix: "[", suffix: "]",
-          by: {
-            guard
-              let (lhsKey, _) = $0.value as? (key: AnyHashable, value: Any),
-              let (rhsKey, _) = $1.value as? (key: AnyHashable, value: Any)
-            else { return false }
-
-            return _customDump(lhsKey.base, name: nil, indent: 0, maxDepth: 1)
-              < _customDump(rhsKey.base, name: nil, indent: 0, maxDepth: 1)
-          },
-          { child, _ in
-            guard let pair = child.value as? (key: AnyHashable, value: Any) else { return }
-            let key = _customDump(pair.key.base, name: nil, indent: 0, maxDepth: maxDepth - 1)
-            child = (key, pair.value)
-          })
-      }
-
-    case (_, .enum?):
-      out.write("\(typeName(mirror.subjectType)).")
-      if let child = mirror.children.first {
-        let childMirror = Mirror(customDumpReflecting: child.value)
-        let associatedValuesMirror =
-          childMirror.displayStyle == .tuple
-          ? childMirror
-          : Mirror(value, unlabeledChildren: [child.value], displayStyle: .tuple)
-        dumpChildren(
-          of: associatedValuesMirror,
-          prefix: "\(child.label ?? "@unknown")(",
-          suffix: ")",
-          { child, _ in
-            if child.label?.first == "." {
-              child.label = nil
-            }
-          }
-        )
-      } else {
-        out.write("\(value)")
-      }
-
-    case (_, .optional?):
-      if let value = mirror.children.first?.value {
-        customDumpHelp(value, to: &out, name: nil, indent: 0, maxDepth: maxDepth)
-      } else {
-        out.write("nil")
-      }
-
-    case (_, .set?):
-      dumpChildren(
-        of: mirror,
-        prefix: "Set([", suffix: "])",
-        by: {
-          _customDump($0.value, name: nil, indent: 0, maxDepth: 1)
-            < _customDump($1.value, name: nil, indent: 0, maxDepth: 1)
-        })
-
-    case (_, .struct?):
-      dumpChildren(of: mirror, prefix: "\(typeName(mirror.subjectType))(", suffix: ")")
-
-    case (_, .tuple?):
-      dumpChildren(
-        of: mirror,
-        prefix: "(",
-        suffix: ")",
-        { child, _ in
-          if child.label?.first == "." {
-            child.label = nil
-          }
-        })
-
-    default:
-      if let value = stringFromStringProtocol(value) {
-        if value.contains(where: \.isNewline) {
-          if maxDepth == 0 {
-            out.write("\"…\"")
-          } else {
-            let hashes = String(repeating: "#", count: value.hashCount)
-            out.write("\(hashes)\"\"\"")
-            out.write("\n")
-            print(value.indenting(by: name != nil ? 2 : 0), to: &out)
-            out.write(name != nil ? "  \"\"\"\(hashes)" : "\"\"\"\(hashes)")
-          }
-        } else {
-          out.write(value.debugDescription)
-        }
-      } else {
-        out.write("\(value)")
-      }
-    }
-
-    target.write((name.map { "\($0): " } ?? "").appending(out).indenting(by: indent))
-  }
-
-  customDumpHelp(value, to: &target, name: name, indent: indent, maxDepth: maxDepth)
-  return value
+    customDumpHelp(value, to: &target, name: name, indent: indent, maxDepth: maxDepth)
+    return value
 }
 
 func _customDump(_ value: Any, name: String?, indent: Int, maxDepth: Int) -> String {
-  var out = ""
-  customDump(value, to: &out, name: name, indent: indent, maxDepth: maxDepth)
-  return out
+    var out = ""
+    customDump(value, to: &out, name: name, indent: indent, maxDepth: maxDepth)
+    return out
 }

--- a/Sources/RxComposableArchitecture/CustomDump/Internal/AnyType.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Internal/AnyType.swift
@@ -1,13 +1,13 @@
 func typeName(_ type: Any.Type) -> String {
-  var name = _typeName(type)
-  if let index = name.firstIndex(of: ".") {
-    name.removeSubrange(...index)
-  }
-  return
-    name
-    .replacingOccurrences(
-      of: #"<.+>|\(unknown context at \$[[:xdigit:]]+\)\."#,
-      with: "",
-      options: .regularExpression
-    )
+    var name = _typeName(type)
+    if let index = name.firstIndex(of: ".") {
+        name.removeSubrange(...index)
+    }
+    return
+        name
+        .replacingOccurrences(
+            of: #"<.+>|\(unknown context at \$[[:xdigit:]]+\)\."#,
+            with: "",
+            options: .regularExpression
+        )
 }

--- a/Sources/RxComposableArchitecture/CustomDump/Internal/Box.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Internal/Box.swift
@@ -3,73 +3,73 @@ enum Box<T> {}
 // MARK: - Equatable
 
 protocol AnyEquatable {
-  static func isEqual(_ lhs: Any, _ rhs: Any) -> Bool
+    static func isEqual(_ lhs: Any, _ rhs: Any) -> Bool
 }
 
 extension Box: AnyEquatable where T: Equatable {
-  static func isEqual(_ lhs: Any, _ rhs: Any) -> Bool {
-    lhs as? T == rhs as? T
-  }
+    static func isEqual(_ lhs: Any, _ rhs: Any) -> Bool {
+        lhs as? T == rhs as? T
+    }
 }
 
 func isMirrorEqual(_ lhs: Any, _ rhs: Any) -> Bool {
-  func open<LHS>(_: LHS.Type) -> Bool? {
-    (Box<LHS>.self as? AnyEquatable.Type)?.isEqual(lhs, rhs)
-  }
-  if let isEqual = _openExistential(type(of: lhs), do: open) { return isEqual }
-  let lhsMirror = Mirror(customDumpReflecting: lhs)
-  let rhsMirror = Mirror(customDumpReflecting: rhs)
-  guard
-    lhsMirror.subjectType == rhsMirror.subjectType,
-    lhsMirror.children.count == rhsMirror.children.count
-  else { return false }
-  for (lhsChild, rhsChild) in zip(lhsMirror.children, rhsMirror.children) {
+    func open<LHS>(_: LHS.Type) -> Bool? {
+        (Box<LHS>.self as? AnyEquatable.Type)?.isEqual(lhs, rhs)
+    }
+    if let isEqual = _openExistential(type(of: lhs), do: open) { return isEqual }
+    let lhsMirror = Mirror(customDumpReflecting: lhs)
+    let rhsMirror = Mirror(customDumpReflecting: rhs)
     guard
-      lhsChild.label == rhsChild.label,
-      isMirrorEqual(lhsChild.value, rhsChild.value)
+        lhsMirror.subjectType == rhsMirror.subjectType,
+        lhsMirror.children.count == rhsMirror.children.count
     else { return false }
-  }
-  return true
+    for (lhsChild, rhsChild) in zip(lhsMirror.children, rhsMirror.children) {
+        guard
+            lhsChild.label == rhsChild.label,
+            isMirrorEqual(lhsChild.value, rhsChild.value)
+        else { return false }
+    }
+    return true
 }
 
 // MARK: - Identifiable
 
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 protocol AnyIdentifiable {
-  static func isIdentityEqual(_ lhs: Any, _ rhs: Any) -> Bool
+    static func isIdentityEqual(_ lhs: Any, _ rhs: Any) -> Bool
 }
 
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 extension Box: AnyIdentifiable where T: Identifiable {
-  static func isIdentityEqual(_ lhs: Any, _ rhs: Any) -> Bool {
-    guard let lhs = lhs as? T, let rhs = rhs as? T else { return false }
-    return lhs.id == rhs.id
-  }
+    static func isIdentityEqual(_ lhs: Any, _ rhs: Any) -> Bool {
+        guard let lhs = lhs as? T, let rhs = rhs as? T else { return false }
+        return lhs.id == rhs.id
+    }
 }
 
 func isIdentityEqual(_ lhs: Any, _ rhs: Any) -> Bool {
-  guard #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) else { return false }
-  func open<LHS>(_: LHS.Type) -> Bool? {
-    (Box<LHS>.self as? AnyIdentifiable.Type)?.isIdentityEqual(lhs, rhs)
-  }
-  return _openExistential(type(of: lhs), do: open) ?? false
+    guard #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) else { return false }
+    func open<LHS>(_: LHS.Type) -> Bool? {
+        (Box<LHS>.self as? AnyIdentifiable.Type)?.isIdentityEqual(lhs, rhs)
+    }
+    return _openExistential(type(of: lhs), do: open) ?? false
 }
 
 // MARK: - StringProtocol
 
 protocol AnyStringProtocol {
-  static func string(from value: Any) -> String?
+    static func string(from value: Any) -> String?
 }
 
 extension Box: AnyStringProtocol where T: StringProtocol {
-  static func string(from value: Any) -> String? {
-    (value as? T).map { String($0) }
-  }
+    static func string(from value: Any) -> String? {
+        (value as? T).map { String($0) }
+    }
 }
 
 func stringFromStringProtocol(_ value: Any) -> String? {
-  func open<STR>(_: STR.Type) -> String? {
-    (Box<STR>.self as? AnyStringProtocol.Type)?.string(from: value)
-  }
-  return _openExistential(type(of: value), do: open)
+    func open<STR>(_: STR.Type) -> String? {
+        (Box<STR>.self as? AnyStringProtocol.Type)?.string(from: value)
+    }
+    return _openExistential(type(of: value), do: open)
 }

--- a/Sources/RxComposableArchitecture/CustomDump/Internal/CollectionDifference.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Internal/CollectionDifference.swift
@@ -1,8 +1,8 @@
 extension CompatibilityCollectionDifference.Change {
-  var offset: Int {
-    switch self {
-    case let .insert(offset, _, _), let .remove(offset, _, _):
-      return offset
+    var offset: Int {
+        switch self {
+        case let .insert(offset, _, _), let .remove(offset, _, _):
+            return offset
+        }
     }
-  }
 }

--- a/Sources/RxComposableArchitecture/CustomDump/Internal/CompatibilityCollectionDifference.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Internal/CompatibilityCollectionDifference.swift
@@ -26,37 +26,37 @@ struct CompatibilityCollectionDifference<ChangeElement> {
         /// original state of the collection. A non-`nil` `associatedWith` value is
         /// the offset of the complementary change.
         case remove(offset: Int, element: ChangeElement, associatedWith: Int?)
-//        // Internal common field accessors
-//        internal var _offset: Int {
-//            get {
-//                switch self {
-//                case .insert(offset: let o, element: _, associatedWith: _):
-//                    return o
-//                case .remove(offset: let o, element: _, associatedWith: _):
-//                    return o
-//                }
-//            }
-//        }
-//        internal var _element: ChangeElement {
-//            get {
-//                switch self {
-//                case .insert(offset: _, element: let e, associatedWith: _):
-//                    return e
-//                case .remove(offset: _, element: let e, associatedWith: _):
-//                    return e
-//                }
-//            }
-//        }
-//        internal var _associatedOffset: Int? {
-//            get {
-//                switch self {
-//                case .insert(offset: _, element: _, associatedWith: let o):
-//                    return o
-//                case .remove(offset: _, element: _, associatedWith: let o):
-//                    return o
-//                }
-//            }
-//        }
+        //        // Internal common field accessors
+        //        internal var _offset: Int {
+        //            get {
+        //                switch self {
+        //                case .insert(offset: let o, element: _, associatedWith: _):
+        //                    return o
+        //                case .remove(offset: let o, element: _, associatedWith: _):
+        //                    return o
+        //                }
+        //            }
+        //        }
+        //        internal var _element: ChangeElement {
+        //            get {
+        //                switch self {
+        //                case .insert(offset: _, element: let e, associatedWith: _):
+        //                    return e
+        //                case .remove(offset: _, element: let e, associatedWith: _):
+        //                    return e
+        //                }
+        //            }
+        //        }
+        //        internal var _associatedOffset: Int? {
+        //            get {
+        //                switch self {
+        //                case .insert(offset: _, element: _, associatedWith: let o):
+        //                    return o
+        //                case .remove(offset: _, element: _, associatedWith: let o):
+        //                    return o
+        //                }
+        //            }
+        //        }
     }
 
     /// The insertions contained by this difference, from lowest offset to
@@ -65,8 +65,12 @@ struct CompatibilityCollectionDifference<ChangeElement> {
 
     /// The removals contained by this difference, from lowest offset to highest.
     public let removals: [CompatibilityCollectionDifference<ChangeElement>.Change]
-    
-    public init?<Changes>(_ changes: Changes) where Changes : Collection, Changes.Element == CompatibilityCollectionDifference<ChangeElement>.Change {
+
+    public init?<Changes>(_ changes: Changes)
+    where
+        Changes: Collection,
+        Changes.Element == CompatibilityCollectionDifference<ChangeElement>.Change
+    {
         var _insertions: [CompatibilityCollectionDifference<ChangeElement>.Change] = []
         var _removals: [CompatibilityCollectionDifference<ChangeElement>.Change] = []
         changes.forEach { change in
@@ -80,256 +84,258 @@ struct CompatibilityCollectionDifference<ChangeElement> {
         self.insertions = _insertions
         self.removals = _removals
     }
-//    public init?<Changes: Collection>(
-//        _ changes: Changes
-//    ) where Changes.Element == Change {
-//        guard CompatibilityCollectionDifference<ChangeElement>._validateChanges(changes) else {
-//            return nil
-//        }
-//
-//        self.init(_validatedChanges: changes)
-//    }
-//
-//    /// Internal initializer for use by algorithms that cannot produce invalid
-//    /// collections of changes. These include the Myers' diff algorithm,
-//    /// self.inverse(), and the move inferencer.
-//    ///
-//    /// If parameter validity cannot be guaranteed by the caller then
-//    /// `CollectionDifference.init?(_:)` should be used instead.
-//    ///
-//    /// - Parameter c: A valid collection of changes that represent a transition
-//    ///   between two states.
-//    ///
-//    /// - Complexity: O(*n* * log(*n*)), where *n* is the length of the
-//    ///   parameter.
-//    internal init<Changes: Collection>(
-//        _validatedChanges changes: Changes
-//    ) where Changes.Element == Change {
-//        let sortedChanges = changes.sorted { (a, b) -> Bool in
-//            switch (a, b) {
-//            case (.remove(_, _, _), .insert(_, _, _)):
-//                return true
-//            case (.insert(_, _, _), .remove(_, _, _)):
-//                return false
-//            default:
-//                return a._offset < b._offset
-//            }
-//        }
-//
-//        // Find first insertion via binary search
-//        let firstInsertIndex: Int
-//        if sortedChanges.isEmpty {
-//            firstInsertIndex = 0
-//        } else {
-//            var range = 0...sortedChanges.count
-//            while range.lowerBound != range.upperBound {
-//                let i = (range.lowerBound + range.upperBound) / 2
-//                switch sortedChanges[i] {
-//                case .insert(_, _, _):
-//                    range = range.lowerBound...i
-//                case .remove(_, _, _):
-//                    range = (i + 1)...range.upperBound
-//                }
-//            }
-//            firstInsertIndex = range.lowerBound
-//        }
-//
-//        removals = Array(sortedChanges[0..<firstInsertIndex])
-//        insertions = Array(sortedChanges[firstInsertIndex..<sortedChanges.count])
-//    }
-//
-//    /// The public initializer calls this function to ensure that its parameter
-//    /// meets the conditions set in its documentation.
-//    ///
-//    /// - Parameter changes: a collection of `CollectionDifference.Change`
-//    ///   instances intended to represent a valid state transition for
-//    ///   `CollectionDifference`.
-//    ///
-//    /// - Returns: whether the parameter meets the following criteria:
-//    ///
-//    ///   1. All insertion offsets are unique
-//    ///   2. All removal offsets are unique
-//    ///   3. All associations between insertions and removals are symmetric
-//    ///
-//    /// Complexity: O(`changes.count`)
-//    private static func _validateChanges<Changes: Collection>(
-//        _ changes : Changes
-//    ) -> Bool where Changes.Element == Change {
-//        if changes.isEmpty { return true }
-//
-//        var insertAssocToOffset = Dictionary<Int,Int>()
-//        var removeOffsetToAssoc = Dictionary<Int,Int>()
-//        var insertOffset = Set<Int>()
-//        var removeOffset = Set<Int>()
-//
-//        for change in changes {
-//            let offset = change._offset
-//            if offset < 0 { return false }
-//
-//            switch change {
-//            case .remove(_, _, _):
-//                if removeOffset.contains(offset) { return false }
-//                removeOffset.insert(offset)
-//            case .insert(_, _, _):
-//                if insertOffset.contains(offset) { return false }
-//                insertOffset.insert(offset)
-//            }
-//
-//            if let assoc = change._associatedOffset {
-//                if assoc < 0 { return false }
-//                switch change {
-//                case .remove(_, _, _):
-//                    if removeOffsetToAssoc[offset] != nil { return false }
-//                    removeOffsetToAssoc[offset] = assoc
-//                case .insert(_, _, _):
-//                    if insertAssocToOffset[assoc] != nil { return false }
-//                    insertAssocToOffset[assoc] = offset
-//                }
-//            }
-//        }
-//
-//        return removeOffsetToAssoc == insertAssocToOffset
-//    }
+    //    public init?<Changes: Collection>(
+    //        _ changes: Changes
+    //    ) where Changes.Element == Change {
+    //        guard CompatibilityCollectionDifference<ChangeElement>._validateChanges(changes) else {
+    //            return nil
+    //        }
+    //
+    //        self.init(_validatedChanges: changes)
+    //    }
+    //
+    //    /// Internal initializer for use by algorithms that cannot produce invalid
+    //    /// collections of changes. These include the Myers' diff algorithm,
+    //    /// self.inverse(), and the move inferencer.
+    //    ///
+    //    /// If parameter validity cannot be guaranteed by the caller then
+    //    /// `CollectionDifference.init?(_:)` should be used instead.
+    //    ///
+    //    /// - Parameter c: A valid collection of changes that represent a transition
+    //    ///   between two states.
+    //    ///
+    //    /// - Complexity: O(*n* * log(*n*)), where *n* is the length of the
+    //    ///   parameter.
+    //    internal init<Changes: Collection>(
+    //        _validatedChanges changes: Changes
+    //    ) where Changes.Element == Change {
+    //        let sortedChanges = changes.sorted { (a, b) -> Bool in
+    //            switch (a, b) {
+    //            case (.remove(_, _, _), .insert(_, _, _)):
+    //                return true
+    //            case (.insert(_, _, _), .remove(_, _, _)):
+    //                return false
+    //            default:
+    //                return a._offset < b._offset
+    //            }
+    //        }
+    //
+    //        // Find first insertion via binary search
+    //        let firstInsertIndex: Int
+    //        if sortedChanges.isEmpty {
+    //            firstInsertIndex = 0
+    //        } else {
+    //            var range = 0...sortedChanges.count
+    //            while range.lowerBound != range.upperBound {
+    //                let i = (range.lowerBound + range.upperBound) / 2
+    //                switch sortedChanges[i] {
+    //                case .insert(_, _, _):
+    //                    range = range.lowerBound...i
+    //                case .remove(_, _, _):
+    //                    range = (i + 1)...range.upperBound
+    //                }
+    //            }
+    //            firstInsertIndex = range.lowerBound
+    //        }
+    //
+    //        removals = Array(sortedChanges[0..<firstInsertIndex])
+    //        insertions = Array(sortedChanges[firstInsertIndex..<sortedChanges.count])
+    //    }
+    //
+    //    /// The public initializer calls this function to ensure that its parameter
+    //    /// meets the conditions set in its documentation.
+    //    ///
+    //    /// - Parameter changes: a collection of `CollectionDifference.Change`
+    //    ///   instances intended to represent a valid state transition for
+    //    ///   `CollectionDifference`.
+    //    ///
+    //    /// - Returns: whether the parameter meets the following criteria:
+    //    ///
+    //    ///   1. All insertion offsets are unique
+    //    ///   2. All removal offsets are unique
+    //    ///   3. All associations between insertions and removals are symmetric
+    //    ///
+    //    /// Complexity: O(`changes.count`)
+    //    private static func _validateChanges<Changes: Collection>(
+    //        _ changes : Changes
+    //    ) -> Bool where Changes.Element == Change {
+    //        if changes.isEmpty { return true }
+    //
+    //        var insertAssocToOffset = Dictionary<Int,Int>()
+    //        var removeOffsetToAssoc = Dictionary<Int,Int>()
+    //        var insertOffset = Set<Int>()
+    //        var removeOffset = Set<Int>()
+    //
+    //        for change in changes {
+    //            let offset = change._offset
+    //            if offset < 0 { return false }
+    //
+    //            switch change {
+    //            case .remove(_, _, _):
+    //                if removeOffset.contains(offset) { return false }
+    //                removeOffset.insert(offset)
+    //            case .insert(_, _, _):
+    //                if insertOffset.contains(offset) { return false }
+    //                insertOffset.insert(offset)
+    //            }
+    //
+    //            if let assoc = change._associatedOffset {
+    //                if assoc < 0 { return false }
+    //                switch change {
+    //                case .remove(_, _, _):
+    //                    if removeOffsetToAssoc[offset] != nil { return false }
+    //                    removeOffsetToAssoc[offset] = assoc
+    //                case .insert(_, _, _):
+    //                    if insertAssocToOffset[assoc] != nil { return false }
+    //                    insertAssocToOffset[assoc] = offset
+    //                }
+    //            }
+    //        }
+    //
+    //        return removeOffsetToAssoc == insertAssocToOffset
+    //    }
 }
 
 // _V is a rudimentary type made to represent the rows of the triangular matrix type used by the Myer's algorithm
 //
 // This type is basically an array that only supports indexes in the set `stride(from: -d, through: d, by: 2)` where `d` is the depth of this row in the matrix
 // `d` is always known at allocation-time, and is used to preallocate the structure.
-fileprivate struct _V {
+private struct _V {
 
-  private var a: [Int]
+    private var a: [Int]
 
-  // The way negative indexes are implemented is by interleaving them in the empty slots between the valid positive indexes
-  @inline(__always) private static func transform(_ index: Int) -> Int {
-    // -3, -1, 1, 3 -> 3, 1, 0, 2 -> 0...3
-    // -2, 0, 2 -> 2, 0, 1 -> 0...2
-    return (index <= 0 ? -index : index &- 1)
-  }
-
-  init(maxIndex largest: Int) {
-    a = [Int](repeating: 0, count: largest + 1)
-  }
-
-  subscript(index: Int) -> Int {
-    get {
-      return a[_V.transform(index)]
+    // The way negative indexes are implemented is by interleaving them in the empty slots between the valid positive indexes
+    @inline(__always) private static func transform(_ index: Int) -> Int {
+        // -3, -1, 1, 3 -> 3, 1, 0, 2 -> 0...3
+        // -2, 0, 2 -> 2, 0, 1 -> 0...2
+        return (index <= 0 ? -index : index &- 1)
     }
-    set(newValue) {
-      a[_V.transform(index)] = newValue
+
+    init(maxIndex largest: Int) {
+        a = [Int](repeating: 0, count: largest + 1)
     }
-  }
+
+    subscript(index: Int) -> Int {
+        get {
+            return a[_V.transform(index)]
+        }
+        set(newValue) {
+            a[_V.transform(index)] = newValue
+        }
+    }
 }
 
-internal func myers<C,D>(
-  from old: C, to new: D,
-  using cmp: (C.Element, D.Element) -> Bool
+internal func myers<C, D>(
+    from old: C, to new: D,
+    using cmp: (C.Element, D.Element) -> Bool
 ) -> CompatibilityCollectionDifference<C.Element>
-  where
-    C : BidirectionalCollection,
-    D : BidirectionalCollection,
+where
+    C: BidirectionalCollection,
+    D: BidirectionalCollection,
     C.Element == D.Element
 {
 
-  // Core implementation of the algorithm described at http://www.xmailserver.org/diff2.pdf
-  // Variable names match those used in the paper as closely as possible
-  func _descent(from a: UnsafeBufferPointer<C.Element>, to b: UnsafeBufferPointer<D.Element>) -> [_V] {
-    let n = a.count
-    let m = b.count
-    let max = n + m
+    // Core implementation of the algorithm described at http://www.xmailserver.org/diff2.pdf
+    // Variable names match those used in the paper as closely as possible
+    func _descent(from a: UnsafeBufferPointer<C.Element>, to b: UnsafeBufferPointer<D.Element>)
+        -> [_V]
+    {
+        let n = a.count
+        let m = b.count
+        let max = n + m
 
-    var result = [_V]()
-    var v = _V(maxIndex: 1)
-    v[1] = 0
+        var result = [_V]()
+        var v = _V(maxIndex: 1)
+        v[1] = 0
 
-    var x = 0
-    var y = 0
-    iterator: for d in 0...max {
-      let prev_v = v
-      result.append(v)
-      v = _V(maxIndex: d)
+        var x = 0
+        var y = 0
+        iterator: for d in 0...max {
+            let prev_v = v
+            result.append(v)
+            v = _V(maxIndex: d)
 
-      // The code in this loop is _very_ hot—the loop bounds increases in terms
-      // of the iterator of the outer loop!
-      for k in stride(from: -d, through: d, by: 2) {
-        if k == -d {
-          x = prev_v[k &+ 1]
-        } else {
-          let km = prev_v[k &- 1]
+            // The code in this loop is _very_ hot—the loop bounds increases in terms
+            // of the iterator of the outer loop!
+            for k in stride(from: -d, through: d, by: 2) {
+                if k == -d {
+                    x = prev_v[k &+ 1]
+                } else {
+                    let km = prev_v[k &- 1]
 
-          if k != d {
-            let kp = prev_v[k &+ 1]
-            if km < kp {
-              x = kp
-            } else {
-              x = km &+ 1
+                    if k != d {
+                        let kp = prev_v[k &+ 1]
+                        if km < kp {
+                            x = kp
+                        } else {
+                            x = km &+ 1
+                        }
+                    } else {
+                        x = km &+ 1
+                    }
+                }
+                y = x &- k
+
+                while x < n && y < m {
+                    if !cmp(a[x], b[y]) {
+                        break
+                    }
+                    x &+= 1
+                    y &+= 1
+                }
+
+                v[k] = x
+
+                if x >= n && y >= m {
+                    break iterator
+                }
             }
-          } else {
-            x = km &+ 1
-          }
-        }
-        y = x &- k
-
-        while x < n && y < m {
-          if !cmp(a[x], b[y]) {
-            break;
-          }
-          x &+= 1
-          y &+= 1
+            if x >= n && y >= m {
+                break
+            }
         }
 
-        v[k] = x
-
-        if x >= n && y >= m {
-          break iterator
-        }
-      }
-      if x >= n && y >= m {
-        break
-      }
+        return result
     }
 
-    return result
-  }
+    // Backtrack through the trace generated by the Myers descent to produce the changes that make up the diff
+    func _formChanges(
+        from a: UnsafeBufferPointer<C.Element>,
+        to b: UnsafeBufferPointer<C.Element>,
+        using trace: [_V]
+    ) -> [CompatibilityCollectionDifference<C.Element>.Change] {
+        var changes = [CompatibilityCollectionDifference<C.Element>.Change]()
 
-  // Backtrack through the trace generated by the Myers descent to produce the changes that make up the diff
-  func _formChanges(
-    from a: UnsafeBufferPointer<C.Element>,
-    to b: UnsafeBufferPointer<C.Element>,
-    using trace: [_V]
-  ) -> [CompatibilityCollectionDifference<C.Element>.Change] {
-    var changes = [CompatibilityCollectionDifference<C.Element>.Change]()
+        var x = a.count
+        var y = b.count
+        for d in stride(from: trace.count &- 1, to: 0, by: -1) {
+            let v = trace[d]
+            let k = x &- y
+            let prev_k = (k == -d || (k != d && v[k &- 1] < v[k &+ 1])) ? k &+ 1 : k &- 1
+            let prev_x = v[prev_k]
+            let prev_y = prev_x &- prev_k
 
-    var x = a.count
-    var y = b.count
-    for d in stride(from: trace.count &- 1, to: 0, by: -1) {
-      let v = trace[d]
-      let k = x &- y
-      let prev_k = (k == -d || (k != d && v[k &- 1] < v[k &+ 1])) ? k &+ 1 : k &- 1
-      let prev_x = v[prev_k]
-      let prev_y = prev_x &- prev_k
+            while x > prev_x && y > prev_y {
+                // No change at this position.
+                x &-= 1
+                y &-= 1
+            }
 
-      while x > prev_x && y > prev_y {
-        // No change at this position.
-        x &-= 1
-        y &-= 1
-      }
+            assert((x == prev_x && y > prev_y) || (y == prev_y && x > prev_x))
+            if y != prev_y {
+                changes.append(.insert(offset: prev_y, element: b[prev_y], associatedWith: nil))
+            } else {
+                changes.append(.remove(offset: prev_x, element: a[prev_x], associatedWith: nil))
+            }
 
-      assert((x == prev_x && y > prev_y) || (y == prev_y && x > prev_x))
-      if y != prev_y {
-        changes.append(.insert(offset: prev_y, element: b[prev_y], associatedWith: nil))
-      } else {
-        changes.append(.remove(offset: prev_x, element: a[prev_x], associatedWith: nil))
-      }
+            x = prev_x
+            y = prev_y
+        }
 
-      x = prev_x
-      y = prev_y
+        return changes
     }
 
-    return changes
-  }
-
-  /* Splatting the collections into contiguous storage has two advantages:
+    /* Splatting the collections into contiguous storage has two advantages:
    *
    *   1) Subscript access is much faster
    *   2) Subscript index becomes Int, matching the iterator types in the algorithm
@@ -342,25 +348,29 @@ internal func myers<C,D>(
    * necessary) is significantly less than the worst-case n² memory use of the
    * descent algorithm.
    */
-  func _withContiguousStorage<C : Collection, R>(
-    for values: C,
-    _ body: (UnsafeBufferPointer<C.Element>) throws -> R
-  ) rethrows -> R {
-    if let result = try values.withContiguousStorageIfAvailable(body) { return result }
-    let array = ContiguousArray(values)
-    return try array.withUnsafeBufferPointer(body)
-  }
-
-  return _withContiguousStorage(for: old) { a in
-    return _withContiguousStorage(for: new) { b in
-      return CompatibilityCollectionDifference(_formChanges(from: a, to: b, using:_descent(from: a, to: b)))!
+    func _withContiguousStorage<C: Collection, R>(
+        for values: C,
+        _ body: (UnsafeBufferPointer<C.Element>) throws -> R
+    ) rethrows -> R {
+        if let result = try values.withContiguousStorageIfAvailable(body) { return result }
+        let array = ContiguousArray(values)
+        return try array.withUnsafeBufferPointer(body)
     }
-  }
+
+    return _withContiguousStorage(for: old) { a in
+        return _withContiguousStorage(for: new) { b in
+            return CompatibilityCollectionDifference(
+                _formChanges(from: a, to: b, using: _descent(from: a, to: b)))!
+        }
+    }
 }
 
 extension Array {
     // For iOS < 13
-    internal func differenceCompatibility<C>(from other: C, by areEquivalent: (C.Element, Element) -> Bool) -> CompatibilityCollectionDifference<Element> where C : BidirectionalCollection, Element == C.Element {
+    internal func differenceCompatibility<C>(
+        from other: C, by areEquivalent: (C.Element, Element) -> Bool
+    ) -> CompatibilityCollectionDifference<Element>
+    where C: BidirectionalCollection, Element == C.Element {
         myers(from: other, to: self, using: areEquivalent)
     }
 }

--- a/Sources/RxComposableArchitecture/CustomDump/Internal/Mirror.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Internal/Mirror.swift
@@ -1,21 +1,21 @@
 extension Mirror {
-  var isSingleValueContainer: Bool {
-    switch self.displayStyle {
-    case .collection?, .dictionary?, .set?:
-      return false
-    default:
-      guard
-        self.children.count == 1,
-        let child = self.children.first
-      else { return false }
-      var value = child.value
-      while let representable = value as? CustomDumpRepresentable {
-        value = representable.customDumpValue
-      }
-      if let convertible = child.value as? CustomDumpStringConvertible {
-        return !convertible.customDumpDescription.contains("\n")
-      }
-      return Mirror(customDumpReflecting: value).children.isEmpty
+    var isSingleValueContainer: Bool {
+        switch self.displayStyle {
+        case .collection?, .dictionary?, .set?:
+            return false
+        default:
+            guard
+                self.children.count == 1,
+                let child = self.children.first
+            else { return false }
+            var value = child.value
+            while let representable = value as? CustomDumpRepresentable {
+                value = representable.customDumpValue
+            }
+            if let convertible = child.value as? CustomDumpStringConvertible {
+                return !convertible.customDumpDescription.contains("\n")
+            }
+            return Mirror(customDumpReflecting: value).children.isEmpty
+        }
     }
-  }
 }

--- a/Sources/RxComposableArchitecture/CustomDump/Internal/String.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/Internal/String.swift
@@ -1,23 +1,25 @@
 import Foundation
 
 extension String {
-  func indenting(by count: Int) -> String {
-    self.indenting(with: String(repeating: " ", count: count))
-  }
-
-  func indenting(with prefix: String) -> String {
-    guard !prefix.isEmpty else { return self }
-    return "\(prefix)\(self.replacingOccurrences(of: "\n", with: "\n\(prefix)"))"
-  }
-
-  var hashCount: Int {
-    var substring = self[...]
-    var hashCount = 0
-    while let range = substring.range(of: "([#]*\"\"\"|\"\"\"[#]*)", options: .regularExpression) {
-      let count = substring.distance(from: range.lowerBound, to: range.upperBound) - 2
-      hashCount = max(count, hashCount)
-      substring.removeSubrange(..<range.upperBound)
+    func indenting(by count: Int) -> String {
+        self.indenting(with: String(repeating: " ", count: count))
     }
-    return hashCount
-  }
+
+    func indenting(with prefix: String) -> String {
+        guard !prefix.isEmpty else { return self }
+        return "\(prefix)\(self.replacingOccurrences(of: "\n", with: "\n\(prefix)"))"
+    }
+
+    var hashCount: Int {
+        var substring = self[...]
+        var hashCount = 0
+        while let range = substring.range(
+            of: "([#]*\"\"\"|\"\"\"[#]*)", options: .regularExpression)
+        {
+            let count = substring.distance(from: range.lowerBound, to: range.upperBound) - 2
+            hashCount = max(count, hashCount)
+            substring.removeSubrange(..<range.upperBound)
+        }
+        return hashCount
+    }
 }

--- a/Sources/RxComposableArchitecture/CustomDump/XCTAssertNoDifference.swift
+++ b/Sources/RxComposableArchitecture/CustomDump/XCTAssertNoDifference.swift
@@ -38,54 +38,54 @@
 ///   - line: The line number where the failure occurs. The default is the line number where you
 ///     call this function.
 #if DEBUG
-public func XCTAssertNoDifference<T>(
-  _ expression1: @autoclosure () throws -> T,
-  _ expression2: @autoclosure () throws -> T,
-  _ message: @autoclosure () -> String = "",
-  file: StaticString = #filePath,
-  line: UInt = #line
-) where T: Equatable {
-  do {
-    let expression1 = try expression1()
-    let expression2 = try expression2()
-    let message = message()
-    guard expression1 != expression2 else { return }
-    let format = DiffFormat.proportional
-    guard let difference = diff(expression1, expression2, format: format)
-    else {
-      XCTFail(
-        """
-        XCTAssertNoDifference failed: An unexpected failure occurred. Please report the issue to https://github.com/pointfreeco/swift-custom-dump …
+    public func XCTAssertNoDifference<T>(
+        _ expression1: @autoclosure () throws -> T,
+        _ expression2: @autoclosure () throws -> T,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) where T: Equatable {
+        do {
+            let expression1 = try expression1()
+            let expression2 = try expression2()
+            let message = message()
+            guard expression1 != expression2 else { return }
+            let format = DiffFormat.proportional
+            guard let difference = diff(expression1, expression2, format: format)
+            else {
+                XCTFail(
+                    """
+                    XCTAssertNoDifference failed: An unexpected failure occurred. Please report the issue to https://github.com/pointfreeco/swift-custom-dump …
 
-        ("\(expression1)" is not equal to ("\(expression2)")
+                    ("\(expression1)" is not equal to ("\(expression2)")
 
-        But no difference was detected.
-        """,
-        file: file,
-        line: line
-      )
-      return
+                    But no difference was detected.
+                    """,
+                    file: file,
+                    line: line
+                )
+                return
+            }
+            let failure = """
+                XCTAssertNoDifference failed: …
+
+                \(difference.indenting(by: 2))
+
+                (First: \(format.first), Second: \(format.second))
+                """
+            XCTFail(
+                "\(failure)\(message.isEmpty ? "" : " - \(message)")",
+                file: file,
+                line: line
+            )
+        } catch {
+            XCTFail(
+                """
+                XCTAssertNoDifference failed: threw error "\(error)"
+                """,
+                file: file,
+                line: line
+            )
+        }
     }
-    let failure = """
-      XCTAssertNoDifference failed: …
-
-      \(difference.indenting(by: 2))
-
-      (First: \(format.first), Second: \(format.second))
-      """
-    XCTFail(
-      "\(failure)\(message.isEmpty ? "" : " - \(message)")",
-      file: file,
-      line: line
-    )
-  } catch {
-    XCTFail(
-      """
-      XCTAssertNoDifference failed: threw error "\(error)"
-      """,
-      file: file,
-      line: line
-    )
-  }
-}
 #endif

--- a/Sources/RxComposableArchitecture/Debugging/Bootstrapping.swift
+++ b/Sources/RxComposableArchitecture/Debugging/Bootstrapping.swift
@@ -8,63 +8,62 @@
 import Foundation
 
 #if DEBUG
-    /**
-     A Way to Mock/Inject custom behaviour to your TCA.
-     with `Bootstrap` you can inject your custom `Environment` to your page.
-     You can injected it like on your `Example`, or using `MainApp TCA Bootstrapping Tweak` options on
-     `Tweaks -> Others -> Bootstrapping`. (will explain later)
+    ///     A Way to Mock/Inject custom behaviour to your TCA.
+    ///     with `Bootstrap` you can inject your custom `Environment` to your page.
+    ///     You can injected it like on your `Example`, or using `MainApp TCA Bootstrapping Tweak` options on
+    ///     `Tweaks -> Others -> Bootstrapping`. (will explain later)
+    ///
+    ///     let's say, our page have this environment
+    ///     ```swift
+    ///     struct Environment {
+    ///        var request: () -> Effect<Result<Response, NetworkError>>
+    ///        ...
+    ///        ...
+    ///     }
+    ///     ```
+    ///
+    ///     ## Injecting custom Environment
+    ///
+    ///     we want to inject custom behaviour like if request fail,
+    ///     we will create the fail `Environment` case, and inject it.
+    ///
+    ///     ```swift
+    ///     let requestFail = Environment {
+    ///        request: {
+    ///            return Effect(value: .failure(.serverError))
+    ///        }
+    ///     }
+    ///     ```
+    ///
+    ///     once we have our Environment, we can inject it by
+    ///     calling `mock(_:)` function on `Bootstrap`
+    ///
+    ///     ```swift
+    ///     Bootstrap.mock(requestFail)
+    ///     ```
+    ///
+    ///     you can expect your feature to have this custom behaviour right away,
+    ///     you *do not* need to restart the simulator, or reinit your page.
+    ///
+    ///     ## Reset custom Environment
+    ///
+    ///     once you inject something, it will be there for the rest of app session(means untill app is killed).
+    ///     maybe after testing and playing with custom behaviour, you want to go back to 'live' or production behaviour,
+    ///     then you need to reset it by
+    ///
+    ///     ```swift
+    ///     Bootstrap.clear(_YOUR_ENVIRONMENT_TYPE)
+    ///     ```
+    ///
+    ///     so on our example
+    ///     ```swift
+    ///     Bootstrap.clear(Environment.self)
+    ///     ```
+    ///     it will clear the custom behaviour and you can expect it right away like when you custom it in the first place.
+    ///
+    ///     - Warning:
+    ///     the way bootstrap works is each `Envrionment` type will become identifier. means you only can inject one at a time for spesific `Environment` type.
 
-     let's say, our page have this environment
-     ```swift
-     struct Environment {
-        var request: () -> Effect<Result<Response, NetworkError>>
-        ...
-        ...
-     }
-     ```
-
-     ## Injecting custom Environment
-
-     we want to inject custom behaviour like if request fail,
-     we will create the fail `Environment` case, and inject it.
-
-     ```swift
-     let requestFail = Environment {
-        request: {
-            return Effect(value: .failure(.serverError))
-        }
-     }
-     ```
-
-     once we have our Environment, we can inject it by
-     calling `mock(_:)` function on `Bootstrap`
-
-     ```swift
-     Bootstrap.mock(requestFail)
-     ```
-
-     you can expect your feature to have this custom behaviour right away,
-     you *do not* need to restart the simulator, or reinit your page.
-
-     ## Reset custom Environment
-
-     once you inject something, it will be there for the rest of app session(means untill app is killed).
-     maybe after testing and playing with custom behaviour, you want to go back to 'live' or production behaviour,
-     then you need to reset it by
-
-     ```swift
-     Bootstrap.clear(_YOUR_ENVIRONMENT_TYPE)
-     ```
-
-     so on our example
-     ```swift
-     Bootstrap.clear(Environment.self)
-     ```
-     it will clear the custom behaviour and you can expect it right away like when you custom it in the first place.
-
-     - Warning:
-     the way bootstrap works is each `Envrionment` type will become identifier. means you only can inject one at a time for spesific `Environment` type.
-     */
     public struct Bootstrap {
         /// Inject your custom `Environment`
         ///
@@ -76,7 +75,9 @@ import Foundation
         /// - Parameter environment: `Environment` to be injected
         public static func mock<Environment>(environment: Environment) {
             guard type(of: environment) != Void.self else {
-                assertionFailure("You made a mistake by passing Void as a param, you never need to mock the Void")
+                assertionFailure(
+                    "You made a mistake by passing Void as a param, you never need to mock the Void"
+                )
                 return
             }
 

--- a/Sources/RxComposableArchitecture/Debugging/MockPageTemplate.swift
+++ b/Sources/RxComposableArchitecture/Debugging/MockPageTemplate.swift
@@ -164,7 +164,8 @@
                 return
             }
 
-            filteredSections = data
+            filteredSections =
+                data
                 .compactMap { section -> Section? in
                     let filteredMocks = section.mocks
                         .filter { $0.title.lowercased().contains(searchKeyword.lowercased()) }
@@ -200,12 +201,15 @@
             filteredSections[section].mocks.count
         }
 
-        override open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        override open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath)
+        {
             tableView.deselectRow(at: indexPath, animated: true)
             filteredSections[indexPath.section].mocks[indexPath.row].apply()
         }
 
-        override open func tableView(_: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        override open func tableView(_: UITableView, cellForRowAt indexPath: IndexPath)
+            -> UITableViewCell
+        {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell") else {
                 return UITableViewCell()
             }
@@ -216,7 +220,9 @@
             return cell
         }
 
-        override open func tableView(_: UITableView, titleForHeaderInSection section: Int) -> String? {
+        override open func tableView(_: UITableView, titleForHeaderInSection section: Int)
+            -> String?
+        {
             filteredSections[section].title
         }
     }

--- a/Sources/RxComposableArchitecture/Debugging/ReducerDebugging.swift
+++ b/Sources/RxComposableArchitecture/Debugging/ReducerDebugging.swift
@@ -210,9 +210,10 @@ extension Reducer {
                                 actionOutput.write(debugCaseOutput(localAction).indent(by: 2))
                             }
                             let stateOutput =
-                            LocalState.self == Void.self
-                            ? ""
-                            : diff(previousState, nextState).map { "\($0)\n" } ?? "  (No state changes)\n"
+                                LocalState.self == Void.self
+                                ? ""
+                                : diff(previousState, nextState).map { "\($0)\n" }
+                                    ?? "  (No state changes)\n"
                             debugEnvironment.printer(
                                 """
                                 \(prefix.isEmpty ? "" : "\(prefix): ")received action:

--- a/Sources/RxComposableArchitecture/Debugging/ReducerInstrumentation.swift
+++ b/Sources/RxComposableArchitecture/Debugging/ReducerInstrumentation.swift
@@ -5,8 +5,8 @@
 //  Created by Wendy Liga on 28/05/20.
 //
 
-import os.signpost
 import RxSwift
+import os.signpost
 
 extension Reducer {
     /// Instruments the reducer with
@@ -57,8 +57,8 @@ extension Reducer {
                     os_signpost(.end, log: log, name: "Action")
                     return
                         effects
-                            .effectSignpost(prefix, log: log, actionOutput: actionOutput)
-                            .eraseToEffect()
+                        .effectSignpost(prefix, log: log, actionOutput: actionOutput)
+                        .eraseToEffect()
                 }
                 return effects
             }
@@ -70,21 +70,29 @@ extension Reducer {
 
 extension ObservableType {
     @available(iOS 12.0, *)
-    internal func effectSignpost(_ prefix: String, log: OSLog, actionOutput: String) -> Observable<Element> {
+    internal func effectSignpost(_ prefix: String, log: OSLog, actionOutput: String) -> Observable<
+        Element
+    > {
         let sid = OSSignpostID(log: log)
 
         return `do`(
             onNext: { _ in
-                os_signpost(.event, log: log, name: "Effect Output", "%sOutput from %s", prefix, actionOutput)
+                os_signpost(
+                    .event, log: log, name: "Effect Output", "%sOutput from %s", prefix,
+                    actionOutput)
             },
             onCompleted: {
                 os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sFinished", prefix)
             },
             onSubscribe: {
-                os_signpost(.begin, log: log, name: "Effect", signpostID: sid, "%sStarting from %s", prefix, actionOutput)
+                os_signpost(
+                    .begin, log: log, name: "Effect", signpostID: sid, "%sStarting from %s", prefix,
+                    actionOutput)
             },
             onSubscribed: {
-                os_signpost(.begin, log: log, name: "Effect", signpostID: sid, "%sStarted from %s", prefix, actionOutput)
+                os_signpost(
+                    .begin, log: log, name: "Effect", signpostID: sid, "%sStarted from %s", prefix,
+                    actionOutput)
             },
             onDispose: {
                 os_signpost(.end, log: log, name: "Effect", signpostID: sid, "%sDisposed", prefix)

--- a/Sources/RxComposableArchitecture/DiffingInterface/HashDiffable.swift
+++ b/Sources/RxComposableArchitecture/DiffingInterface/HashDiffable.swift
@@ -11,9 +11,9 @@ public protocol HashDiffable {
     func isEqual(to source: Self) -> Bool
 }
 
-public extension HashDiffable where Self: Hashable {
+extension HashDiffable where Self: Hashable {
     /// The `self` value as an identifier for difference calculation.
-    var id: Self {
+    public var id: Self {
         return self
     }
 }

--- a/Sources/RxComposableArchitecture/DiffingInterface/HashDiffing.swift
+++ b/Sources/RxComposableArchitecture/DiffingInterface/HashDiffing.swift
@@ -22,15 +22,13 @@ internal struct Stack<Element> {
     }
 }
 
-/**
- `References`:
-    **About the Code Reference**
-    - https://github.com/Instagram/IGListKit/blob/master/Source/IGListDiff.mm
-
-    **If You want to learn the Algorithm**
-    - https://github.com/AmbarSeptian/DiffingSharingSession
-    - https://docs.google.com/spreadsheets/d/10CV51it4Oq_Uv1sTS8wBLdGyiE6t5OGtFBT-gCn7w1k/edit?usp=sharing
- */
+/// `References`:
+///    **About the Code Reference**
+///    - https://github.com/Instagram/IGListKit/blob/master/Source/IGListDiff.mm
+///
+///    **If You want to learn the Algorithm**
+///    - https://github.com/AmbarSeptian/DiffingSharingSession
+///    - https://docs.google.com/spreadsheets/d/10CV51it4Oq_Uv1sTS8wBLdGyiE6t5OGtFBT-gCn7w1k/edit?usp=sharing
 public enum DiffingInterfaceList {
     /// Used to track data stats while diffing.
     /// We expect to keep a reference of entry, thus its declaration as (final) class.
@@ -91,7 +89,8 @@ public enum DiffingInterfaceList {
         public var oldMap = [AnyHashable: Int]()
         public var newMap = [AnyHashable: Int]()
         public var hasChanges: Bool {
-            return (inserts.count > 0) || (deletes.count > 0) || (updates.count > 0) || (moves.count > 0)
+            return (inserts.count > 0) || (deletes.count > 0) || (updates.count > 0)
+                || (moves.count > 0)
         }
 
         public var changeCount: Int {
@@ -164,7 +163,9 @@ public enum DiffingInterfaceList {
         newRecords.enumerated().filter { $1.entry.occurOnBothSides }.forEach { i, newRecord in
             let entry = newRecord.entry
             // grab and pop the top old index. if the item was inserted this will be nil
-            assert(!entry.oldIndexes.isEmpty, "Old indexes is empty while iterating new item \(i). Should have nil")
+            assert(
+                !entry.oldIndexes.isEmpty,
+                "Old indexes is empty while iterating new item \(i). Should have nil")
             guard let oldIndex = entry.oldIndexes.pop() else {
                 return
             }
@@ -216,7 +217,7 @@ public enum DiffingInterfaceList {
                 if (oldIndex - deleteOffset + insertOffset) != i {
                     result.moves.append(MoveIndex(from: oldIndex, to: i))
                 }
-            } else { // add to inserts if the opposing index is nil
+            } else {  // add to inserts if the opposing index is nil
                 result.inserts.insert(i)
                 runningOffset += 1
             }
@@ -224,7 +225,10 @@ public enum DiffingInterfaceList {
             return insertOffset
         }
 
-        assert(result.validate(oldArray, newArray), "Sanity check failed applying \(result.inserts.count) inserts and \(result.deletes.count) deletes to old count \(oldArray.count) equaling new count \(newArray.count)")
+        assert(
+            result.validate(oldArray, newArray),
+            "Sanity check failed applying \(result.inserts.count) inserts and \(result.deletes.count) deletes to old count \(oldArray.count) equaling new count \(newArray.count)"
+        )
 
         return result
     }

--- a/Sources/RxComposableArchitecture/Effect.swift
+++ b/Sources/RxComposableArchitecture/Effect.swift
@@ -128,7 +128,9 @@ public final class Effect<Output>: ObservableType {
     ///
     /// - Parameter attemptToFulfill: A closure encapsulating some work to execute in the real world.
     /// - Returns: An effect.
-    public static func result(_ attemptToFulfill: @escaping () -> Result<Output, Error>) -> Effect<Output> {
+    public static func result(_ attemptToFulfill: @escaping () -> Result<Output, Error>) -> Effect<
+        Output
+    > {
         Observable<Output>.create { observer in
             switch attemptToFulfill() {
             case let .success(output):
@@ -202,10 +204,10 @@ public final class Effect<Output>: ObservableType {
 
         return
             effects
-                .dropFirst()
-                .reduce(into: first) { effects, effect in
-                    effects = effects.concat(effect).eraseToEffect()
-                }
+            .dropFirst()
+            .reduce(into: first) { effects, effect in
+                effects = effects.concat(effect).eraseToEffect()
+            }
     }
 
     /// Merges a variadic list of effects together into a single effect, which runs the effects at the

--- a/Sources/RxComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/RxComposableArchitecture/Effects/Cancellation.swift
@@ -31,18 +31,18 @@ extension Effect {
         Observable.deferred {
             cancellablesLock.lock()
             defer { cancellablesLock.unlock() }
-            
+
             let id = CancelToken(id: id)
             if cancelInFlight {
                 cancellationCancellables[id]?.forEach { $0.dispose() }
             }
-            
+
             /// Flag is used to prevent disposable to send event on disposed `cancellationSubject`
             /// Thanks: https://github.com/dannyhertz/rxswift-composable-architecture/issues/5
             var hasCompleted = false
-            
+
             let cancellationSubject = PublishSubject<Void>()
-            
+
             var cancellationCancellable: AnyDisposable!
             cancellationCancellable = AnyDisposable(
                 Disposables.create {
@@ -58,7 +58,7 @@ extension Effect {
                     }
                 }
             )
-            
+
             return self.takeUntil(cancellationSubject)
                 .do(
                     onError: { _ in
@@ -80,7 +80,7 @@ extension Effect {
         }
         .eraseToEffect()
     }
-    
+
     /// Turns an effect into one that is capable of being canceled.
     ///
     /// A convenience for calling ``Effect/cancellable(id:cancelInFlight:)-17skv`` with a static type
@@ -94,7 +94,7 @@ extension Effect {
     public func cancellable(id: Any.Type, cancelInFlight: Bool = false) -> Effect {
         self.cancellable(id: ObjectIdentifier(id), cancelInFlight: cancelInFlight)
     }
-    
+
     /// An effect that will cancel any currently in-flight effect with the given identifier.
     ///
     /// - Parameter id: An effect identifier.
@@ -107,7 +107,7 @@ extension Effect {
             }
         }
     }
-    
+
     /// An effect that will cancel any currently in-flight effect with the given identifier.
     ///
     /// A convenience for calling ``Effect/cancel(id:)-iun1`` with a static type as the effect's
@@ -119,7 +119,7 @@ extension Effect {
     public static func cancel(id: Any.Type) -> Effect {
         .cancel(id: ObjectIdentifier(id))
     }
-    
+
     /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
     ///
     /// - Parameter ids: An array of effect identifiers.
@@ -128,7 +128,7 @@ extension Effect {
     public static func cancel(ids: [AnyHashable]) -> Effect {
         .merge(ids.map(Effect.cancel(id:)))
     }
-    
+
     /// An effect that will cancel multiple currently in-flight effects with the given identifiers.
     ///
     /// A convenience for calling ``Effect/cancel(ids:)-dmwy`` with a static type as the effect's
@@ -145,7 +145,7 @@ extension Effect {
 struct CancelToken: Hashable {
     let id: AnyHashable
     let discriminator: ObjectIdentifier
-    
+
     init(id: AnyHashable) {
         self.id = id
         self.discriminator = ObjectIdentifier(type(of: id.base))

--- a/Sources/RxComposableArchitecture/Effects/Debouncing.swift
+++ b/Sources/RxComposableArchitecture/Effects/Debouncing.swift
@@ -34,7 +34,7 @@ extension Effect {
             .eraseToEffect()
             .cancellable(id: id, cancelInFlight: true)
     }
-    
+
     /// Turns an effect into one that can be debounced.
     ///
     /// A convenience for calling ``Effect/debounce(id:for:scheduler:options:)-76yye`` with a static

--- a/Sources/RxComposableArchitecture/Effects/Throttling.swift
+++ b/Sources/RxComposableArchitecture/Effects/Throttling.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by jefferson.setiawan on 05/07/22.
 //
@@ -30,13 +30,13 @@ extension Effect {
             .flatMap { value -> Observable<Output> in
                 throttleLock.lock()
                 defer { throttleLock.unlock() }
-                
+
                 guard let throttleTime = throttleTimes[id] as! Date? else {
                     throttleTimes[id] = scheduler.now
                     throttleValues[id] = nil
                     return .just(value)
                 }
-                
+
                 let value = latest ? value : (throttleValues[id] as! Output? ?? value)
                 throttleValues[id] = value
                 guard
@@ -47,8 +47,10 @@ extension Effect {
                     throttleValues[id] = nil
                     return .just(value)
                 }
-                let delayTimeInMs = Int((throttleTime.addingTimeInterval(interval.convertToSecondsInterval).timeIntervalSince1970
-                                         - scheduler.now.timeIntervalSince1970) * 1_000)
+                let delayTimeInMs = Int(
+                    (throttleTime.addingTimeInterval(interval.convertToSecondsInterval)
+                        .timeIntervalSince1970
+                        - scheduler.now.timeIntervalSince1970) * 1_000)
                 return .just(value)
                     .delay(
                         .milliseconds(delayTimeInMs),
@@ -63,7 +65,7 @@ extension Effect {
             .eraseToEffect()
             .cancellable(id: id, cancelInFlight: true)
     }
-    
+
     /// Throttles an effect so that it only publishes one output per given interval.
     ///
     /// A convenience for calling ``Effect/throttle(id:for:scheduler:latest:)-5jfpx`` with a static

--- a/Sources/RxComposableArchitecture/Effects/Timer.swift
+++ b/Sources/RxComposableArchitecture/Effects/Timer.swift
@@ -107,7 +107,7 @@ extension Effect where Output: RxAbstractInteger {
             .eraseToEffect()
             .cancellable(id: id, cancelInFlight: true)
     }
-    
+
     /// Returns an effect that repeatedly emits the current time of the given scheduler on the given
     /// interval.
     ///

--- a/Sources/RxComposableArchitecture/IdentifiedArray.swift
+++ b/Sources/RxComposableArchitecture/IdentifiedArray.swift
@@ -44,7 +44,7 @@ import Foundation
 ///       }
 ///     }
 public struct IdentifiedArray<ID, Element>: MutableCollection, RandomAccessCollection
-    where ID: Hashable {
+where ID: Hashable {
     /// A key path to a value that identifies an element.
     public let id: KeyPath<Element, ID>
 
@@ -63,7 +63,8 @@ public struct IdentifiedArray<ID, Element>: MutableCollection, RandomAccessColle
     /// - Parameters:
     ///   - elements: A sequence of elements.
     ///   - id: A key path to a value that identifies an element.
-    public init<S>(_ elements: S, id: KeyPath<Element, ID>) where S: Sequence, S.Element == Element {
+    public init<S>(_ elements: S, id: KeyPath<Element, ID>)
+    where S: Sequence, S.Element == Element {
         self.id = id
 
         let idsAndElements = elements.map { (id: $0[keyPath: id], element: $0) }
@@ -201,9 +202,9 @@ public struct IdentifiedArray<ID, Element>: MutableCollection, RandomAccessColle
     }
 
     /// Unavailable, if needed, please implement this, The implementation of `move` is in SwitUI.Collection.Array
-//    public mutating func move(fromOffsets source: IndexSet, toOffset destination: Int) {
-//        self.ids.move(fromOffsets: source, toOffset: destination)
-//    }
+    //    public mutating func move(fromOffsets source: IndexSet, toOffset destination: Int) {
+    //        self.ids.move(fromOffsets: source, toOffset: destination)
+    //    }
 
     public mutating func sort(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows {
         try ids.sort {
@@ -243,7 +244,8 @@ extension IdentifiedArray: CustomStringConvertible {
     }
 }
 
-extension IdentifiedArray: Decodable where Element: Decodable & HashDiffable, ID == Element.IdentifierType {
+extension IdentifiedArray: Decodable
+where Element: Decodable & HashDiffable, ID == Element.IdentifierType {
     public init(from decoder: Decoder) throws {
         self.init(try [Element](from: decoder))
     }
@@ -265,7 +267,8 @@ extension IdentifiedArray where Element: Comparable {
     }
 }
 
-extension IdentifiedArray: ExpressibleByArrayLiteral where Element: HashDiffable, ID == Element.IdentifierType {
+extension IdentifiedArray: ExpressibleByArrayLiteral
+where Element: HashDiffable, ID == Element.IdentifierType {
     public init(arrayLiteral elements: Element...) {
         self.init(elements)
     }
@@ -278,13 +281,13 @@ extension IdentifiedArray where Element: HashDiffable, ID == Element.IdentifierT
 }
 
 extension IdentifiedArray: RangeReplaceableCollection
-    where Element: HashDiffable, ID == Element.IdentifierType {
+where Element: HashDiffable, ID == Element.IdentifierType {
     public init() {
         self.init([], id: \.id)
     }
 
     public mutating func replaceSubrange<C, R>(_ subrange: R, with newElements: C)
-        where C: Collection, R: RangeExpression, Element == C.Element, Index == R.Bound {
+    where C: Collection, R: RangeExpression, Element == C.Element, Index == R.Bound {
         let replacingIds = ids[subrange]
         let newIds = newElements.map { $0.id }
         ids.replaceSubrange(subrange, with: newIds)
@@ -301,7 +304,7 @@ extension IdentifiedArray: RangeReplaceableCollection
 
 /// A convenience type to specify an `IdentifiedArray` by an identifiable element.
 public typealias IdentifiedArrayOf<Element> = IdentifiedArray<Element.IdentifierType, Element>
-    where Element: HashDiffable
+where Element: HashDiffable
 
 extension IdentifiedArrayOf where Element: HashDiffable, Element.IdentifierType == ID {
     public func removeDuplicates() -> Self {

--- a/Sources/RxComposableArchitecture/Internal/Debug.swift
+++ b/Sources/RxComposableArchitecture/Internal/Debug.swift
@@ -1,13 +1,13 @@
 //
 //  Debug.swift
-//  
+//
 //
 //  Created by jefferson.setiawan on 02/08/22.
 //
 
 extension String {
-  func indent(by indent: Int) -> String {
-    let indentation = String(repeating: " ", count: indent)
-    return indentation + self.replacingOccurrences(of: "\n", with: "\n\(indentation)")
-  }
+    func indent(by indent: Int) -> String {
+        let indentation = String(repeating: " ", count: indent)
+        return indentation + self.replacingOccurrences(of: "\n", with: "\n\(indentation)")
+    }
 }

--- a/Sources/RxComposableArchitecture/Internal/Deprecated.swift
+++ b/Sources/RxComposableArchitecture/Internal/Deprecated.swift
@@ -12,7 +12,7 @@ extension Reducer {
     public var optional: Reducer<State?, Action, Environment> {
         self.optional()
     }
-    
+
     /// https://github.com/pointfreeco/swift-composable-architecture/pull/641
     @available(*, deprecated, message: "Use the 'IdentifiedArray'-based version, instead.")
     public func forEach<GlobalState, GlobalAction, GlobalEnvironment>(
@@ -83,14 +83,17 @@ extension Reducer where State: HashDiffable {
         action toLocalAction: CasePath<GlobalAction, (Identifier, Action)>,
         environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment
     ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment>
-        where Identifier == State.IdentifierType {
+    where Identifier == State.IdentifierType {
         .init { globalState, globalAction, globalEnvironment in
             guard let (identifier, localAction) = toLocalAction.extract(from: globalAction) else {
                 return .none
             }
 
             // search index of identifier
-            guard let index = globalState[keyPath: toLocalState].firstIndex(where: { $0.id == identifier })
+            guard
+                let index = globalState[keyPath: toLocalState].firstIndex(where: {
+                    $0.id == identifier
+                })
             else {
                 assertionFailure("\(identifier) is not exist on Global State")
                 return .none

--- a/Sources/RxComposableArchitecture/Internal/RuntimeWarnings.swift
+++ b/Sources/RxComposableArchitecture/Internal/RuntimeWarnings.swift
@@ -1,28 +1,28 @@
 #if DEBUG
-import os
+    import os
 
-// NB: Xcode runtime warnings offer a much better experience than traditional assertions and
-//     breakpoints, but Apple provides no means of creating custom runtime warnings ourselves.
-//     To work around this, we hook into SwiftUI's runtime issue delivery mechanism, instead.
-//
-// Feedback filed: https://gist.github.com/stephencelis/a8d06383ed6ccde3e5ef5d1b3ad52bbc
-private let rw = (
-    dso: { () -> UnsafeMutableRawPointer in
-        let count = _dyld_image_count()
-        for i in 0..<count {
-            if let name = _dyld_get_image_name(i) {
-                let swiftString = String(cString: name)
-                if swiftString.hasSuffix("/SwiftUI") {
-                    if let header = _dyld_get_image_header(i) {
-                        return UnsafeMutableRawPointer(mutating: UnsafeRawPointer(header))
+    // NB: Xcode runtime warnings offer a much better experience than traditional assertions and
+    //     breakpoints, but Apple provides no means of creating custom runtime warnings ourselves.
+    //     To work around this, we hook into SwiftUI's runtime issue delivery mechanism, instead.
+    //
+    // Feedback filed: https://gist.github.com/stephencelis/a8d06383ed6ccde3e5ef5d1b3ad52bbc
+    private let rw = (
+        dso: { () -> UnsafeMutableRawPointer in
+            let count = _dyld_image_count()
+            for i in 0..<count {
+                if let name = _dyld_get_image_name(i) {
+                    let swiftString = String(cString: name)
+                    if swiftString.hasSuffix("/SwiftUI") {
+                        if let header = _dyld_get_image_header(i) {
+                            return UnsafeMutableRawPointer(mutating: UnsafeRawPointer(header))
+                        }
                     }
                 }
             }
-        }
-        return UnsafeMutableRawPointer(mutating: #dsohandle)
-    }(),
-    log: OSLog(subsystem: "com.apple.runtime-issues", category: "ComposableArchitecture")
-)
+            return UnsafeMutableRawPointer(mutating: #dsohandle)
+        }(),
+        log: OSLog(subsystem: "com.apple.runtime-issues", category: "ComposableArchitecture")
+    )
 #endif
 
 @_transparent
@@ -32,21 +32,22 @@ func runtimeWarning(
     _ args: @autoclosure () -> [CVarArg] = []
 ) {
     #if DEBUG
-    if _XCTIsTesting {
-        XCTFail(String(format: "\(message())", arguments: args()))
-    } else {
-        if #available(iOS 12.0, *) {
-            unsafeBitCast(
-                os_log as (OSLogType, UnsafeRawPointer, OSLog, StaticString, CVarArg...) -> Void,
-                to: ((OSLogType, UnsafeRawPointer, OSLog, StaticString, [CVarArg]) -> Void).self
-            )(.fault, rw.dso, rw.log, message(), args())
+        if _XCTIsTesting {
+            XCTFail(String(format: "\(message())", arguments: args()))
         } else {
-            fputs(
-                "\(message())",
-                stderr
-            )
-            raise(SIGTRAP)
+            if #available(iOS 12.0, *) {
+                unsafeBitCast(
+                    os_log
+                        as (OSLogType, UnsafeRawPointer, OSLog, StaticString, CVarArg...) -> Void,
+                    to: ((OSLogType, UnsafeRawPointer, OSLog, StaticString, [CVarArg]) -> Void).self
+                )(.fault, rw.dso, rw.log, message(), args())
+            } else {
+                fputs(
+                    "\(message())",
+                    stderr
+                )
+                raise(SIGTRAP)
+            }
         }
-    }
     #endif
 }

--- a/Sources/RxComposableArchitecture/Internal/XCTIsTesting.swift
+++ b/Sources/RxComposableArchitecture/Internal/XCTIsTesting.swift
@@ -1,11 +1,11 @@
 #if DEBUG
-import Foundation
+    import Foundation
 
-public let _XCTIsTesting: Bool = {
-  ProcessInfo.processInfo.environment.keys.contains("XCTestSessionIdentifier")
-    || ProcessInfo.processInfo.arguments.first
-      .flatMap(URL.init(fileURLWithPath:))
-      .map { $0.lastPathComponent == "xctest" || $0.pathExtension == "xctest" }
-      ?? false
-}()
+    public let _XCTIsTesting: Bool = {
+        ProcessInfo.processInfo.environment.keys.contains("XCTestSessionIdentifier")
+            || ProcessInfo.processInfo.arguments.first
+                .flatMap(URL.init(fileURLWithPath:))
+                .map { $0.lastPathComponent == "xctest" || $0.pathExtension == "xctest" }
+                ?? false
+    }()
 #endif

--- a/Sources/RxComposableArchitecture/PropertyWrapper/NeverEqual.swift
+++ b/Sources/RxComposableArchitecture/PropertyWrapper/NeverEqual.swift
@@ -1,6 +1,6 @@
 //
 //  NeverEqual.swift
-//  
+//
 //
 //  Created by jefferson.setiawan on 03/06/22.
 //
@@ -31,18 +31,18 @@
    }
  }
  ```
- 
+
  By default, if `scrollToTop` property never get resetted, it will never emit again even though you are sending multiple `.didTapScrollToTop` action to the reducer.
  This is because the `store.subscribe` has `distinctUntilChanged`, so the `subscribe` will only be emitted once it's not equal from the previous property.
- 
+
  We usually do this juggling (set and reset) because we don't know when the right time to reset the property, and when PointFree enhance its store.send mechanism, this mechanism will not work.
- 
+
  When using the NeverEqual, you don't need to reset the state again just to make it not equal.
  ```swift
  struct EmitState: Equatable {
      @NeverEqual var scrollToTop: Stateless?
  }
- 
+
  Reducer {
    switch action {
      case .didTapScrollToTop:
@@ -50,37 +50,37 @@
          return .none
     }
  }
- 
+
  // UI
- 
+
  store.subscribeNeverEqual(\.$scrollToTop)
     .subscribe(onNext: { ... })
  ```
  Behind the scene, the property wrapper will increment the number everytime you set it to new value, so it will not equal.
- 
+
 */
 @propertyWrapper
- public struct NeverEqual<Value> {
-     private var value: Value
-     private var numberOfIncrement: UInt8 = 0
+public struct NeverEqual<Value> {
+    private var value: Value
+    private var numberOfIncrement: UInt8 = 0
 
-     public var wrappedValue: Value {
-         get { value }
-         set {
-             value = newValue
-             if numberOfIncrement == .max {
-                 numberOfIncrement = 0
-             } else {
-                 numberOfIncrement += 1
-             }
-         }
-     }
+    public var wrappedValue: Value {
+        get { value }
+        set {
+            value = newValue
+            if numberOfIncrement == .max {
+                numberOfIncrement = 0
+            } else {
+                numberOfIncrement += 1
+            }
+        }
+    }
 
-     public var projectedValue: NeverEqual<Value> { self }
+    public var projectedValue: NeverEqual<Value> { self }
 
-     public init(wrappedValue: Value) {
-         self.value = wrappedValue
-     }
- }
+    public init(wrappedValue: Value) {
+        self.value = wrappedValue
+    }
+}
 
- extension NeverEqual: Equatable where Value: Equatable {}
+extension NeverEqual: Equatable where Value: Equatable {}

--- a/Sources/RxComposableArchitecture/PropertyWrapper/UniqueElements.swift
+++ b/Sources/RxComposableArchitecture/PropertyWrapper/UniqueElements.swift
@@ -5,25 +5,23 @@
 //  Created by Kensen on 07/01/21.
 //
 
-
-/**
- Property wrapper to reduce boiler plate code to remove duplicates from a collection of HashDiffable.
-
- ```
- struct Element: Equatable, HashDiffable {}
-
- struct ParentState: Equatable {
-    @UniqueElements var arrayState: [Element]
-    @UniqueElements var identifiedArrayState: IdentifiedArrayOf<Element>
- }
- ```
-
- Everytime we set arrayState or identifiedArrayState, it will automatically remove all duplicates, making them having only unique elements.
- Using this property wrapper will help reduce data disrepancy between the source of data and components that use them
- */
+/// Property wrapper to reduce boiler plate code to remove duplicates from a collection of HashDiffable.
+///
+/// ```
+/// struct Element: Equatable, HashDiffable {}
+///
+/// struct ParentState: Equatable {
+///    @UniqueElements var arrayState: [Element]
+///    @UniqueElements var identifiedArrayState: IdentifiedArrayOf<Element>
+/// }
+/// ```
+///
+/// Everytime we set arrayState or identifiedArrayState, it will automatically remove all duplicates, making them having only unique elements.
+/// Using this property wrapper will help reduce data disrepancy between the source of data and components that use them
 
 @propertyWrapper
-public struct UniqueElements<State>: Equatable where State: Collection & Equatable, State.Element: HashDiffable {
+public struct UniqueElements<State>: Equatable
+where State: Collection & Equatable, State.Element: HashDiffable {
     public var wrappedValue: State {
         didSet {
             wrappedValue = Self.getUniqueState(wrappedValue)

--- a/Sources/RxComposableArchitecture/Reducer.swift
+++ b/Sources/RxComposableArchitecture/Reducer.swift
@@ -82,9 +82,10 @@ public struct Reducer<State, Action, Environment> {
         action toLocalAction: ActionPath,
         environment toLocalEnvironment: @escaping (GlobalEnvironment) -> Environment
     ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment>
-        where
+    where
         StatePath: WritablePath, StatePath.Root == GlobalState, StatePath.Value == State,
-        ActionPath: WritablePath, ActionPath.Root == GlobalAction, ActionPath.Value == Action {
+        ActionPath: WritablePath, ActionPath.Root == GlobalAction, ActionPath.Value == Action
+    {
         return .init { globalState, globalAction, globalEnvironment in
             guard
                 var localState = toLocalState.extract(from: globalState),
@@ -92,12 +93,12 @@ public struct Reducer<State, Action, Environment> {
             else { return .none }
             let effect =
                 self
-                    .reducer(&localState, localAction, toLocalEnvironment(globalEnvironment))
-                    .map { localAction -> GlobalAction in
-                        var globalAction = globalAction
-                        toLocalAction.set(into: &globalAction, localAction)
-                        return globalAction
-                    }
+                .reducer(&localState, localAction, toLocalEnvironment(globalEnvironment))
+                .map { localAction -> GlobalAction in
+                    var globalAction = globalAction
+                    toLocalAction.set(into: &globalAction, localAction)
+                    return globalAction
+                }
             toLocalState.set(into: &globalState, localState)
             return effect
         }
@@ -301,7 +302,9 @@ public struct Reducer<State, Action, Environment> {
         _ line: UInt = #line
     ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
         .init { globalState, globalAction, globalEnvironment in
-            guard let (key, localAction) = toLocalAction.extract(from: globalAction) else { return .none }
+            guard let (key, localAction) = toLocalAction.extract(from: globalAction) else {
+                return .none
+            }
             if globalState[keyPath: toLocalState][key] == nil {
                 #if DEBUG
                     if breakpointOnNil {
@@ -393,7 +396,9 @@ public struct Reducer<State, Action, Environment> {
         _ line: UInt = #line
     ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
         .init { globalState, globalAction, globalEnvironment in
-            guard let (id, localAction) = toLocalAction.extract(from: globalAction) else { return .none }
+            guard let (id, localAction) = toLocalAction.extract(from: globalAction) else {
+                return .none
+            }
             if globalState[keyPath: toLocalState][id: id] == nil {
                 #if DEBUG
                     if breakpointOnNil {
@@ -433,12 +438,12 @@ public struct Reducer<State, Action, Environment> {
             }
             return
                 self
-                    .reducer(
-                        &globalState[keyPath: toLocalState][id: id]!,
-                        localAction,
-                        toLocalEnvironment(globalEnvironment)
-                    )
-                    .map { toLocalAction.embed((id, $0)) }
+                .reducer(
+                    &globalState[keyPath: toLocalState][id: id]!,
+                    localAction,
+                    toLocalEnvironment(globalEnvironment)
+                )
+                .map { toLocalAction.embed((id, $0)) }
         }
     }
 
@@ -460,7 +465,8 @@ public struct Reducer<State, Action, Environment> {
         _ environment: Environment
     ) -> Effect<Action> {
         #if DEBUG
-            reducer(&state, action, Bootstrap.get(environment: type(of: environment)) ?? environment)
+            reducer(
+                &state, action, Bootstrap.get(environment: type(of: environment)) ?? environment)
         #else
             reducer(&state, action, environment)
         #endif

--- a/Sources/RxComposableArchitecture/Store.swift
+++ b/Sources/RxComposableArchitecture/Store.swift
@@ -13,17 +13,17 @@ public final class Store<State, Action> {
     private var bufferedActions: [Action] = []
 
     private let reducer: (inout State, Action) -> Effect<Action>
-    
+
     internal let disposeBag = DisposeBag()
     internal var effectDisposables = CompositeDisposable()
     internal let relay: BehaviorRelay<State>
-    
+
     private let useNewScope: Bool
     fileprivate let cancelsEffectsOnDeinit: Bool
     fileprivate var scope: AnyScope?
-    
+
     #if DEBUG
-    private let mainThreadChecksEnabled: Bool
+        private let mainThreadChecksEnabled: Bool
     #endif
 
     public var observable: Observable<State> {
@@ -42,25 +42,25 @@ public final class Store<State, Action> {
         self.reducer = { state, action in reducer.run(&state, action, environment) }
         self.useNewScope = useNewScope
         self.cancelsEffectsOnDeinit = cancelsEffectsOnDeinit
-        
+
         #if DEBUG
-        self.mainThreadChecksEnabled = mainThreadChecksEnabled
+            self.mainThreadChecksEnabled = mainThreadChecksEnabled
         #endif
-        
+
         state = initialState
-        
+
         self.threadCheck(status: .`init`)
-        
+
         if cancelsEffectsOnDeinit {
             // ties the disposables to the lifetime of the dispose bag for cleanup.
             effectDisposables.disposed(by: disposeBag)
         }
     }
-    
+
     private func newSend(_ action: Action, originatingFrom originatingAction: Action? = nil) {
         bufferedActions.append(action)
         guard !isSending else { return }
-        
+
         isSending = true
         var currentState = state
         defer {
@@ -70,10 +70,10 @@ public final class Store<State, Action> {
         while !bufferedActions.isEmpty {
             let action = bufferedActions.removeFirst()
             let effect = reducer(&currentState, action)
-            
+
             var didComplete = false
             var disposeKey: CompositeDisposable.DisposeKey?
-            
+
             let effectDisposable = effect.subscribe(
                 onNext: { [weak self] effectAction in
                     self?.send(effectAction, originatingFrom: action)
@@ -89,13 +89,13 @@ public final class Store<State, Action> {
                     }
                 }
             )
-            
+
             if !didComplete {
                 disposeKey = effectDisposables.insert(effectDisposable)
             }
         }
     }
-    
+
     public func send(_ action: Action, originatingFrom originatingAction: Action? = nil) {
         self.threadCheck(status: .send(action, originatingAction: originatingAction))
         guard !useNewScope else {
@@ -110,7 +110,8 @@ public final class Store<State, Action> {
         }
 
         while !synchronousActionsToSend.isEmpty || !bufferedActions.isEmpty {
-            let action = !synchronousActionsToSend.isEmpty
+            let action =
+                !synchronousActionsToSend.isEmpty
                 ? synchronousActionsToSend.removeFirst()
                 : bufferedActions.removeFirst()
 
@@ -155,7 +156,8 @@ public final class Store<State, Action> {
     ) -> Store<LocalState, LocalAction> {
         self.threadCheck(status: .scope)
         if useNewScope {
-            return (self.scope ?? Scope(root: self)).rescope(self, state: toLocalState, action: fromLocalAction)
+            return (self.scope ?? Scope(root: self)).rescope(
+                self, state: toLocalState, action: fromLocalAction)
         } else {
             let localStore = Store<LocalState, LocalAction>(
                 initialState: toLocalState(state),
@@ -196,7 +198,7 @@ public final class Store<State, Action> {
         func absurd<A>(_: Never) -> A {}
         return scope(state: { $0 }, action: absurd)
     }
-    
+
     private enum ThreadCheckStatus {
         case effectCompletion(Action)
         case `init`
@@ -206,98 +208,98 @@ public final class Store<State, Action> {
 
     @inline(__always)
     private func threadCheck(status: ThreadCheckStatus) {
-      #if DEBUG
-        guard self.mainThreadChecksEnabled && !Thread.isMainThread
-        else { return }
-        
-        switch status {
-        case let .effectCompletion(action):
-            runtimeWarning(
-            """
-            An effect completed on a non-main thread. …
-            
-              Effect returned from:
-                %@
-            
-            Make sure to use ".receive(on:)" on any effects that execute on background threads to \
-            receive their output on the main thread, or create your store via "Store.unchecked" to \
-            opt out of the main thread checker.
-            
-            The "Store" class is not thread-safe, and so all interactions with an instance of \
-            "Store" (including all of its scopes and derived view stores) must be done on the same \
-            thread.
-            """,
-            [debugCaseOutput(action)]
-            )
-            
-        case .`init`:
-            runtimeWarning(
-            """
-            A store initialized on a non-main thread. …
-            
-            If a store is intended to be used on a background thread, create it via \
-            "Store.unchecked" to opt out of the main thread checker.
-            
-            The "Store" class is not thread-safe, and so all interactions with an instance of \
-            "Store" (including all of its scopes and derived view stores) must be done on the same \
-            thread.
-            """
-            )
-            
-        case .scope:
-            runtimeWarning(
-            """
-            "Store.scope" was called on a non-main thread. …
-            
-            Make sure to use "Store.scope" on the main thread, or create your store via \
-            "Store.unchecked" to opt out of the main thread checker.
-            
-            The "Store" class is not thread-safe, and so all interactions with an instance of \
-            "Store" (including all of its scopes and derived view stores) must be done on the same \
-            thread.
-            """
-            )
-            
-        case let .send(action, originatingAction: nil):
-            runtimeWarning(
-            """
-            "Store.send" was called on a non-main thread with: %@ …
-            
-            Make sure that "store.send" is always called on the main thread, or create your \
-            store via "Store.unchecked" to opt out of the main thread checker.
-            
-            The "Store" class is not thread-safe, and so all interactions with an instance of \
-            "Store" (including all of its scopes and derived view stores) must be done on the same \
-            thread.
-            """,
-            [debugCaseOutput(action)]
-            )
-            
-        case let .send(action, originatingAction: .some(originatingAction)):
-            runtimeWarning(
-            """
-            An effect published an action on a non-main thread. …
-            
-              Effect published:
-                %@
-            
-              Effect returned from:
-                %@
-            
-            Make sure to use ".receive(on:)" on any effects that execute on background threads to \
-            receive their output on the main thread, or create this store via "Store.unchecked" to \
-            disable the main thread checker.
-            
-            The "Store" class is not thread-safe, and so all interactions with an instance of \
-            "Store" (including all of its scopes and derived view stores) must be done on the same \
-            thread.
-            """,
-            [
-                debugCaseOutput(action),
-                debugCaseOutput(originatingAction),
-            ])
-        }
-      #endif
+        #if DEBUG
+            guard self.mainThreadChecksEnabled && !Thread.isMainThread
+            else { return }
+
+            switch status {
+            case let .effectCompletion(action):
+                runtimeWarning(
+                    """
+                    An effect completed on a non-main thread. …
+
+                      Effect returned from:
+                        %@
+
+                    Make sure to use ".receive(on:)" on any effects that execute on background threads to \
+                    receive their output on the main thread, or create your store via "Store.unchecked" to \
+                    opt out of the main thread checker.
+
+                    The "Store" class is not thread-safe, and so all interactions with an instance of \
+                    "Store" (including all of its scopes and derived view stores) must be done on the same \
+                    thread.
+                    """,
+                    [debugCaseOutput(action)]
+                )
+
+            case .`init`:
+                runtimeWarning(
+                    """
+                    A store initialized on a non-main thread. …
+
+                    If a store is intended to be used on a background thread, create it via \
+                    "Store.unchecked" to opt out of the main thread checker.
+
+                    The "Store" class is not thread-safe, and so all interactions with an instance of \
+                    "Store" (including all of its scopes and derived view stores) must be done on the same \
+                    thread.
+                    """
+                )
+
+            case .scope:
+                runtimeWarning(
+                    """
+                    "Store.scope" was called on a non-main thread. …
+
+                    Make sure to use "Store.scope" on the main thread, or create your store via \
+                    "Store.unchecked" to opt out of the main thread checker.
+
+                    The "Store" class is not thread-safe, and so all interactions with an instance of \
+                    "Store" (including all of its scopes and derived view stores) must be done on the same \
+                    thread.
+                    """
+                )
+
+            case let .send(action, originatingAction: nil):
+                runtimeWarning(
+                    """
+                    "Store.send" was called on a non-main thread with: %@ …
+
+                    Make sure that "store.send" is always called on the main thread, or create your \
+                    store via "Store.unchecked" to opt out of the main thread checker.
+
+                    The "Store" class is not thread-safe, and so all interactions with an instance of \
+                    "Store" (including all of its scopes and derived view stores) must be done on the same \
+                    thread.
+                    """,
+                    [debugCaseOutput(action)]
+                )
+
+            case let .send(action, originatingAction: .some(originatingAction)):
+                runtimeWarning(
+                    """
+                    An effect published an action on a non-main thread. …
+
+                      Effect published:
+                        %@
+
+                      Effect returned from:
+                        %@
+
+                    Make sure to use ".receive(on:)" on any effects that execute on background threads to \
+                    receive their output on the main thread, or create this store via "Store.unchecked" to \
+                    disable the main thread checker.
+
+                    The "Store" class is not thread-safe, and so all interactions with an instance of \
+                    "Store" (including all of its scopes and derived view stores) must be done on the same \
+                    thread.
+                    """,
+                    [
+                        debugCaseOutput(action),
+                        debugCaseOutput(originatingAction),
+                    ])
+            }
+        #endif
     }
 
     public func subscribe<LocalState>(
@@ -322,12 +324,12 @@ extension Store {
             .map(\.wrappedValue)
             .eraseToEffect()
     }
-    
+
     fileprivate var isMainThreadChecksEnabled: Bool {
         #if DEBUG
-        return mainThreadChecksEnabled
+            return mainThreadChecksEnabled
         #else
-        return false
+            return false
         #endif
     }
 }
@@ -338,7 +340,8 @@ extension Store where State: Equatable {
     }
 }
 
-extension Store where State: Collection, State.Element: HashDiffable, State: Equatable, State.Element: Equatable {
+extension Store
+where State: Collection, State.Element: HashDiffable, State: Equatable, State.Element: Equatable {
     /**
      A version of scope that scope an collection of sub store.
 
@@ -375,7 +378,8 @@ extension Store where State: Collection, State.Element: HashDiffable, State: Equ
         action fromLocalAction: @escaping (LocalAction) -> Action
     ) -> Store<State.Element, LocalAction>? {
         self.threadCheck(status: .scope)
-        let toLocalState: (State.Element.IdentifierType, State) -> State.Element? = { identifier, state in
+        let toLocalState: (State.Element.IdentifierType, State) -> State.Element? = {
+            identifier, state in
             /**
              if current state is IdentifiedArray, use pre exist subscript by identifier, to improve performance
              */
@@ -406,7 +410,7 @@ extension Store where State: Collection, State.Element: HashDiffable, State: Equ
                 mainThreadChecksEnabled: isMainThreadChecksEnabled,
                 cancelsEffectsOnDeinit: cancelsEffectsOnDeinit
             )
-            
+
             relay
                 .skip(1)
                 .subscribe(onNext: { [weak localStore] newValue in
@@ -415,7 +419,7 @@ extension Store where State: Collection, State.Element: HashDiffable, State: Equ
                     localStore?.state = element
                 })
                 .disposed(by: localStore.disposeBag)
-            
+
             return localStore
         } else {
             // skip if element on parent state wasn't found
@@ -469,11 +473,11 @@ private protocol AnyScope {
 private struct Scope<RootState, RootAction>: AnyScope {
     let root: Store<RootState, RootAction>
     let fromScopedAction: Any
-    
+
     init(root: Store<RootState, RootAction>) {
         self.init(root: root, fromScopedAction: { $0 })
     }
-    
+
     private init<ScopedAction>(
         root: Store<RootState, RootAction>,
         fromScopedAction: @escaping (ScopedAction) -> RootAction
@@ -481,14 +485,14 @@ private struct Scope<RootState, RootAction>: AnyScope {
         self.root = root
         self.fromScopedAction = fromScopedAction
     }
-    
+
     func rescope<ScopedState, ScopedAction, RescopedState, RescopedAction>(
         _ scopedStore: Store<ScopedState, ScopedAction>,
         state toRescopedState: @escaping (ScopedState) -> RescopedState,
         action fromRescopedAction: @escaping (RescopedAction) -> ScopedAction
     ) -> Store<RescopedState, RescopedAction> {
         let fromScopedAction = self.fromScopedAction as! (ScopedAction) -> RootAction
-        
+
         var isSending = false
         let rescopedStore = Store<RescopedState, RescopedAction>(
             initialState: toRescopedState(scopedStore.state),
@@ -504,7 +508,7 @@ private struct Scope<RootState, RootAction>: AnyScope {
             mainThreadChecksEnabled: root.isMainThreadChecksEnabled,
             cancelsEffectsOnDeinit: root.cancelsEffectsOnDeinit
         )
-        
+
         scopedStore.relay
             .skip(1)
             .subscribe(onNext: { [weak rescopedStore] newValue in
@@ -512,7 +516,7 @@ private struct Scope<RootState, RootAction>: AnyScope {
                 rescopedStore?.relay.accept(toRescopedState(newValue))
             })
             .disposed(by: rescopedStore.disposeBag)
-        
+
         rescopedStore.scope = Scope<RootState, RootAction>(
             root: self.root,
             fromScopedAction: { fromScopedAction(fromRescopedAction($0)) }
@@ -525,7 +529,7 @@ public struct StoreConfig {
     public var useNewScope: () -> Bool
     public var mainThreadChecksEnabled: () -> Bool
     public var cancelsEffectsOnDeinit: () -> Bool
-    
+
     public init(
         useNewScope: @escaping () -> Bool,
         mainThreadChecksEnabled: @escaping () -> Bool,

--- a/Sources/RxComposableArchitecture/TestSupport/Effect+Failing.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/Effect+Failing.swift
@@ -1,88 +1,88 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by jefferson.setiawan on 03/06/22.
 //
 
 #if DEBUG
-extension Effect {
-    /// An effect that causes a test to fail if it runs.
-    ///
-    /// This effect can provide an additional layer of certainty that a tested code path does not
-    /// execute a particular effect.
-    ///
-    /// For example, let's say we have a very simple counter application, where a user can increment
-    /// and decrement a number. The state and actions are simple enough:
-    ///
-    ///     struct CounterState: Equatable {
-    ///       var count = 0
-    ///     }
-    ///
-    ///     enum CounterAction: Equatable {
-    ///       case decrementButtonTapped
-    ///       case incrementButtonTapped
-    ///     }
-    ///
-    /// Let's throw in a side effect. If the user attempts to decrement the counter below zero, the
-    /// application should refuse and play an alert sound instead.
-    ///
-    /// We can model playing a sound in the environment with an effect:
-    ///
-    ///     struct CounterEnvironment {
-    ///       let playAlertSound: () -> Effect<Never, Never>
-    ///     }
-    ///
-    /// Now that we've defined the domain, we can describe the logic in a reducer:
-    ///
-    ///     let counterReducer = Reducer<
-    ///       CounterState, CounterAction, CounterEnvironment
-    ///     > { state, action, environment in
-    ///       switch action {
-    ///       case .decrementButtonTapped:
-    ///         if state > 0 {
-    ///           state.count -= 0
-    ///           return .none
-    ///         } else {
-    ///           return environment.playAlertSound()
-    ///             .fireAndForget()
-    ///         }
-    ///
-    ///       case .incrementButtonTapped:
-    ///         state.count += 1
-    ///         return .non
-    ///       }
-    ///     }
-    ///
-    /// Let's say we want to write a test for the increment path. We can see in the reducer that it
-    /// should never play an alert, so we can configure the environment with an effect that will
-    /// fail if it ever executes:
-    ///
-    ///     func testIncrement() {
-    ///       let store = TestStore(
-    ///         initialState: CounterState(count: 0)
-    ///         reducer: counterReducer,
-    ///         environment: CounterEnvironment(
-    ///           playSound: .failing("playSound")
-    ///         )
-    ///       )
-    ///
-    ///       store.send(.increment) {
-    ///         $0.count = 1
-    ///       }
-    ///     }
-    ///
-    /// By using a `.failing` effect in our environment we have strengthened the assertion and made
-    /// the test easier to understand at the same time. We can see, without consulting the reducer
-    /// itself, that this particular action should not access this effect.
-    ///
-    /// - Parameter prefix: A string that identifies this scheduler and will prefix all failure
-    ///   messages.
-    /// - Returns: An effect that causes a test to fail if it runs.
-    public static func failing(_ prefix: String) -> Effect<Output> {
-        .fireAndForget {
-            XCTFail("\(prefix.isEmpty ? "" : "\(prefix) - ")A failing effect ran.")
+    extension Effect {
+        /// An effect that causes a test to fail if it runs.
+        ///
+        /// This effect can provide an additional layer of certainty that a tested code path does not
+        /// execute a particular effect.
+        ///
+        /// For example, let's say we have a very simple counter application, where a user can increment
+        /// and decrement a number. The state and actions are simple enough:
+        ///
+        ///     struct CounterState: Equatable {
+        ///       var count = 0
+        ///     }
+        ///
+        ///     enum CounterAction: Equatable {
+        ///       case decrementButtonTapped
+        ///       case incrementButtonTapped
+        ///     }
+        ///
+        /// Let's throw in a side effect. If the user attempts to decrement the counter below zero, the
+        /// application should refuse and play an alert sound instead.
+        ///
+        /// We can model playing a sound in the environment with an effect:
+        ///
+        ///     struct CounterEnvironment {
+        ///       let playAlertSound: () -> Effect<Never, Never>
+        ///     }
+        ///
+        /// Now that we've defined the domain, we can describe the logic in a reducer:
+        ///
+        ///     let counterReducer = Reducer<
+        ///       CounterState, CounterAction, CounterEnvironment
+        ///     > { state, action, environment in
+        ///       switch action {
+        ///       case .decrementButtonTapped:
+        ///         if state > 0 {
+        ///           state.count -= 0
+        ///           return .none
+        ///         } else {
+        ///           return environment.playAlertSound()
+        ///             .fireAndForget()
+        ///         }
+        ///
+        ///       case .incrementButtonTapped:
+        ///         state.count += 1
+        ///         return .non
+        ///       }
+        ///     }
+        ///
+        /// Let's say we want to write a test for the increment path. We can see in the reducer that it
+        /// should never play an alert, so we can configure the environment with an effect that will
+        /// fail if it ever executes:
+        ///
+        ///     func testIncrement() {
+        ///       let store = TestStore(
+        ///         initialState: CounterState(count: 0)
+        ///         reducer: counterReducer,
+        ///         environment: CounterEnvironment(
+        ///           playSound: .failing("playSound")
+        ///         )
+        ///       )
+        ///
+        ///       store.send(.increment) {
+        ///         $0.count = 1
+        ///       }
+        ///     }
+        ///
+        /// By using a `.failing` effect in our environment we have strengthened the assertion and made
+        /// the test easier to understand at the same time. We can see, without consulting the reducer
+        /// itself, that this particular action should not access this effect.
+        ///
+        /// - Parameter prefix: A string that identifies this scheduler and will prefix all failure
+        ///   messages.
+        /// - Returns: An effect that causes a test to fail if it runs.
+        public static func failing(_ prefix: String) -> Effect<Output> {
+            .fireAndForget {
+                XCTFail("\(prefix.isEmpty ? "" : "\(prefix) - ")A failing effect ran.")
+            }
         }
     }
-}
 #endif

--- a/Sources/RxComposableArchitecture/TestSupport/PriorityQueue.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/PriorityQueue.swift
@@ -7,112 +7,121 @@
 //
 
 #if DEBUG
-import Foundation
+    import Foundation
 
-// this is a copy pasted code, so don't wanna bother much with linting
-// swiftlint:disable explicit_acl
-struct PriorityQueue<Element> {
-    private let _hasHigherPriority: (Element, Element) -> Bool
-    private let _isEqual: (Element, Element) -> Bool
+    // this is a copy pasted code, so don't wanna bother much with linting
+    // swiftlint:disable explicit_acl
+    struct PriorityQueue<Element> {
+        private let _hasHigherPriority: (Element, Element) -> Bool
+        private let _isEqual: (Element, Element) -> Bool
 
-    private var _elements = [Element]()
+        private var _elements = [Element]()
 
-    init(hasHigherPriority: @escaping (Element, Element) -> Bool, isEqual: @escaping (Element, Element) -> Bool) {
-        _hasHigherPriority = hasHigherPriority
-        _isEqual = isEqual
-    }
-
-    mutating func enqueue(_ element: Element) {
-        _elements.append(element)
-        bubbleToHigherPriority(_elements.count - 1)
-    }
-
-    func peek() -> Element? {
-        return _elements.first
-    }
-
-    var isEmpty: Bool {
-        return _elements.count == 0
-    }
-
-    mutating func dequeue() -> Element? {
-        guard let front = peek() else {
-            return nil
+        init(
+            hasHigherPriority: @escaping (Element, Element) -> Bool,
+            isEqual: @escaping (Element, Element) -> Bool
+        ) {
+            _hasHigherPriority = hasHigherPriority
+            _isEqual = isEqual
         }
 
-        removeAt(0)
+        mutating func enqueue(_ element: Element) {
+            _elements.append(element)
+            bubbleToHigherPriority(_elements.count - 1)
+        }
 
-        return front
-    }
+        func peek() -> Element? {
+            return _elements.first
+        }
 
-    mutating func remove(_ element: Element) {
-        for i in 0 ..< _elements.count {
-            if _isEqual(_elements[i], element) {
-                removeAt(i)
-                return
+        var isEmpty: Bool {
+            return _elements.count == 0
+        }
+
+        mutating func dequeue() -> Element? {
+            guard let front = peek() else {
+                return nil
+            }
+
+            removeAt(0)
+
+            return front
+        }
+
+        mutating func remove(_ element: Element) {
+            for i in 0..<_elements.count {
+                if _isEqual(_elements[i], element) {
+                    removeAt(i)
+                    return
+                }
+            }
+        }
+
+        private mutating func removeAt(_ index: Int) {
+            let removingLast = index == _elements.count - 1
+            if !removingLast {
+                _elements.swapAt(index, _elements.count - 1)
+            }
+
+            _ = _elements.popLast()
+
+            if !removingLast {
+                bubbleToHigherPriority(index)
+                bubbleToLowerPriority(index)
+            }
+        }
+
+        private mutating func bubbleToHigherPriority(_ initialUnbalancedIndex: Int) {
+            precondition(initialUnbalancedIndex >= 0)
+            precondition(initialUnbalancedIndex < _elements.count)
+
+            var unbalancedIndex = initialUnbalancedIndex
+
+            while unbalancedIndex > 0 {
+                let parentIndex = (unbalancedIndex - 1) / 2
+                guard _hasHigherPriority(_elements[unbalancedIndex], _elements[parentIndex]) else {
+                    break
+                }
+                _elements.swapAt(unbalancedIndex, parentIndex)
+                unbalancedIndex = parentIndex
+            }
+        }
+
+        private mutating func bubbleToLowerPriority(_ initialUnbalancedIndex: Int) {
+            precondition(initialUnbalancedIndex >= 0)
+            precondition(initialUnbalancedIndex < _elements.count)
+
+            var unbalancedIndex = initialUnbalancedIndex
+            while true {
+                let leftChildIndex = unbalancedIndex * 2 + 1
+                let rightChildIndex = unbalancedIndex * 2 + 2
+
+                var highestPriorityIndex = unbalancedIndex
+
+                if leftChildIndex < _elements.count,
+                    _hasHigherPriority(_elements[leftChildIndex], _elements[highestPriorityIndex])
+                {
+                    highestPriorityIndex = leftChildIndex
+                }
+
+                if rightChildIndex < _elements.count,
+                    _hasHigherPriority(_elements[rightChildIndex], _elements[highestPriorityIndex])
+                {
+                    highestPriorityIndex = rightChildIndex
+                }
+
+                guard highestPriorityIndex != unbalancedIndex else { break }
+                _elements.swapAt(highestPriorityIndex, unbalancedIndex)
+
+                unbalancedIndex = highestPriorityIndex
             }
         }
     }
 
-    private mutating func removeAt(_ index: Int) {
-        let removingLast = index == _elements.count - 1
-        if !removingLast {
-            _elements.swapAt(index, _elements.count - 1)
-        }
-
-        _ = _elements.popLast()
-
-        if !removingLast {
-            bubbleToHigherPriority(index)
-            bubbleToLowerPriority(index)
+    extension PriorityQueue: CustomDebugStringConvertible {
+        var debugDescription: String {
+            return _elements.debugDescription
         }
     }
-
-    private mutating func bubbleToHigherPriority(_ initialUnbalancedIndex: Int) {
-        precondition(initialUnbalancedIndex >= 0)
-        precondition(initialUnbalancedIndex < _elements.count)
-
-        var unbalancedIndex = initialUnbalancedIndex
-
-        while unbalancedIndex > 0 {
-            let parentIndex = (unbalancedIndex - 1) / 2
-            guard _hasHigherPriority(_elements[unbalancedIndex], _elements[parentIndex]) else { break }
-            _elements.swapAt(unbalancedIndex, parentIndex)
-            unbalancedIndex = parentIndex
-        }
-    }
-
-    private mutating func bubbleToLowerPriority(_ initialUnbalancedIndex: Int) {
-        precondition(initialUnbalancedIndex >= 0)
-        precondition(initialUnbalancedIndex < _elements.count)
-
-        var unbalancedIndex = initialUnbalancedIndex
-        while true {
-            let leftChildIndex = unbalancedIndex * 2 + 1
-            let rightChildIndex = unbalancedIndex * 2 + 2
-
-            var highestPriorityIndex = unbalancedIndex
-
-            if leftChildIndex < _elements.count, _hasHigherPriority(_elements[leftChildIndex], _elements[highestPriorityIndex]) {
-                highestPriorityIndex = leftChildIndex
-            }
-
-            if rightChildIndex < _elements.count, _hasHigherPriority(_elements[rightChildIndex], _elements[highestPriorityIndex]) {
-                highestPriorityIndex = rightChildIndex
-            }
-
-            guard highestPriorityIndex != unbalancedIndex else { break }
-            _elements.swapAt(highestPriorityIndex, unbalancedIndex)
-
-            unbalancedIndex = highestPriorityIndex
-        }
-    }
-}
-
-extension PriorityQueue: CustomDebugStringConvertible {
-    var debugDescription: String {
-        return _elements.debugDescription
-    }
-}
 
 #endif

--- a/Sources/RxComposableArchitecture/TestSupport/TestScheduler.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/TestScheduler.swift
@@ -23,56 +23,62 @@ extension DispatchTimeInterval {
 
     internal var convertToSecondsInterval: Double {
         switch self {
-        case let .microseconds(value), let .milliseconds(value), let .seconds(value), let .nanoseconds(value): return Double(value) / convertToSecondsFactor
+        case let .microseconds(value), let .milliseconds(value), let .seconds(value),
+            let .nanoseconds(value):
+            return Double(value) / convertToSecondsFactor
         default: fatalError("Unsupported DispatchTimeInterval value: \(self)")
         }
     }
 }
 
 #if DEBUG
-public struct TestSchedulerVirtualTimeConverter: VirtualTimeConverterType {
-    public typealias VirtualTimeUnit = Double
+    public struct TestSchedulerVirtualTimeConverter: VirtualTimeConverterType {
+        public typealias VirtualTimeUnit = Double
 
-    public typealias VirtualTimeIntervalUnit = DispatchTimeInterval
+        public typealias VirtualTimeIntervalUnit = DispatchTimeInterval
 
-    public func convertFromVirtualTime(_ virtualTime: Double) -> RxTime {
-        Date(timeIntervalSince1970: virtualTime)
-    }
+        public func convertFromVirtualTime(_ virtualTime: Double) -> RxTime {
+            Date(timeIntervalSince1970: virtualTime)
+        }
 
-    public func convertToVirtualTime(_ time: RxTime) -> Double {
-        time.timeIntervalSince1970
-    }
+        public func convertToVirtualTime(_ time: RxTime) -> Double {
+            time.timeIntervalSince1970
+        }
 
-    public func convertFromVirtualTimeInterval(_ virtualTimeInterval: DispatchTimeInterval) -> TimeInterval {
-        virtualTimeInterval.convertToSecondsInterval
-    }
+        public func convertFromVirtualTimeInterval(_ virtualTimeInterval: DispatchTimeInterval)
+            -> TimeInterval
+        {
+            virtualTimeInterval.convertToSecondsInterval
+        }
 
-    public func convertToVirtualTimeInterval(_ timeInterval: TimeInterval) -> DispatchTimeInterval {
-        .nanoseconds(Int(timeInterval * 1_000_000_000))
-    }
+        public func convertToVirtualTimeInterval(_ timeInterval: TimeInterval)
+            -> DispatchTimeInterval
+        {
+            .nanoseconds(Int(timeInterval * 1_000_000_000))
+        }
 
-    public func offsetVirtualTime(_ time: Double, offset: DispatchTimeInterval) -> Double {
-        return time + offset.convertToSecondsInterval
-    }
+        public func offsetVirtualTime(_ time: Double, offset: DispatchTimeInterval) -> Double {
+            return time + offset.convertToSecondsInterval
+        }
 
-    public func compareVirtualTime(_ lhs: Double, _ rhs: Double) -> VirtualTimeComparison {
-        if lhs < rhs {
-            return .lessThan
-        } else if lhs > rhs {
-            return .greaterThan
-        } else {
-            return .equal
+        public func compareVirtualTime(_ lhs: Double, _ rhs: Double) -> VirtualTimeComparison {
+            if lhs < rhs {
+                return .lessThan
+            } else if lhs > rhs {
+                return .greaterThan
+            } else {
+                return .equal
+            }
         }
     }
-}
 
-public class TestScheduler: _VirtualTimeScheduler<TestSchedulerVirtualTimeConverter> {
-    public init(initialClock: Double) {
-        super.init(initialClock: initialClock, converter: TestSchedulerVirtualTimeConverter())
+    public class TestScheduler: _VirtualTimeScheduler<TestSchedulerVirtualTimeConverter> {
+        public init(initialClock: Double) {
+            super.init(initialClock: initialClock, converter: TestSchedulerVirtualTimeConverter())
+        }
+
+        public func advance() {
+            advance(by: .nanoseconds(1))
+        }
     }
-    
-    public func advance() {
-        advance(by: .nanoseconds(1))
-    }
-}
 #endif

--- a/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
@@ -1,761 +1,768 @@
 #if DEBUG
-import Foundation
-import RxSwift
+    import Foundation
+    import RxSwift
 
-/// A testable runtime for a reducer.
-///
-/// This object aids in writing expressive and exhaustive tests for features built in the
-/// Composable Architecture. It allows you to send a sequence of actions to the store, and each
-/// step of the way you must assert exactly how state changed, and how effect emissions were fed
-/// back into the system.
-///
-/// There are multiple ways the test store forces you to exhaustively assert on how your feature
-/// behaves:
-///
-///   * After each action is sent you must describe precisely how the state changed from before
-///     the action was sent to after it was sent.
-///
-///     If even the smallest piece of data differs the test will fail. This guarantees that you
-///     are proving you know precisely how the state of the system changes.
-///
-///   * Sending an action can sometimes cause an effect to be executed, and if that effect emits
-///     an action that is fed back into the system, you **must** explicitly assert that you expect
-///     to receive that action from the effect, _and_ you must assert how state changed as a
-///     result.
-///
-///     If you try to send another action before you have handled all effect emissions the
-///     assertion will fail. This guarantees that you do not accidentally forget about an effect
-///     emission, and that the sequence of steps you are describing will mimic how the application
-///     behaves in reality.
-///
-///   * All effects must complete by the time the assertion has finished running the steps you
-///     specify.
-///
-///     If at the end of the assertion there is still an in-flight effect running, the assertion
-///     will fail. This helps exhaustively prove that you know what effects are in flight and
-///     forces you to prove that effects will not cause any future changes to your state.
-///
-/// For example, given a simple counter reducer:
-///
-///     struct CounterState {
-///       var count = 0
-///     }
-///
-///     enum CounterAction: Equatable {
-///       case decrementButtonTapped
-///       case incrementButtonTapped
-///     }
-///
-///     let counterReducer = Reducer<CounterState, CounterAction, Void> { state, action, _ in
-///       switch action {
-///       case .decrementButtonTapped:
-///         state.count -= 1
-///         return .none
-///
-///       case .incrementButtonTapped:
-///         state.count += 1
-///         return .none
-///       }
-///     }
-///
-/// One can assert against its behavior over time:
-///
-///     class CounterTests: XCTestCase {
-///       func testCounter() {
-///         let store = TestStore(
-///           initialState: .init(count: 0),     // GIVEN counter state of 0
-///           reducer: counterReducer,
-///           environment: ()
-///         )
-///         store.send(.incrementButtonTapped) { // WHEN the increment button is tapped
-///           $0.count = 1                       // THEN the count should be 1
-///         }
-///       }
-///     }
-///
-/// Note that in the trailing closure of `.send(.incrementButtonTapped)` we are given a single
-/// mutable value of the state before the action was sent, and it is our job to mutate the value
-/// to match the state after the action was sent. In this case the `count` field changes to `1`.
-///
-/// For a more complex example, consider the following bare-bones search feature that uses the
-/// `.debounce` operator to wait for the user to stop typing before making a network request:
-///
-///     struct SearchState: Equatable {
-///       var query = ""
-///       var results: [String] = []
-///     }
-///
-///     enum SearchAction: Equatable {
-///       case queryChanged(String)
-///       case response([String])
-///     }
-///
-///     struct SearchEnvironment {
-///       var mainQueue: AnySchedulerOf<DispatchQueue>
-///       var request: (String) -> Effect<[String], Never>
-///     }
-///
-///     let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
-///       state, action, environment in
-///
-///         enum SearchId {}
-///
-///         switch action {
-///         case let .queryChanged(query):
-///           state.query = query
-///           return environment.request(self.query)
-///             .debounce(id: SearchId.self, for: 0.5, scheduler: environment.mainQueue)
-///
-///         case let .response(results):
-///           state.results = results
-///           return .none
-///         }
-///     }
-///
-/// It can be fully tested by controlling the environment's scheduler and effect:
-///
-///     // Create a test dispatch scheduler to control the timing of effects
-///     let scheduler = DispatchQueue.testScheduler
-///
-///     let store = TestStore(
-///       initialState: SearchState(),
-///       reducer: searchReducer,
-///       environment: SearchEnvironment(
-///         // Wrap the test scheduler in a type-erased scheduler
-///         mainQueue: scheduler.eraseToAnyScheduler(),
-///         // Simulate a search response with one item
-///         request: { _ in Effect(value: ["Composable Architecture"]) }
-///       )
-///     )
-///
-///     // Change the query
-///     store.send(.searchFieldChanged("c") {
-///       // Assert that state updates accordingly
-///       $0.query = "c"
-///     }
-///
-///     // Advance the scheduler by a period shorter than the debounce
-///     scheduler.advance(by: 0.25)
-///
-///     // Change the query again
-///     store.send(.searchFieldChanged("co") {
-///       $0.query = "co"
-///     }
-///
-///     // Advance the scheduler by a period shorter than the debounce
-///     scheduler.advance(by: 0.25)
-///     // Advance the scheduler to the debounce
-///     scheduler.advance(by: 0.25)
-///
-///     // Assert that the expected response is received
-///     store.receive(.response(["Composable Architecture"])) {
-///       // Assert that state updates accordingly
-///       $0.results = ["Composable Architecture"]
-///     }
-///
-/// This test is proving that the debounced network requests are correctly canceled when we do not
-/// wait longer than the 0.5 seconds, because if it wasn't and it delivered an action when we did
-/// not expect it would cause a test failure.
-///
-public final class TestStore<State, LocalState, Action, LocalAction, Environment> {
-    
-    /// The current environment.
+    /// A testable runtime for a reducer.
     ///
-    /// The environment can be modified throughout a test store's lifecycle in order to influence
-    /// how it produces effects.
-    public var environment: Environment
-    
-    /// The current state.
+    /// This object aids in writing expressive and exhaustive tests for features built in the
+    /// Composable Architecture. It allows you to send a sequence of actions to the store, and each
+    /// step of the way you must assert exactly how state changed, and how effect emissions were fed
+    /// back into the system.
     ///
-    /// When read from a trailing closure assertion in ``send(_:_:file:line:)`` or
-    /// ``receive(_:_:file:line:)``, it will equal the `inout` state passed to the closure.
-    public private(set) var state: State
-    
-    private let file: StaticString
-    private let fromLocalAction: (LocalAction) -> Action
-    private var line: UInt
-    private var inFlightEffects: Set<LongLivingEffect> = []
-    private var receivedActions: [(action: Action, state: State)] = []
-    private let reducer: Reducer<State, Action, Environment>
-    private var store: Store<State, TestAction>!
-    private let toLocalState: (State) -> LocalState
-    
-    private let failingWhenNothingChange: Bool
-    private let useNewScope: Bool
+    /// There are multiple ways the test store forces you to exhaustively assert on how your feature
+    /// behaves:
+    ///
+    ///   * After each action is sent you must describe precisely how the state changed from before
+    ///     the action was sent to after it was sent.
+    ///
+    ///     If even the smallest piece of data differs the test will fail. This guarantees that you
+    ///     are proving you know precisely how the state of the system changes.
+    ///
+    ///   * Sending an action can sometimes cause an effect to be executed, and if that effect emits
+    ///     an action that is fed back into the system, you **must** explicitly assert that you expect
+    ///     to receive that action from the effect, _and_ you must assert how state changed as a
+    ///     result.
+    ///
+    ///     If you try to send another action before you have handled all effect emissions the
+    ///     assertion will fail. This guarantees that you do not accidentally forget about an effect
+    ///     emission, and that the sequence of steps you are describing will mimic how the application
+    ///     behaves in reality.
+    ///
+    ///   * All effects must complete by the time the assertion has finished running the steps you
+    ///     specify.
+    ///
+    ///     If at the end of the assertion there is still an in-flight effect running, the assertion
+    ///     will fail. This helps exhaustively prove that you know what effects are in flight and
+    ///     forces you to prove that effects will not cause any future changes to your state.
+    ///
+    /// For example, given a simple counter reducer:
+    ///
+    ///     struct CounterState {
+    ///       var count = 0
+    ///     }
+    ///
+    ///     enum CounterAction: Equatable {
+    ///       case decrementButtonTapped
+    ///       case incrementButtonTapped
+    ///     }
+    ///
+    ///     let counterReducer = Reducer<CounterState, CounterAction, Void> { state, action, _ in
+    ///       switch action {
+    ///       case .decrementButtonTapped:
+    ///         state.count -= 1
+    ///         return .none
+    ///
+    ///       case .incrementButtonTapped:
+    ///         state.count += 1
+    ///         return .none
+    ///       }
+    ///     }
+    ///
+    /// One can assert against its behavior over time:
+    ///
+    ///     class CounterTests: XCTestCase {
+    ///       func testCounter() {
+    ///         let store = TestStore(
+    ///           initialState: .init(count: 0),     // GIVEN counter state of 0
+    ///           reducer: counterReducer,
+    ///           environment: ()
+    ///         )
+    ///         store.send(.incrementButtonTapped) { // WHEN the increment button is tapped
+    ///           $0.count = 1                       // THEN the count should be 1
+    ///         }
+    ///       }
+    ///     }
+    ///
+    /// Note that in the trailing closure of `.send(.incrementButtonTapped)` we are given a single
+    /// mutable value of the state before the action was sent, and it is our job to mutate the value
+    /// to match the state after the action was sent. In this case the `count` field changes to `1`.
+    ///
+    /// For a more complex example, consider the following bare-bones search feature that uses the
+    /// `.debounce` operator to wait for the user to stop typing before making a network request:
+    ///
+    ///     struct SearchState: Equatable {
+    ///       var query = ""
+    ///       var results: [String] = []
+    ///     }
+    ///
+    ///     enum SearchAction: Equatable {
+    ///       case queryChanged(String)
+    ///       case response([String])
+    ///     }
+    ///
+    ///     struct SearchEnvironment {
+    ///       var mainQueue: AnySchedulerOf<DispatchQueue>
+    ///       var request: (String) -> Effect<[String], Never>
+    ///     }
+    ///
+    ///     let searchReducer = Reducer<SearchState, SearchAction, SearchEnvironment> {
+    ///       state, action, environment in
+    ///
+    ///         enum SearchId {}
+    ///
+    ///         switch action {
+    ///         case let .queryChanged(query):
+    ///           state.query = query
+    ///           return environment.request(self.query)
+    ///             .debounce(id: SearchId.self, for: 0.5, scheduler: environment.mainQueue)
+    ///
+    ///         case let .response(results):
+    ///           state.results = results
+    ///           return .none
+    ///         }
+    ///     }
+    ///
+    /// It can be fully tested by controlling the environment's scheduler and effect:
+    ///
+    ///     // Create a test dispatch scheduler to control the timing of effects
+    ///     let scheduler = DispatchQueue.testScheduler
+    ///
+    ///     let store = TestStore(
+    ///       initialState: SearchState(),
+    ///       reducer: searchReducer,
+    ///       environment: SearchEnvironment(
+    ///         // Wrap the test scheduler in a type-erased scheduler
+    ///         mainQueue: scheduler.eraseToAnyScheduler(),
+    ///         // Simulate a search response with one item
+    ///         request: { _ in Effect(value: ["Composable Architecture"]) }
+    ///       )
+    ///     )
+    ///
+    ///     // Change the query
+    ///     store.send(.searchFieldChanged("c") {
+    ///       // Assert that state updates accordingly
+    ///       $0.query = "c"
+    ///     }
+    ///
+    ///     // Advance the scheduler by a period shorter than the debounce
+    ///     scheduler.advance(by: 0.25)
+    ///
+    ///     // Change the query again
+    ///     store.send(.searchFieldChanged("co") {
+    ///       $0.query = "co"
+    ///     }
+    ///
+    ///     // Advance the scheduler by a period shorter than the debounce
+    ///     scheduler.advance(by: 0.25)
+    ///     // Advance the scheduler to the debounce
+    ///     scheduler.advance(by: 0.25)
+    ///
+    ///     // Assert that the expected response is received
+    ///     store.receive(.response(["Composable Architecture"])) {
+    ///       // Assert that state updates accordingly
+    ///       $0.results = ["Composable Architecture"]
+    ///     }
+    ///
+    /// This test is proving that the debounced network requests are correctly canceled when we do not
+    /// wait longer than the 0.5 seconds, because if it wasn't and it delivered an action when we did
+    /// not expect it would cause a test failure.
+    ///
+    public final class TestStore<State, LocalState, Action, LocalAction, Environment> {
 
-    public var stateDiffMode: DiffMode = .distinct
-    public var actionDiffMode: DiffMode = .distinct
-    
-    private init(
-        environment: Environment,
-        file: StaticString,
-        fromLocalAction: @escaping (LocalAction) -> Action,
-        initialState: State,
-        line: UInt,
-        reducer: Reducer<State, Action, Environment>,
-        toLocalState: @escaping (State) -> LocalState,
-        failingWhenNothingChange: Bool,
-        useNewScope: Bool
-    ) {
-        self.environment = environment
-        self.file = file
-        self.fromLocalAction = fromLocalAction
-        self.line = line
-        self.reducer = reducer
-        state = initialState
-        self.toLocalState = toLocalState
-        self.failingWhenNothingChange = failingWhenNothingChange
-        self.useNewScope = useNewScope
-        
-        store = Store(
-            initialState: initialState,
-            reducer: Reducer<State, TestAction, Void> { [unowned self] state, action, _ in
-                let effects: Effect<Action>
-                switch action.origin {
-                case let .send(localAction):
-                    effects = self.reducer.run(&state, self.fromLocalAction(localAction), self.environment)
-                    self.state = state
-                    
-                case let .receive(action):
-                    effects = self.reducer.run(&state, action, self.environment)
-                    self.receivedActions.append((action, state))
-                }
-                
-                let effect = LongLivingEffect(file: action.file, line: action.line)
-                return effects
-                    .do(
-                        onCompleted: { [weak self] in self?.inFlightEffects.remove(effect) },
-                        onSubscribe: { [weak self] in self?.inFlightEffects.insert(effect) },
-                        onDispose: { [weak self] in self?.inFlightEffects.remove(effect) }
-                    )
-                    .map { .init(origin: .receive($0), file: action.file, line: action.line) }
-                    .eraseToEffect()
-            },
-            environment: (),
-            useNewScope: useNewScope
-        )
-    }
-    
-    deinit {
-        self.completed()
-    }
-    
-    private func completed() {
-        if !receivedActions.isEmpty {
-            var actions = ""
-            customDump(self.receivedActions.map(\.action), to: &actions)
-            XCTFail(
-                """
-                The store received \(receivedActions.count) unexpected \
-                action\(receivedActions.count == 1 ? "" : "s") after this one: …
-                
-                Unhandled actions: \(actions)
-                """,
-                file: file, line: line
-            )
-        }
-        for effect in inFlightEffects {
-            XCTFail(
-                """
-                An effect returned for this action is still running. It must complete before the end of \
-                the test. …
-                
-                To fix, inspect any effects the reducer returns for this action and ensure that all of \
-                them complete by the end of the test. There are a few reasons why an effect may not have \
-                completed:
-                
-                • If an effect uses a scheduler (via "receive(on:)", "delay", "debounce", etc.), make \
-                sure that you wait enough time for the scheduler to perform the effect. If you are using \
-                a test scheduler, advance the scheduler so that the effects may complete, or consider \
-                using an immediate scheduler to immediately perform the effect instead.
-                
-                • If you are returning a long-living effect (timers, notifications, subjects, etc.), \
-                then make sure those effects are torn down by marking the effect ".cancellable" and \
-                returning a corresponding cancellation effect ("Effect.cancel") from another action, or, \
-                if your effect is driven by a Combine subject, send it a completion.
-                """,
-                file: effect.file,
-                line: effect.line
-            )
-        }
-    }
-    
-    private struct LongLivingEffect: Hashable {
-        let id = UUID()
-        let file: StaticString
-        let line: UInt
-        
-        static func == (lhs: Self, rhs: Self) -> Bool {
-            lhs.id == rhs.id
-        }
-        
-        func hash(into hasher: inout Hasher) {
-            id.hash(into: &hasher)
-        }
-    }
-    
-    private struct TestAction: CustomDebugStringConvertible {
-        let origin: Origin
-        let file: StaticString
-        let line: UInt
-        
-        enum Origin {
-            case send(LocalAction)
-            case receive(Action)
-        }
-        
-        var debugDescription: String {
-            switch self.origin {
-            case let .send(action):
-                return debugCaseOutput(action)
-                
-            case let .receive(action):
-                return debugCaseOutput(action)
-            }
-        }
-    }
-}
+        /// The current environment.
+        ///
+        /// The environment can be modified throughout a test store's lifecycle in order to influence
+        /// how it produces effects.
+        public var environment: Environment
 
-extension TestStore where State == LocalState, Action == LocalAction {
-    /// Initializes a test store from an initial state, a reducer, and an initial environment.
-    ///
-    /// - Parameters:
-    ///   - initialState: The state to start the test from.
-    ///   - reducer: A reducer.
-    ///   - environment: The environment to start the test from.
-    ///   - failingWhenNothingChange: Flag to failing the test if the trailing closure on send and receive  is provided but nothing is changed
-    ///   - useNewScope: Use improved store.
-    public convenience init(
-        initialState: State,
-        reducer: Reducer<State, Action, Environment>,
-        environment: Environment,
-        failingWhenNothingChange: Bool = true,
-        useNewScope: Bool = false,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        self.init(
-            environment: environment,
-            file: file,
-            fromLocalAction: { $0 },
-            initialState: initialState,
-            line: line,
-            reducer: reducer,
-            toLocalState: { $0 },
-            failingWhenNothingChange: failingWhenNothingChange,
-            useNewScope: useNewScope
-        )
-    }
-}
+        /// The current state.
+        ///
+        /// When read from a trailing closure assertion in ``send(_:_:file:line:)`` or
+        /// ``receive(_:_:file:line:)``, it will equal the `inout` state passed to the closure.
+        public private(set) var state: State
 
-extension TestStore where LocalState: Equatable {
-    public func send(
-        _ action: LocalAction,
-        file: StaticString = #file,
-        line: UInt = #line,
-        _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil
-    ) {
-        if !receivedActions.isEmpty {
-            var actions = ""
-            customDump(self.receivedActions.map(\.action), to: &actions)
-            XCTFail(
-                """
-                Must handle \(receivedActions.count) received \
-                action\(receivedActions.count == 1 ? "" : "s") before sending an action: …
-                
-                Unhandled actions: \(action)
-                """,
-                file: file, line: line
-            )
-        }
-        var expectedState = toLocalState(self.state)
-        let previousState = self.state
-        self.store.send(.init(origin: .send(action), file: file, line: line))
-        do {
-            let currentState = self.state
-            self.state = previousState
-            defer { self.state = currentState }
-            try expectedStateShouldMatch(
-                expected: &expectedState,
-                actual: toLocalState(currentState),
-                modify: updateExpectingResult,
-                file: file,
-                line: line
-            )
-        } catch {
-            XCTFail("Threw error: \(error)", file: file, line: line)
-        }
-        
-        if "\(self.file)" == "\(file)" {
-            self.line = line
-        }
-    }
-    
-    private func expectedStateShouldMatch(
-        expected: inout LocalState,
-        actual: LocalState,
-        modify: ((inout LocalState) throws -> Void)? = nil,
-        file: StaticString,
-        line: UInt
-    ) throws {
-        let current = expected
-        if let modify = modify {
-            try modify(&expected)
-        }
-        if expected != actual {
-            let difference =
-            diff(expected, actual, format: .proportional)
-                .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
-            ?? """
-              Expected:
-              \(String(describing: expected).indent(by: 2))
-              
-              Actual:
-              \(String(describing: actual).indent(by: 2))
-              """
-            
-            let messageHeading = modify != nil
-            ? "A state change does not match expectation"
-            : "State was not expected to change, but a change occurred"
-            XCTFail(
-              """
-              \(messageHeading): …
-              
-              \(difference)
-              """,
-              file: file,
-              line: line
-            )
-        } else if expected == current && modify != nil && failingWhenNothingChange {
-            XCTFail(
-              """
-              Expected state to change, but no change occurred.
-              
-              The trailing closure made no observable modifications to state. If no change to state is \
-              expected, omit the trailing closure.
-              """,
-              file: file, line: line
-            )
-        }
-    }
-}
+        private let file: StaticString
+        private let fromLocalAction: (LocalAction) -> Action
+        private var line: UInt
+        private var inFlightEffects: Set<LongLivingEffect> = []
+        private var receivedActions: [(action: Action, state: State)] = []
+        private let reducer: Reducer<State, Action, Environment>
+        private var store: Store<State, TestAction>!
+        private let toLocalState: (State) -> LocalState
 
-extension TestStore where LocalState: Equatable, Action: Equatable {
-    /// Asserts an action was received from an effect and asserts when state changes.
-    ///
-    /// - Parameters:
-    ///   - expectedAction: An action expected from an effect.
-    ///   - updateExpectingResult: A closure that asserts state changed by sending the action to the
-    ///     store. The mutable state sent to this closure must be modified to match the state of the
-    ///     store after processing the given action. Do not provide a closure if no change is
-    ///     expected.
-    public func receive(
-        _ expectedAction: Action,
-        file: StaticString = #file,
-        line: UInt = #line,
-        _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil
-    ) {
-        guard !receivedActions.isEmpty else {
-            XCTFail(
-                """
-                Expected to receive an action, but received none.
-                """,
-                file: file, line: line
-            )
-            return
-        }
-        let (receivedAction, state) = receivedActions.removeFirst()
-        if expectedAction != receivedAction {
-            let difference =
-            diff(expectedAction, receivedAction, format: .proportional)
-                .map { "\($0.indent(by: 4))\n\n(Expected: −, Received: +)" }
-            ?? """
-            Expected:
-            \(String(describing: expectedAction).indent(by: 2))
-            
-            Received:
-            \(String(describing: receivedAction).indent(by: 2))
-            """
-            
-            XCTFail(
-                """
-                Received unexpected action: …
-                
-                \(difference)
-                """,
-                file: file, line: line
-            )
-        }
-        var expectedState = toLocalState(self.state)
-        do {
-            try expectedStateShouldMatch(
-                expected: &expectedState,
-                actual: toLocalState(state),
-                modify: updateExpectingResult,
-                file: file,
-                line: line
-            )
-        } catch {
-            XCTFail("Threw error: \(error)", file: file, line: line)
-        }
-        
-        self.state = state
-        if "\(self.file)" == "\(file)" {
-            self.line = line
-        }
-    }
-    
-    /// Asserts against a script of actions.
-    public func assert(
-        _ steps: Step...,
-        groupLevel: Int = 0,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        assert(steps, groupLevel: groupLevel, file: file, line: line)
-    }
-    
-    /// Asserts against an array of actions.
-    public func assert(
-        _ steps: [Step],
-        groupLevel: Int = 0,
-        file _: StaticString = #file,
-        line _: UInt = #line
-    ) {
-        func assert(step: Step) {
-            switch step.type {
-            case let .send(action, update):
-                self.send(action, file: step.file, line: step.line, update)
-            case let .receive(expectedAction, update):
-                self.receive(expectedAction, file: step.file, line: step.line, update)
-            case let .environment(work):
-                if !self.receivedActions.isEmpty {
-                    var actions = ""
-                    customDump(self.receivedActions.map(\.action), to: &actions)
-                    XCTFail(
-                        """
-                        Must handle \(self.receivedActions.count) received \
-                        action\(self.receivedActions.count == 1 ? "" : "s") before performing this work: …
-                        Unhandled actions: \(actions)
-                        """,
-                        file: step.file, line: step.line
-                    )
-                }
-                do {
-                    try work(&self.environment)
-                } catch {
-                    XCTFail("Threw error: \(error)", file: step.file, line: step.line)
-                }
+        private let failingWhenNothingChange: Bool
+        private let useNewScope: Bool
 
-            case let .do(work):
-                if !self.receivedActions.isEmpty {
-                    var actions = ""
-                    customDump(self.receivedActions.map(\.action), to: &actions)
-                    XCTFail(
-                        """
-                        Must handle \(self.receivedActions.count) received \
-                        action\(self.receivedActions.count == 1 ? "" : "s") before performing this work: …
-                        Unhandled actions: \(actions)
-                        """,
-                        file: step.file, line: step.line
-                    )
-                }
-                do {
-                    try work()
-                } catch {
-                    XCTFail("Threw error: \(error)", file: step.file, line: step.line)
-                }
-            case let .group(_, steps):
-                if steps.count > 0 {
-                    self.assert(
-                        steps,
-                        groupLevel: groupLevel + 1,
-                        file: step.file,
-                        line: step.line
-                    )
-                }
-                return
-            }
-        }
-        
-        steps.forEach(assert(step:))
-        
-        self.completed()
-    }
-}
+        public var stateDiffMode: DiffMode = .distinct
+        public var actionDiffMode: DiffMode = .distinct
 
-extension TestStore {
-    /// Scopes a store to assert against more local state and actions.
-    ///
-    /// Useful for testing view store-specific state and actions.
-    ///
-    /// - Parameters:
-    ///   - toLocalState: A function that transforms the reducer's state into more local state. This
-    ///     state will be asserted against as it is mutated by the reducer. Useful for testing view
-    ///     store state transformations.
-    ///   - fromLocalAction: A function that wraps a more local action in the reducer's action.
-    ///     Local actions can be "sent" to the store, while any reducer action may be received.
-    ///     Useful for testing view store action transformations.
-    public func scope<S, A>(
-        state toLocalState: @escaping (LocalState) -> S,
-        action fromLocalAction: @escaping (A) -> LocalAction
-    ) -> TestStore<State, S, Action, A, Environment> {
-        .init(
-            environment: environment,
-            file: file,
-            fromLocalAction: { self.fromLocalAction(fromLocalAction($0)) },
-            initialState: store.state,
-            line: line,
-            reducer: reducer,
-            toLocalState: { toLocalState(self.toLocalState($0)) },
-            failingWhenNothingChange: failingWhenNothingChange,
-            useNewScope: useNewScope
-        )
-    }
-    
-    /// Scopes a store to assert against more local state.
-    ///
-    /// Useful for testing view store-specific state.
-    ///
-    /// - Parameter toLocalState: A function that transforms the reducer's state into more local
-    ///   state. This state will be asserted against as it is mutated by the reducer. Useful for
-    ///   testing view store state transformations.
-    public func scope<S>(
-        state toLocalState: @escaping (LocalState) -> S
-    ) -> TestStore<State, S, Action, LocalAction, Environment> {
-        scope(state: toLocalState, action: { $0 })
-    }
-    
-    /// Deprecated
-    /// A single step of a `TestStore` assertion.
-    public struct Step {
-        internal let type: StepType
-        fileprivate let file: StaticString
-        fileprivate let line: UInt
-        
         private init(
-            _ type: StepType,
+            environment: Environment,
+            file: StaticString,
+            fromLocalAction: @escaping (LocalAction) -> Action,
+            initialState: State,
+            line: UInt,
+            reducer: Reducer<State, Action, Environment>,
+            toLocalState: @escaping (State) -> LocalState,
+            failingWhenNothingChange: Bool,
+            useNewScope: Bool
+        ) {
+            self.environment = environment
+            self.file = file
+            self.fromLocalAction = fromLocalAction
+            self.line = line
+            self.reducer = reducer
+            state = initialState
+            self.toLocalState = toLocalState
+            self.failingWhenNothingChange = failingWhenNothingChange
+            self.useNewScope = useNewScope
+
+            store = Store(
+                initialState: initialState,
+                reducer: Reducer<State, TestAction, Void> { [unowned self] state, action, _ in
+                    let effects: Effect<Action>
+                    switch action.origin {
+                    case let .send(localAction):
+                        effects = self.reducer.run(
+                            &state, self.fromLocalAction(localAction), self.environment)
+                        self.state = state
+
+                    case let .receive(action):
+                        effects = self.reducer.run(&state, action, self.environment)
+                        self.receivedActions.append((action, state))
+                    }
+
+                    let effect = LongLivingEffect(file: action.file, line: action.line)
+                    return
+                        effects
+                        .do(
+                            onCompleted: { [weak self] in self?.inFlightEffects.remove(effect) },
+                            onSubscribe: { [weak self] in self?.inFlightEffects.insert(effect) },
+                            onDispose: { [weak self] in self?.inFlightEffects.remove(effect) }
+                        )
+                        .map { .init(origin: .receive($0), file: action.file, line: action.line) }
+                        .eraseToEffect()
+                },
+                environment: (),
+                useNewScope: useNewScope
+            )
+        }
+
+        deinit {
+            self.completed()
+        }
+
+        private func completed() {
+            if !receivedActions.isEmpty {
+                var actions = ""
+                customDump(self.receivedActions.map(\.action), to: &actions)
+                XCTFail(
+                    """
+                    The store received \(receivedActions.count) unexpected \
+                    action\(receivedActions.count == 1 ? "" : "s") after this one: …
+
+                    Unhandled actions: \(actions)
+                    """,
+                    file: file, line: line
+                )
+            }
+            for effect in inFlightEffects {
+                XCTFail(
+                    """
+                    An effect returned for this action is still running. It must complete before the end of \
+                    the test. …
+
+                    To fix, inspect any effects the reducer returns for this action and ensure that all of \
+                    them complete by the end of the test. There are a few reasons why an effect may not have \
+                    completed:
+
+                    • If an effect uses a scheduler (via "receive(on:)", "delay", "debounce", etc.), make \
+                    sure that you wait enough time for the scheduler to perform the effect. If you are using \
+                    a test scheduler, advance the scheduler so that the effects may complete, or consider \
+                    using an immediate scheduler to immediately perform the effect instead.
+
+                    • If you are returning a long-living effect (timers, notifications, subjects, etc.), \
+                    then make sure those effects are torn down by marking the effect ".cancellable" and \
+                    returning a corresponding cancellation effect ("Effect.cancel") from another action, or, \
+                    if your effect is driven by a Combine subject, send it a completion.
+                    """,
+                    file: effect.file,
+                    line: effect.line
+                )
+            }
+        }
+
+        private struct LongLivingEffect: Hashable {
+            let id = UUID()
+            let file: StaticString
+            let line: UInt
+
+            static func == (lhs: Self, rhs: Self) -> Bool {
+                lhs.id == rhs.id
+            }
+
+            func hash(into hasher: inout Hasher) {
+                id.hash(into: &hasher)
+            }
+        }
+
+        private struct TestAction: CustomDebugStringConvertible {
+            let origin: Origin
+            let file: StaticString
+            let line: UInt
+
+            enum Origin {
+                case send(LocalAction)
+                case receive(Action)
+            }
+
+            var debugDescription: String {
+                switch self.origin {
+                case let .send(action):
+                    return debugCaseOutput(action)
+
+                case let .receive(action):
+                    return debugCaseOutput(action)
+                }
+            }
+        }
+    }
+
+    extension TestStore where State == LocalState, Action == LocalAction {
+        /// Initializes a test store from an initial state, a reducer, and an initial environment.
+        ///
+        /// - Parameters:
+        ///   - initialState: The state to start the test from.
+        ///   - reducer: A reducer.
+        ///   - environment: The environment to start the test from.
+        ///   - failingWhenNothingChange: Flag to failing the test if the trailing closure on send and receive  is provided but nothing is changed
+        ///   - useNewScope: Use improved store.
+        public convenience init(
+            initialState: State,
+            reducer: Reducer<State, Action, Environment>,
+            environment: Environment,
+            failingWhenNothingChange: Bool = true,
+            useNewScope: Bool = false,
             file: StaticString = #file,
             line: UInt = #line
         ) {
-            self.type = type
-            self.file = file
-            self.line = line
+            self.init(
+                environment: environment,
+                file: file,
+                fromLocalAction: { $0 },
+                initialState: initialState,
+                line: line,
+                reducer: reducer,
+                toLocalState: { $0 },
+                failingWhenNothingChange: failingWhenNothingChange,
+                useNewScope: useNewScope
+            )
         }
-        
-        /// A step that describes an action sent to a store and asserts against how the store's state
-        /// is expected to change.
-        ///
-        /// - Parameters:
-        ///   - action: An action to send to the test store.
-        ///   - update: A function that describes how the test store's state is expected to change.
-        /// - Returns: A step that describes an action sent to a store and asserts against how the
-        ///   store's state is expected to change.
-        public static func send(
+    }
+
+    extension TestStore where LocalState: Equatable {
+        public func send(
             _ action: LocalAction,
-            _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
             file: StaticString = #file,
-            line: UInt = #line
-        ) -> Step {
-            Step(.send(action, updateExpectingResult), file: file, line: line)
+            line: UInt = #line,
+            _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil
+        ) {
+            if !receivedActions.isEmpty {
+                var actions = ""
+                customDump(self.receivedActions.map(\.action), to: &actions)
+                XCTFail(
+                    """
+                    Must handle \(receivedActions.count) received \
+                    action\(receivedActions.count == 1 ? "" : "s") before sending an action: …
+
+                    Unhandled actions: \(action)
+                    """,
+                    file: file, line: line
+                )
+            }
+            var expectedState = toLocalState(self.state)
+            let previousState = self.state
+            self.store.send(.init(origin: .send(action), file: file, line: line))
+            do {
+                let currentState = self.state
+                self.state = previousState
+                defer { self.state = currentState }
+                try expectedStateShouldMatch(
+                    expected: &expectedState,
+                    actual: toLocalState(currentState),
+                    modify: updateExpectingResult,
+                    file: file,
+                    line: line
+                )
+            } catch {
+                XCTFail("Threw error: \(error)", file: file, line: line)
+            }
+
+            if "\(self.file)" == "\(file)" {
+                self.line = line
+            }
         }
-        
-        /// A step that describes an action received by an effect and asserts against how the store's
-        /// state is expected to change.
+
+        private func expectedStateShouldMatch(
+            expected: inout LocalState,
+            actual: LocalState,
+            modify: ((inout LocalState) throws -> Void)? = nil,
+            file: StaticString,
+            line: UInt
+        ) throws {
+            let current = expected
+            if let modify = modify {
+                try modify(&expected)
+            }
+            if expected != actual {
+                let difference =
+                    diff(expected, actual, format: .proportional)
+                    .map { "\($0.indent(by: 4))\n\n(Expected: −, Actual: +)" }
+                    ?? """
+                    Expected:
+                    \(String(describing: expected).indent(by: 2))
+
+                    Actual:
+                    \(String(describing: actual).indent(by: 2))
+                    """
+
+                let messageHeading =
+                    modify != nil
+                    ? "A state change does not match expectation"
+                    : "State was not expected to change, but a change occurred"
+                XCTFail(
+                    """
+                    \(messageHeading): …
+
+                    \(difference)
+                    """,
+                    file: file,
+                    line: line
+                )
+            } else if expected == current && modify != nil && failingWhenNothingChange {
+                XCTFail(
+                    """
+                    Expected state to change, but no change occurred.
+
+                    The trailing closure made no observable modifications to state. If no change to state is \
+                    expected, omit the trailing closure.
+                    """,
+                    file: file, line: line
+                )
+            }
+        }
+    }
+
+    extension TestStore where LocalState: Equatable, Action: Equatable {
+        /// Asserts an action was received from an effect and asserts when state changes.
         ///
         /// - Parameters:
-        ///   - action: An action the test store should receive by evaluating an effect.
-        ///   - update: A function that describes how the test store's state is expected to change.
-        /// - Returns: A step that describes an action received by an effect and asserts against how
-        ///   the store's state is expected to change.
-        public static func receive(
-            _ action: Action,
-            _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+        ///   - expectedAction: An action expected from an effect.
+        ///   - updateExpectingResult: A closure that asserts state changed by sending the action to the
+        ///     store. The mutable state sent to this closure must be modified to match the state of the
+        ///     store after processing the given action. Do not provide a closure if no change is
+        ///     expected.
+        public func receive(
+            _ expectedAction: Action,
+            file: StaticString = #file,
+            line: UInt = #line,
+            _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil
+        ) {
+            guard !receivedActions.isEmpty else {
+                XCTFail(
+                    """
+                    Expected to receive an action, but received none.
+                    """,
+                    file: file, line: line
+                )
+                return
+            }
+            let (receivedAction, state) = receivedActions.removeFirst()
+            if expectedAction != receivedAction {
+                let difference =
+                    diff(expectedAction, receivedAction, format: .proportional)
+                    .map { "\($0.indent(by: 4))\n\n(Expected: −, Received: +)" }
+                    ?? """
+                    Expected:
+                    \(String(describing: expectedAction).indent(by: 2))
+
+                    Received:
+                    \(String(describing: receivedAction).indent(by: 2))
+                    """
+
+                XCTFail(
+                    """
+                    Received unexpected action: …
+
+                    \(difference)
+                    """,
+                    file: file, line: line
+                )
+            }
+            var expectedState = toLocalState(self.state)
+            do {
+                try expectedStateShouldMatch(
+                    expected: &expectedState,
+                    actual: toLocalState(state),
+                    modify: updateExpectingResult,
+                    file: file,
+                    line: line
+                )
+            } catch {
+                XCTFail("Threw error: \(error)", file: file, line: line)
+            }
+
+            self.state = state
+            if "\(self.file)" == "\(file)" {
+                self.line = line
+            }
+        }
+
+        /// Asserts against a script of actions.
+        public func assert(
+            _ steps: Step...,
+            groupLevel: Int = 0,
             file: StaticString = #file,
             line: UInt = #line
-        ) -> Step {
-            Step(.receive(action, updateExpectingResult), file: file, line: line)
+        ) {
+            assert(steps, groupLevel: groupLevel, file: file, line: line)
         }
-        
-        /// A step that updates a test store's environment.
-        ///
-        /// - Parameter update: A function that updates the test store's environment for subsequent
-        ///   steps.
-        /// - Returns: A step that updates a test store's environment.
-        public static func environment(
-            file: StaticString = #file,
-            line: UInt = #line,
-            _ update: @escaping (inout Environment) throws -> Void
-        ) -> Step {
-            Step(.environment(update), file: file, line: line)
-        }
-        
-        /// A step that captures some work to be done between assertions
-        ///
-        /// - Parameter work: A function that is called between steps.
-        /// - Returns: A step that captures some work to be done between assertions.
-        public static func `do`(
-            file: StaticString = #file,
-            line: UInt = #line,
-            _ work: @escaping () throws -> Void
-        ) -> Step {
-            Step(.do(work), file: file, line: line)
-        }
-        
-        /// A step that captures a sub-sequence of steps.
-        ///
-        /// - Parameter steps: An array of `Step`
-        /// - Returns: A step that captures a sub-sequence of steps.
-        public static func group(
-            _ name: String,
-            file: StaticString = #file,
-            line: UInt = #line,
-            _ steps: Step...
-        ) -> Step {
-            Step(.group(name, steps), file: file, line: line)
-        }
-        
-        internal enum StepType {
-            case send(LocalAction, ((inout LocalState) throws -> Void)?)
-            case receive(Action, ((inout LocalState) throws -> Void)?)
-            case environment((inout Environment) throws -> Void)
-            case `do`(() throws -> Void)
-            case group(String, [Step])
+
+        /// Asserts against an array of actions.
+        public func assert(
+            _ steps: [Step],
+            groupLevel: Int = 0,
+            file _: StaticString = #file,
+            line _: UInt = #line
+        ) {
+            func assert(step: Step) {
+                switch step.type {
+                case let .send(action, update):
+                    self.send(action, file: step.file, line: step.line, update)
+                case let .receive(expectedAction, update):
+                    self.receive(expectedAction, file: step.file, line: step.line, update)
+                case let .environment(work):
+                    if !self.receivedActions.isEmpty {
+                        var actions = ""
+                        customDump(self.receivedActions.map(\.action), to: &actions)
+                        XCTFail(
+                            """
+                            Must handle \(self.receivedActions.count) received \
+                            action\(self.receivedActions.count == 1 ? "" : "s") before performing this work: …
+                            Unhandled actions: \(actions)
+                            """,
+                            file: step.file, line: step.line
+                        )
+                    }
+                    do {
+                        try work(&self.environment)
+                    } catch {
+                        XCTFail("Threw error: \(error)", file: step.file, line: step.line)
+                    }
+
+                case let .do(work):
+                    if !self.receivedActions.isEmpty {
+                        var actions = ""
+                        customDump(self.receivedActions.map(\.action), to: &actions)
+                        XCTFail(
+                            """
+                            Must handle \(self.receivedActions.count) received \
+                            action\(self.receivedActions.count == 1 ? "" : "s") before performing this work: …
+                            Unhandled actions: \(actions)
+                            """,
+                            file: step.file, line: step.line
+                        )
+                    }
+                    do {
+                        try work()
+                    } catch {
+                        XCTFail("Threw error: \(error)", file: step.file, line: step.line)
+                    }
+                case let .group(_, steps):
+                    if steps.count > 0 {
+                        self.assert(
+                            steps,
+                            groupLevel: groupLevel + 1,
+                            file: step.file,
+                            line: step.line
+                        )
+                    }
+                    return
+                }
+            }
+
+            steps.forEach(assert(step:))
+
+            self.completed()
         }
     }
-    
-    public struct Annotating {
-        public typealias StepResultCallback = (Bool) -> Void
-        
-        public var annotate: (Step, Int, @escaping (@escaping StepResultCallback) -> Void) -> Void
-        
-        public init(annotate: @escaping (Step, Int, @escaping (@escaping StepResultCallback) -> Void) -> Void) {
-            self.annotate = annotate
+
+    extension TestStore {
+        /// Scopes a store to assert against more local state and actions.
+        ///
+        /// Useful for testing view store-specific state and actions.
+        ///
+        /// - Parameters:
+        ///   - toLocalState: A function that transforms the reducer's state into more local state. This
+        ///     state will be asserted against as it is mutated by the reducer. Useful for testing view
+        ///     store state transformations.
+        ///   - fromLocalAction: A function that wraps a more local action in the reducer's action.
+        ///     Local actions can be "sent" to the store, while any reducer action may be received.
+        ///     Useful for testing view store action transformations.
+        public func scope<S, A>(
+            state toLocalState: @escaping (LocalState) -> S,
+            action fromLocalAction: @escaping (A) -> LocalAction
+        ) -> TestStore<State, S, Action, A, Environment> {
+            .init(
+                environment: environment,
+                file: file,
+                fromLocalAction: { self.fromLocalAction(fromLocalAction($0)) },
+                initialState: store.state,
+                line: line,
+                reducer: reducer,
+                toLocalState: { toLocalState(self.toLocalState($0)) },
+                failingWhenNothingChange: failingWhenNothingChange,
+                useNewScope: useNewScope
+            )
         }
-        
-        public static func combine(_ annotatings: Annotating...) -> Self {
-            return Annotating { step, groupLevel, callback in
-                var combinedCallbacks: [StepResultCallback] = []
-                
-                for annotating in annotatings {
-                    annotating.annotate(step, groupLevel) { resultCallback in
-                        combinedCallbacks.append(resultCallback)
+
+        /// Scopes a store to assert against more local state.
+        ///
+        /// Useful for testing view store-specific state.
+        ///
+        /// - Parameter toLocalState: A function that transforms the reducer's state into more local
+        ///   state. This state will be asserted against as it is mutated by the reducer. Useful for
+        ///   testing view store state transformations.
+        public func scope<S>(
+            state toLocalState: @escaping (LocalState) -> S
+        ) -> TestStore<State, S, Action, LocalAction, Environment> {
+            scope(state: toLocalState, action: { $0 })
+        }
+
+        /// Deprecated
+        /// A single step of a `TestStore` assertion.
+        public struct Step {
+            internal let type: StepType
+            fileprivate let file: StaticString
+            fileprivate let line: UInt
+
+            private init(
+                _ type: StepType,
+                file: StaticString = #file,
+                line: UInt = #line
+            ) {
+                self.type = type
+                self.file = file
+                self.line = line
+            }
+
+            /// A step that describes an action sent to a store and asserts against how the store's state
+            /// is expected to change.
+            ///
+            /// - Parameters:
+            ///   - action: An action to send to the test store.
+            ///   - update: A function that describes how the test store's state is expected to change.
+            /// - Returns: A step that describes an action sent to a store and asserts against how the
+            ///   store's state is expected to change.
+            public static func send(
+                _ action: LocalAction,
+                _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+                file: StaticString = #file,
+                line: UInt = #line
+            ) -> Step {
+                Step(.send(action, updateExpectingResult), file: file, line: line)
+            }
+
+            /// A step that describes an action received by an effect and asserts against how the store's
+            /// state is expected to change.
+            ///
+            /// - Parameters:
+            ///   - action: An action the test store should receive by evaluating an effect.
+            ///   - update: A function that describes how the test store's state is expected to change.
+            /// - Returns: A step that describes an action received by an effect and asserts against how
+            ///   the store's state is expected to change.
+            public static func receive(
+                _ action: Action,
+                _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
+                file: StaticString = #file,
+                line: UInt = #line
+            ) -> Step {
+                Step(.receive(action, updateExpectingResult), file: file, line: line)
+            }
+
+            /// A step that updates a test store's environment.
+            ///
+            /// - Parameter update: A function that updates the test store's environment for subsequent
+            ///   steps.
+            /// - Returns: A step that updates a test store's environment.
+            public static func environment(
+                file: StaticString = #file,
+                line: UInt = #line,
+                _ update: @escaping (inout Environment) throws -> Void
+            ) -> Step {
+                Step(.environment(update), file: file, line: line)
+            }
+
+            /// A step that captures some work to be done between assertions
+            ///
+            /// - Parameter work: A function that is called between steps.
+            /// - Returns: A step that captures some work to be done between assertions.
+            public static func `do`(
+                file: StaticString = #file,
+                line: UInt = #line,
+                _ work: @escaping () throws -> Void
+            ) -> Step {
+                Step(.do(work), file: file, line: line)
+            }
+
+            /// A step that captures a sub-sequence of steps.
+            ///
+            /// - Parameter steps: An array of `Step`
+            /// - Returns: A step that captures a sub-sequence of steps.
+            public static func group(
+                _ name: String,
+                file: StaticString = #file,
+                line: UInt = #line,
+                _ steps: Step...
+            ) -> Step {
+                Step(.group(name, steps), file: file, line: line)
+            }
+
+            internal enum StepType {
+                case send(LocalAction, ((inout LocalState) throws -> Void)?)
+                case receive(Action, ((inout LocalState) throws -> Void)?)
+                case environment((inout Environment) throws -> Void)
+                case `do`(() throws -> Void)
+                case group(String, [Step])
+            }
+        }
+
+        public struct Annotating {
+            public typealias StepResultCallback = (Bool) -> Void
+
+            public var annotate:
+                (Step, Int, @escaping (@escaping StepResultCallback) -> Void) -> Void
+
+            public init(
+                annotate: @escaping (Step, Int, @escaping (@escaping StepResultCallback) -> Void) ->
+                    Void
+            ) {
+                self.annotate = annotate
+            }
+
+            public static func combine(_ annotatings: Annotating...) -> Self {
+                return Annotating { step, groupLevel, callback in
+                    var combinedCallbacks: [StepResultCallback] = []
+
+                    for annotating in annotatings {
+                        annotating.annotate(step, groupLevel) { resultCallback in
+                            combinedCallbacks.append(resultCallback)
+                        }
                     }
-                }
-                
-                callback { stepResult in
-                    for callback in combinedCallbacks {
-                        callback(stepResult)
+
+                    callback { stepResult in
+                        for callback in combinedCallbacks {
+                            callback(stepResult)
+                        }
                     }
                 }
             }
-        }
-        
-        public static var none: Self {
-            Self { _, _, callback in
-                callback { _ in }
+
+            public static var none: Self {
+                Self { _, _, callback in
+                    callback { _ in }
+                }
             }
         }
     }
-}
 #endif

--- a/Sources/RxComposableArchitecture/TestSupport/VirtualTimeScheduler.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/VirtualTimeScheduler.swift
@@ -1,278 +1,288 @@
 #if DEBUG
-import Foundation
-import RxSwift
+    import Foundation
+    import RxSwift
 
-// swiftlint:disable explicit_acl
-// this is mostly a copy pasted code, so don't wanna bother much with linting
-/// A modified version of RxSwift's VirtualTimeScheduler to support advancing by relative time
-open class _VirtualTimeScheduler<Converter: VirtualTimeConverterType>:
-    SchedulerType {
-    public typealias VirtualTime = Converter.VirtualTimeUnit
-    public typealias VirtualTimeInterval = Converter.VirtualTimeIntervalUnit
+    // swiftlint:disable explicit_acl
+    // this is mostly a copy pasted code, so don't wanna bother much with linting
+    /// A modified version of RxSwift's VirtualTimeScheduler to support advancing by relative time
+    open class _VirtualTimeScheduler<Converter: VirtualTimeConverterType>:
+        SchedulerType
+    {
+        public typealias VirtualTime = Converter.VirtualTimeUnit
+        public typealias VirtualTimeInterval = Converter.VirtualTimeIntervalUnit
 
-    private var _running: Bool
+        private var _running: Bool
 
-    private var _clock: VirtualTime
+        private var _clock: VirtualTime
 
-    fileprivate var _schedulerQueue: PriorityQueue<VirtualSchedulerItem<VirtualTime>>
-    private var _converter: Converter
+        fileprivate var _schedulerQueue: PriorityQueue<VirtualSchedulerItem<VirtualTime>>
+        private var _converter: Converter
 
-    private var _nextId = 0
+        private var _nextId = 0
 
-    /// - returns: Current time.
-    public var now: RxTime {
-        return _converter.convertFromVirtualTime(clock)
-    }
+        /// - returns: Current time.
+        public var now: RxTime {
+            return _converter.convertFromVirtualTime(clock)
+        }
 
-    /// - returns: Scheduler's absolute time clock value.
-    public var clock: VirtualTime {
-        return _clock
-    }
+        /// - returns: Scheduler's absolute time clock value.
+        public var clock: VirtualTime {
+            return _clock
+        }
 
-    /// Creates a new virtual time scheduler.
-    ///
-    /// - parameter initialClock: Initial value for the clock.
-    public init(initialClock: VirtualTime, converter: Converter) {
-        _clock = initialClock
-        _running = false
-        _converter = converter
-        _schedulerQueue = PriorityQueue(
-            hasHigherPriority: {
-                switch converter.compareVirtualTime($0.time, $1.time) {
-                case .lessThan:
-                    return true
-                case .equal:
-                    return $0.id < $1.id
-                case .greaterThan:
-                    return false
-                }
-            }, isEqual: { $0 === $1 }
-        )
-        #if TRACE_RESOURCES
-            _ = Resources.incrementTotal()
-        #endif
-    }
+        /// Creates a new virtual time scheduler.
+        ///
+        /// - parameter initialClock: Initial value for the clock.
+        public init(initialClock: VirtualTime, converter: Converter) {
+            _clock = initialClock
+            _running = false
+            _converter = converter
+            _schedulerQueue = PriorityQueue(
+                hasHigherPriority: {
+                    switch converter.compareVirtualTime($0.time, $1.time) {
+                    case .lessThan:
+                        return true
+                    case .equal:
+                        return $0.id < $1.id
+                    case .greaterThan:
+                        return false
+                    }
+                }, isEqual: { $0 === $1 }
+            )
+            #if TRACE_RESOURCES
+                _ = Resources.incrementTotal()
+            #endif
+        }
 
-    /**
+        /**
      Schedules an action to be executed immediately.
      - parameter state: State passed to the action to be executed.
      - parameter action: Action to be executed.
      - returns: The disposable object used to cancel the scheduled action (best effort).
      */
-    public func schedule<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable)
-        -> Disposable {
-        return scheduleRelative(state, dueTime: .nanoseconds(0)) { a in
-            action(a)
+        public func schedule<StateType>(
+            _ state: StateType, action: @escaping (StateType) -> Disposable
+        )
+            -> Disposable
+        {
+            return scheduleRelative(state, dueTime: .nanoseconds(0)) { a in
+                action(a)
+            }
         }
-    }
 
-    /**
+        /**
      Schedules an action to be executed.
      - parameter state: State passed to the action to be executed.
      - parameter dueTime: Relative time after which to execute the action.
      - parameter action: Action to be executed.
      - returns: The disposable object used to cancel the scheduled action (best effort).
      */
-    public func scheduleRelative<StateType>(
-        _ state: StateType, dueTime: RxTimeInterval, action: @escaping (StateType) -> Disposable
-    ) -> Disposable {
-        let time = now.addingTimeInterval(dueTime.convertToSecondsInterval)
-        let absoluteTime = _converter.convertToVirtualTime(time)
-        let adjustedTime = adjustScheduledTime(absoluteTime)
-        return scheduleAbsoluteVirtual(state, time: adjustedTime, action: action)
-    }
+        public func scheduleRelative<StateType>(
+            _ state: StateType, dueTime: RxTimeInterval, action: @escaping (StateType) -> Disposable
+        ) -> Disposable {
+            let time = now.addingTimeInterval(dueTime.convertToSecondsInterval)
+            let absoluteTime = _converter.convertToVirtualTime(time)
+            let adjustedTime = adjustScheduledTime(absoluteTime)
+            return scheduleAbsoluteVirtual(state, time: adjustedTime, action: action)
+        }
 
-    /**
+        /**
      Schedules an action to be executed after relative time has passed.
      - parameter state: State passed to the action to be executed.
      - parameter time: Absolute time when to execute the action. If this is less or equal then `now`, `now + 1`  will be used.
      - parameter action: Action to be executed.
      - returns: The disposable object used to cancel the scheduled action (best effort).
      */
-    public func scheduleRelativeVirtual<StateType>(
-        _ state: StateType, dueTime: VirtualTimeInterval, action: @escaping (StateType) -> Disposable
-    ) -> Disposable {
-        let time = _converter.offsetVirtualTime(clock, offset: dueTime)
-        return scheduleAbsoluteVirtual(state, time: time, action: action)
-    }
+        public func scheduleRelativeVirtual<StateType>(
+            _ state: StateType, dueTime: VirtualTimeInterval,
+            action: @escaping (StateType) -> Disposable
+        ) -> Disposable {
+            let time = _converter.offsetVirtualTime(clock, offset: dueTime)
+            return scheduleAbsoluteVirtual(state, time: time, action: action)
+        }
 
-    /**
+        /**
      Schedules an action to be executed at absolute virtual time.
      - parameter state: State passed to the action to be executed.
      - parameter time: Absolute time when to execute the action.
      - parameter action: Action to be executed.
      - returns: The disposable object used to cancel the scheduled action (best effort).
      */
-    public func scheduleAbsoluteVirtual<StateType>(
-        _ state: StateType, time: Converter.VirtualTimeUnit, action: @escaping (StateType) -> Disposable
-    ) -> Disposable {
-        MainScheduler.ensureExecutingOnScheduler()
+        public func scheduleAbsoluteVirtual<StateType>(
+            _ state: StateType, time: Converter.VirtualTimeUnit,
+            action: @escaping (StateType) -> Disposable
+        ) -> Disposable {
+            MainScheduler.ensureExecutingOnScheduler()
 
-        let compositeDisposable = CompositeDisposable()
+            let compositeDisposable = CompositeDisposable()
 
-        let item = VirtualSchedulerItem(
-            action: {
-                let dispose = action(state)
-                return dispose
-            }, time: time, id: _nextId
-        )
+            let item = VirtualSchedulerItem(
+                action: {
+                    let dispose = action(state)
+                    return dispose
+                }, time: time, id: _nextId
+            )
 
-        _nextId += 1
+            _nextId += 1
 
-        _schedulerQueue.enqueue(item)
+            _schedulerQueue.enqueue(item)
 
-        _ = compositeDisposable.insert(item)
+            _ = compositeDisposable.insert(item)
 
-        return compositeDisposable
-    }
-
-    /// Adjusts time of scheduling before adding item to schedule queue.
-    open func adjustScheduledTime(_ time: Converter.VirtualTimeUnit) -> Converter.VirtualTimeUnit {
-        return time
-    }
-
-    /// Runs the scheduler until it has no scheduled items left.
-    public func run() {
-        MainScheduler.ensureExecutingOnScheduler()
-
-        if _running {
-            return
+            return compositeDisposable
         }
 
-        _running = true
-        repeat {
-            guard let next = findNext() else {
-                break
-            }
-
-            if _converter.compareVirtualTime(next.time, clock).greaterThan {
-                _clock = next.time
-            }
-
-            next.invoke()
-            _schedulerQueue.remove(next)
-        } while _running
-
-        _running = false
-    }
-
-    func findNext() -> VirtualSchedulerItem<VirtualTime>? {
-        while let front = _schedulerQueue.peek() {
-            if front.isDisposed {
-                _schedulerQueue.remove(front)
-                continue
-            }
-
-            return front
+        /// Adjusts time of scheduling before adding item to schedule queue.
+        open func adjustScheduledTime(_ time: Converter.VirtualTimeUnit)
+            -> Converter.VirtualTimeUnit
+        {
+            return time
         }
 
-        return nil
-    }
+        /// Runs the scheduler until it has no scheduled items left.
+        public func run() {
+            MainScheduler.ensureExecutingOnScheduler()
 
-    /// Advances the scheduler's clock to the specified time, running all work till that point.
-    ///
-    /// - parameter virtualTime: Absolute time to advance the scheduler's clock to.
-    public func advance(to virtualTime: VirtualTime) {
-        MainScheduler.ensureExecutingOnScheduler()
+            if _running {
+                return
+            }
 
-        if _running {
-            fatalError("Scheduler is already running")
+            _running = true
+            repeat {
+                guard let next = findNext() else {
+                    break
+                }
+
+                if _converter.compareVirtualTime(next.time, clock).greaterThan {
+                    _clock = next.time
+                }
+
+                next.invoke()
+                _schedulerQueue.remove(next)
+            } while _running
+
+            _running = false
         }
 
-        _running = true
-        repeat {
-            guard let next = findNext() else {
-                break
+        func findNext() -> VirtualSchedulerItem<VirtualTime>? {
+            while let front = _schedulerQueue.peek() {
+                if front.isDisposed {
+                    _schedulerQueue.remove(front)
+                    continue
+                }
+
+                return front
             }
 
-            if _converter.compareVirtualTime(next.time, virtualTime).greaterThan {
-                break
-            }
-
-            if _converter.compareVirtualTime(next.time, clock).greaterThan {
-                _clock = next.time
-            }
-
-            next.invoke()
-            _schedulerQueue.remove(next)
-        } while _running
-
-        _clock = virtualTime
-        _running = false
-    }
-
-    public func advance(by virtualInterval: VirtualTimeInterval) {
-        let absoluteTime = _converter.offsetVirtualTime(clock, offset: virtualInterval)
-
-        advance(to: absoluteTime)
-    }
-
-    #if TRACE_RESOURCES
-        deinit {
-            _ = Resources.decrementTotal()
+            return nil
         }
-    #endif
-}
 
-// MARK: description
+        /// Advances the scheduler's clock to the specified time, running all work till that point.
+        ///
+        /// - parameter virtualTime: Absolute time to advance the scheduler's clock to.
+        public func advance(to virtualTime: VirtualTime) {
+            MainScheduler.ensureExecutingOnScheduler()
 
-extension _VirtualTimeScheduler: CustomDebugStringConvertible {
-    /// A textual representation of `self`, suitable for debugging.
-    public var debugDescription: String {
-        return _schedulerQueue.debugDescription
-    }
-}
+            if _running {
+                fatalError("Scheduler is already running")
+            }
 
-final class VirtualSchedulerItem<Time>:
-    Disposable {
-    typealias Action = () -> Disposable
+            _running = true
+            repeat {
+                guard let next = findNext() else {
+                    break
+                }
 
-    let action: Action
-    let time: Time
-    let id: Int
+                if _converter.compareVirtualTime(next.time, virtualTime).greaterThan {
+                    break
+                }
 
-    var isDisposed: Bool {
-        return disposable.isDisposed
-    }
+                if _converter.compareVirtualTime(next.time, clock).greaterThan {
+                    _clock = next.time
+                }
 
-    var disposable = SingleAssignmentDisposable()
+                next.invoke()
+                _schedulerQueue.remove(next)
+            } while _running
 
-    init(action: @escaping Action, time: Time, id: Int) {
-        self.action = action
-        self.time = time
-        self.id = id
-    }
+            _clock = virtualTime
+            _running = false
+        }
 
-    func invoke() {
-        disposable.setDisposable(action())
-    }
+        public func advance(by virtualInterval: VirtualTimeInterval) {
+            let absoluteTime = _converter.offsetVirtualTime(clock, offset: virtualInterval)
 
-    func dispose() {
-        disposable.dispose()
-    }
-}
+            advance(to: absoluteTime)
+        }
 
-extension VirtualSchedulerItem:
-    CustomDebugStringConvertible {
-    var debugDescription: String {
-        return "\(time)"
-    }
-}
-
-extension VirtualTimeComparison {
-    /// lhs < rhs.
-    var lessThan: Bool {
-        return self == .lessThan
+        #if TRACE_RESOURCES
+            deinit {
+                _ = Resources.decrementTotal()
+            }
+        #endif
     }
 
-    /// lhs > rhs
-    var greaterThan: Bool {
-        return self == .greaterThan
+    // MARK: description
+
+    extension _VirtualTimeScheduler: CustomDebugStringConvertible {
+        /// A textual representation of `self`, suitable for debugging.
+        public var debugDescription: String {
+            return _schedulerQueue.debugDescription
+        }
     }
 
-    /// lhs == rhs
-    var equal: Bool {
-        return self == .equal
+    final class VirtualSchedulerItem<Time>:
+        Disposable
+    {
+        typealias Action = () -> Disposable
+
+        let action: Action
+        let time: Time
+        let id: Int
+
+        var isDisposed: Bool {
+            return disposable.isDisposed
+        }
+
+        var disposable = SingleAssignmentDisposable()
+
+        init(action: @escaping Action, time: Time, id: Int) {
+            self.action = action
+            self.time = time
+            self.id = id
+        }
+
+        func invoke() {
+            disposable.setDisposable(action())
+        }
+
+        func dispose() {
+            disposable.dispose()
+        }
     }
-}
+
+    extension VirtualSchedulerItem:
+        CustomDebugStringConvertible
+    {
+        var debugDescription: String {
+            return "\(time)"
+        }
+    }
+
+    extension VirtualTimeComparison {
+        /// lhs < rhs.
+        var lessThan: Bool {
+            return self == .lessThan
+        }
+
+        /// lhs > rhs
+        var greaterThan: Bool {
+            return self == .greaterThan
+        }
+
+        /// lhs == rhs
+        var equal: Bool {
+            return self == .equal
+        }
+    }
 #endif

--- a/Sources/RxComposableArchitecture/TestSupport/XCTFail.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/XCTFail.swift
@@ -1,7 +1,79 @@
 #if DEBUG
-  #if canImport(ObjectiveC)
-    import Foundation
-  
+    #if canImport(ObjectiveC)
+        import Foundation
+
+        /// This function generates a failure immediately and unconditionally.
+        ///
+        /// Dynamically creates and records an `XCTIssue` under the hood that captures the source code
+        /// context of the caller. Useful for defining assertion helpers that fail in indirect code
+        /// paths, where the `file` and `line` of the failure have not been realized.
+        ///
+        /// - Parameter message: An optional description of the assertion, for inclusion in test
+        ///   results.
+        internal func XCTFail(_ message: String = "") {
+            if let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter")
+                as Any as? NSObjectProtocol,
+                String(describing: XCTestObservationCenter) != "<null>",
+                let shared = XCTestObservationCenter.perform(
+                    Selector(("sharedTestObservationCenter")))?
+                    .takeUnretainedValue(),
+                let observers = shared.perform(Selector(("observers")))?
+                    .takeUnretainedValue() as? [AnyObject],
+                let observer =
+                    observers
+                    .first(where: { NSStringFromClass(type(of: $0)) == "XCTestMisuseObserver" }),
+                let currentTestCase = observer.perform(Selector(("currentTestCase")))?
+                    .takeUnretainedValue(),
+                let XCTIssue = NSClassFromString("XCTIssue")
+                    as Any as? NSObjectProtocol,
+                let alloc = XCTIssue.perform(NSSelectorFromString("alloc"))?
+                    .takeUnretainedValue(),
+                let issue =
+                    alloc
+                    .perform(
+                        Selector(("initWithType:compactDescription:")),
+                        with: 0,
+                        with: message.isEmpty ? "failed" : message
+                    )?
+                    .takeUnretainedValue()
+            {
+                _ = currentTestCase.perform(Selector(("recordIssue:")), with: issue)
+                return
+            }
+        }
+
+        /// This function generates a failure immediately and unconditionally.
+        ///
+        /// Dynamically calls `XCTFail` with the given file and line. Useful for defining assertion
+        /// helpers that have the source code context at hand and want to highlight the direct caller
+        /// of the helper.
+        ///
+        /// - Parameter message: An optional description of the assertion, for inclusion in test
+        ///   results.
+        internal func XCTFail(_ message: String = "", file: StaticString, line: UInt) {
+            guard let _XCTFailureHandler = _XCTFailureHandler
+            else { return }
+
+            _XCTFailureHandler(
+                nil, true, "\(file)", line, "\(message.isEmpty ? "failed" : message)", nil)
+        }
+
+        private typealias XCTFailureHandler = @convention(c) (
+            AnyObject?, Bool, UnsafePointer<CChar>, UInt, String, String?
+        ) -> Void
+        private let XCTest = NSClassFromString("XCTest")
+            .flatMap(Bundle.init(for:))
+            .flatMap { $0.executablePath }
+            .flatMap { dlopen($0, RTLD_NOW) }
+        private let _XCTFailureHandler =
+            XCTest
+            .flatMap { dlsym($0, "_XCTFailureHandler") }
+            .map { unsafeBitCast($0, to: XCTFailureHandler.self) }
+    #else
+        // NB: It seems to be safe to import XCTest on Linux
+        @_exported import func XCTest.XCTFail
+    #endif
+#else
     /// This function generates a failure immediately and unconditionally.
     ///
     /// Dynamically creates and records an `XCTIssue` under the hood that captures the source code
@@ -10,85 +82,15 @@
     ///
     /// - Parameter message: An optional description of the assertion, for inclusion in test
     ///   results.
-    internal func XCTFail(_ message: String = "") {
-      if let XCTestObservationCenter = NSClassFromString("XCTestObservationCenter")
-        as Any as? NSObjectProtocol,
-        String(describing: XCTestObservationCenter) != "<null>",
-        let shared = XCTestObservationCenter.perform(Selector(("sharedTestObservationCenter")))?
-          .takeUnretainedValue(),
-        let observers = shared.perform(Selector(("observers")))?
-          .takeUnretainedValue() as? [AnyObject],
-        let observer =
-          observers
-          .first(where: { NSStringFromClass(type(of: $0)) == "XCTestMisuseObserver" }),
-        let currentTestCase = observer.perform(Selector(("currentTestCase")))?
-          .takeUnretainedValue(),
-        let XCTIssue = NSClassFromString("XCTIssue")
-          as Any as? NSObjectProtocol,
-        let alloc = XCTIssue.perform(NSSelectorFromString("alloc"))?
-          .takeUnretainedValue(),
-        let issue =
-          alloc
-          .perform(
-            Selector(("initWithType:compactDescription:")),
-            with: 0,
-            with: message.isEmpty ? "failed" : message
-          )?
-          .takeUnretainedValue()
-      {
-        _ = currentTestCase.perform(Selector(("recordIssue:")), with: issue)
-        return
-      }
-    }
-  
+    internal func XCTFail(_ message: String = "") {}
+
     /// This function generates a failure immediately and unconditionally.
     ///
-    /// Dynamically calls `XCTFail` with the given file and line. Useful for defining assertion
-    /// helpers that have the source code context at hand and want to highlight the direct caller
-    /// of the helper.
+    /// Dynamically creates and records an `XCTIssue` under the hood that captures the source code
+    /// context of the caller. Useful for defining assertion helpers that fail in indirect code
+    /// paths, where the `file` and `line` of the failure have not been realized.
     ///
     /// - Parameter message: An optional description of the assertion, for inclusion in test
     ///   results.
-    internal func XCTFail(_ message: String = "", file: StaticString, line: UInt) {
-      guard let _XCTFailureHandler = _XCTFailureHandler
-      else { return }
-  
-      _XCTFailureHandler(nil, true, "\(file)", line, "\(message.isEmpty ? "failed" : message)", nil)
-    }
-  
-    private typealias XCTFailureHandler = @convention(c) (
-      AnyObject?, Bool, UnsafePointer<CChar>, UInt, String, String?
-    ) -> Void
-    private let XCTest = NSClassFromString("XCTest")
-      .flatMap(Bundle.init(for:))
-      .flatMap { $0.executablePath }
-      .flatMap { dlopen($0, RTLD_NOW) }
-    private let _XCTFailureHandler =
-      XCTest
-      .flatMap { dlsym($0, "_XCTFailureHandler") }
-      .map { unsafeBitCast($0, to: XCTFailureHandler.self) }
-  #else
-    // NB: It seems to be safe to import XCTest on Linux
-    @_exported import func XCTest.XCTFail
-  #endif
-#else
-  /// This function generates a failure immediately and unconditionally.
-  ///
-  /// Dynamically creates and records an `XCTIssue` under the hood that captures the source code
-  /// context of the caller. Useful for defining assertion helpers that fail in indirect code
-  /// paths, where the `file` and `line` of the failure have not been realized.
-  ///
-  /// - Parameter message: An optional description of the assertion, for inclusion in test
-  ///   results.
-  internal func XCTFail(_ message: String = "") {}
-
-  /// This function generates a failure immediately and unconditionally.
-  ///
-  /// Dynamically creates and records an `XCTIssue` under the hood that captures the source code
-  /// context of the caller. Useful for defining assertion helpers that fail in indirect code
-  /// paths, where the `file` and `line` of the failure have not been realized.
-  ///
-  /// - Parameter message: An optional description of the assertion, for inclusion in test
-  ///   results.
-  internal func XCTFail(_ message: String = "", file: StaticString, line: UInt) {}
+    internal func XCTFail(_ message: String = "", file: StaticString, line: UInt) {}
 #endif

--- a/Tests/RxComposableArchitectureTests/BootstrapTests.swift
+++ b/Tests/RxComposableArchitectureTests/BootstrapTests.swift
@@ -1,6 +1,6 @@
 //
 //  BoostrapTests.swift
-//  
+//
 //
 //  Created by jefferson.setiawan on 03/08/22.
 //
@@ -15,7 +15,7 @@ internal final class BoostrapTests: XCTestCase {
         struct Env {
             var getNumber: () -> Int
         }
-        
+
         let reducer = Reducer<Int, Void, Env> { state, action, env in
             state = env.getNumber()
             return .none
@@ -24,16 +24,16 @@ internal final class BoostrapTests: XCTestCase {
             return 0
         })
         let store = Store(initialState: -1, reducer: reducer, environment: env)
-        
+
         let mockEnv = Env(getNumber: {
             return 100
         })
         Bootstrap.mock(environment: mockEnv)
-        
+
         store.send(())
 
         XCTAssertEqual(store.state, 100)
-        
+
         // clearing the bootstrap
         Bootstrap.clear(environment: Env.self)
         store.send(())

--- a/Tests/RxComposableArchitectureTests/CustomDumpTests/Conformances/CoreImageTests.swift
+++ b/Tests/RxComposableArchitectureTests/CustomDumpTests/Conformances/CoreImageTests.swift
@@ -1,39 +1,39 @@
 #if canImport(CoreImage)
-  import CoreImage
-  import RxComposableArchitecture
-  import XCTest
+    import CoreImage
+    import RxComposableArchitecture
+    import XCTest
 
-  final class CoreImageTests: XCTestCase {
-    func testCIQRCodeDescriptor() {
-      var dump = ""
-      customDump(
-        [.levelH, .levelL, .levelM, .levelQ] as [CIQRCodeDescriptor.ErrorCorrectionLevel],
-        to: &dump
-      )
+    final class CoreImageTests: XCTestCase {
+        func testCIQRCodeDescriptor() {
+            var dump = ""
+            customDump(
+                [.levelH, .levelL, .levelM, .levelQ] as [CIQRCodeDescriptor.ErrorCorrectionLevel],
+                to: &dump
+            )
 
-      XCTAssertEqual(
-        dump,
-        """
-        [
-          [0]: CIQRCodeDescriptor.ErrorCorrectionLevel.levelH,
-          [1]: CIQRCodeDescriptor.ErrorCorrectionLevel.levelL,
-          [2]: CIQRCodeDescriptor.ErrorCorrectionLevel.levelM,
-          [3]: CIQRCodeDescriptor.ErrorCorrectionLevel.levelQ
-        ]
-        """
-      )
+            XCTAssertEqual(
+                dump,
+                """
+                [
+                  [0]: CIQRCodeDescriptor.ErrorCorrectionLevel.levelH,
+                  [1]: CIQRCodeDescriptor.ErrorCorrectionLevel.levelL,
+                  [2]: CIQRCodeDescriptor.ErrorCorrectionLevel.levelM,
+                  [3]: CIQRCodeDescriptor.ErrorCorrectionLevel.levelQ
+                ]
+                """
+            )
 
-      dump = ""
-      customDump(
-        CIQRCodeDescriptor.ErrorCorrectionLevel.levelH,
-        to: &dump
-      )
-      XCTAssertEqual(
-        dump,
-        """
-        CIQRCodeDescriptor.ErrorCorrectionLevel.levelH
-        """
-      )
+            dump = ""
+            customDump(
+                CIQRCodeDescriptor.ErrorCorrectionLevel.levelH,
+                to: &dump
+            )
+            XCTAssertEqual(
+                dump,
+                """
+                CIQRCodeDescriptor.ErrorCorrectionLevel.levelH
+                """
+            )
+        }
     }
-  }
 #endif

--- a/Tests/RxComposableArchitectureTests/CustomDumpTests/Conformances/FoundationTests.swift
+++ b/Tests/RxComposableArchitectureTests/CustomDumpTests/Conformances/FoundationTests.swift
@@ -1,652 +1,652 @@
-import RxComposableArchitecture
 import Foundation
+import RxComposableArchitecture
 import XCTest
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+    import FoundationNetworking
 #endif
 
 final class FoundationTests: XCTestCase {
-  func testAttributedString() {
-    #if compiler(>=5.5) && !targetEnvironment(macCatalyst) && (os(iOS) || os(tvOS) || os(watchOS))
-      if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
-        var dump = ""
-        customDump(
-          try? AttributedString(markdown: "Hello, **Blob**!"),
-          to: &dump
-        )
-        XCTAssertNoDifference(
-          dump,
-          """
-          "Hello, Blob!"
-          """
-        )
-      }
-    #endif
-  }
-
-  func testCFNumber() {
-    // NB: `CFNumber` is unavailable on Linux
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-      var dump = ""
-      customDump(
-        42 as CFNumber,
-        to: &dump
-      )
-      XCTAssertNoDifference(
-        dump,
-        """
-        42
-        """
-      )
-    #endif
-  }
-
-  func testDate() {
-    var dump = ""
-    customDump(
-      Date(timeIntervalSince1970: 0),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Date(1970-01-01T00:00:00.000Z)
-      """
-    )
-
-    #if compiler(>=5.4)
-      dump = ""
-      customDump(
-        NestedDate(date: Date(timeIntervalSince1970: 0)),
-        to: &dump
-      )
-      XCTAssertNoDifference(
-        dump,
-        """
-        NestedDate(date: Date(1970-01-01T00:00:00.000Z))
-        """
-      )
-    #endif
-  }
-
-  func testDecimal() {
-    var dump = ""
-    customDump(
-      Decimal(string: "1.23"),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      1.23
-      """
-    )
-  }
-
-  func testNSArray() {
-    var dump = ""
-    customDump(
-      [1, 2, 3] as NSArray,
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      [
-        [0]: 1,
-        [1]: 2,
-        [2]: 3
-      ]
-      """
-    )
-  }
-
-  func testNSAttributedString() {
-    let attributedString = NSMutableAttributedString(string: "")
-    attributedString.append(NSAttributedString(string: "Hello, "))
-    attributedString.append(
-      NSAttributedString(string: "Blob", attributes: [.init(rawValue: "name"): true])
-    )
-    attributedString.append(NSAttributedString(string: "!"))
-    var dump = ""
-    customDump(
-      attributedString,
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      "Hello, Blob!"
-      """
-    )
-  }
-
-  func testNSCalendar() {
-    let calendar = NSCalendar(calendarIdentifier: .gregorian)!
-    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-    var dump = ""
-    customDump(
-      calendar,
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Calendar(
-        identifier: Calendar.Identifier.gregorian,
-        locale: Locale(),
-        timeZone: TimeZone(
-          identifier: "GMT",
-          abbreviation: "GMT",
-          secondsFromGMT: 0,
-          isDaylightSavingTime: false
-        ),
-        firstWeekday: 1,
-        minimumDaysInFirstWeek: 1
-      )
-      """
-    )
-  }
-
-  func testNSCountedSet() {
-    var dump = ""
-    customDump(
-      NSCountedSet(array: [1, 2, 2, 3, 3, 3]),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Set([
-        1,
-        2,
-        3
-      ])
-      """
-    )
-  }
-
-  func testNSData() {
-    var dump = ""
-    customDump(
-      NSData(data: .init(repeating: 0, count: 4)),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Data(4 bytes)
-      """
-    )
-  }
-
-  func testNSDate() {
-    var dump = ""
-    customDump(
-      NSDate(timeIntervalSince1970: 0),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Date(1970-01-01T00:00:00.000Z)
-      """
-    )
-  }
-
-  func testNSDictionary() {
-    var dump = ""
-    customDump(
-      [1: "1", 2: "2", 3: "3"] as NSDictionary,
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      [
-        1: "1",
-        2: "2",
-        3: "3"
-      ]
-      """
-    )
-  }
-
-  func testNSError() {
-    var dump = ""
-    customDump(
-      NSError(
-        domain: "co.pointfree",
-        code: 42,
-        userInfo: [
-          NSLocalizedDescriptionKey: "An error occurred" as NSString
-        ]
-      ),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      NSError(
-        domain: "co.pointfree",
-        code: 42,
-        userInfo: [
-          "NSLocalizedDescription": "An error occurred"
-        ]
-      )
-      """
-    )
-
-    #if !os(Windows)
-      class SubclassedError: NSError {}
-
-      dump = ""
-      customDump(
-        SubclassedError(
-          domain: "co.pointfree",
-          code: 43,
-          userInfo: [
-            NSLocalizedDescriptionKey: "An error occurred" as NSString
-          ]
-        ),
-        to: &dump
-      )
-      XCTAssertNoDifference(
-        dump,
-        """
-        NSError(
-          domain: "co.pointfree",
-          code: 43,
-          userInfo: [
-            "NSLocalizedDescription": "An error occurred"
-          ]
-        )
-        """
-      )
-    #endif
-
-    enum BridgedError: Error {
-      case thisIsFine(Int)
+    func testAttributedString() {
+        #if compiler(>=5.5) && !targetEnvironment(macCatalyst) && (os(iOS) || os(tvOS) || os(watchOS))
+            if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
+                var dump = ""
+                customDump(
+                    try? AttributedString(markdown: "Hello, **Blob**!"),
+                    to: &dump
+                )
+                XCTAssertNoDifference(
+                    dump,
+                    """
+                    "Hello, Blob!"
+                    """
+                )
+            }
+        #endif
     }
 
-    dump = ""
-    customDump(BridgedError.thisIsFine(94) as NSError, to: &dump)
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-      XCTAssertNoDifference(
-        dump,
-        """
-        FoundationTests.BridgedError.thisIsFine(94)
-        """
-      )
-    #elseif compiler(>=5.4)
-      // Can't unwrap bridged Errors on Linux: https://bugs.swift.org/browse/SR-15191
-      XCTAssertNoDifference(
-        dump.replacingOccurrences(
-          of: #"\(unknown context at \$[[:xdigit:]]+\)\."#,
-          with: "",
-          options: .regularExpression
-        ),
-        """
-        NSError(
-          domain: "CustomDumpTests.FoundationTests.BridgedError",
-          code: 0,
-          userInfo: [:]
+    func testCFNumber() {
+        // NB: `CFNumber` is unavailable on Linux
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+            var dump = ""
+            customDump(
+                42 as CFNumber,
+                to: &dump
+            )
+            XCTAssertNoDifference(
+                dump,
+                """
+                42
+                """
+            )
+        #endif
+    }
+
+    func testDate() {
+        var dump = ""
+        customDump(
+            Date(timeIntervalSince1970: 0),
+            to: &dump
         )
-        """
-      )
-    #endif
-  }
-
-  func testNSException() {
-    // NB: `NSException` is unavailable on Linux
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-      var dump = ""
-      customDump(
-        NSException(name: .genericException, reason: "Oops!", userInfo: nil),
-        to: &dump
-      )
-      XCTAssertNoDifference(
-        dump,
-        """
-        NSException(
-          name: NSGenericException,
-          reason: "Oops!",
-          userInfo: nil
+        XCTAssertNoDifference(
+            dump,
+            """
+            Date(1970-01-01T00:00:00.000Z)
+            """
         )
-        """
-      )
-    #endif
-  }
 
-  func testNSExpression() {
-    // NB: `NSExpression` is unavailable on Linux
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-      var dump = ""
-      customDump(
-        NSExpression(format: "1 + 1"),
-        to: &dump
-      )
-      XCTAssertNoDifference(
-        dump,
-        """
-        1 + 1
-        """
-      )
-    #endif
-  }
+        #if compiler(>=5.4)
+            dump = ""
+            customDump(
+                NestedDate(date: Date(timeIntervalSince1970: 0)),
+                to: &dump
+            )
+            XCTAssertNoDifference(
+                dump,
+                """
+                NestedDate(date: Date(1970-01-01T00:00:00.000Z))
+                """
+            )
+        #endif
+    }
 
-  func testNSIndexPath() {
-    var dump = ""
-    customDump(
-      NSIndexPath(),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      []
-      """
-    )
-  }
+    func testDecimal() {
+        var dump = ""
+        customDump(
+            Decimal(string: "1.23"),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            1.23
+            """
+        )
+    }
 
-  func testNSIndexSet() {
-    var dump = ""
-    customDump(
-      NSIndexSet(indexSet: [1, 2, 3, 5, 7]),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      IndexSet(
-        ranges: [
-          [0]: 1..<4,
-          [1]: 5..<6,
-          [2]: 7..<8
-        ]
-      )
-      """
-    )
-  }
+    func testNSArray() {
+        var dump = ""
+        customDump(
+            [1, 2, 3] as NSArray,
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            [
+              [0]: 1,
+              [1]: 2,
+              [2]: 3
+            ]
+            """
+        )
+    }
 
-  func testNSLocale() {
-    var dump = ""
-    customDump(
-      NSLocale(localeIdentifier: "en_US"),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Locale(en_US)
-      """
-    )
-  }
+    func testNSAttributedString() {
+        let attributedString = NSMutableAttributedString(string: "")
+        attributedString.append(NSAttributedString(string: "Hello, "))
+        attributedString.append(
+            NSAttributedString(string: "Blob", attributes: [.init(rawValue: "name"): true])
+        )
+        attributedString.append(NSAttributedString(string: "!"))
+        var dump = ""
+        customDump(
+            attributedString,
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            "Hello, Blob!"
+            """
+        )
+    }
 
-  func testNSMeasurement() {
-    var dump = ""
-    customDump(
-      NSMeasurement(doubleValue: 42, unit: Unit(symbol: "kg")),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Measurement(
-        value: 42.0,
-        unit: "kg"
-      )
-      """
-    )
-  }
+    func testNSCalendar() {
+        let calendar = NSCalendar(calendarIdentifier: .gregorian)!
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        var dump = ""
+        customDump(
+            calendar,
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Calendar(
+              identifier: Calendar.Identifier.gregorian,
+              locale: Locale(),
+              timeZone: TimeZone(
+                identifier: "GMT",
+                abbreviation: "GMT",
+                secondsFromGMT: 0,
+                isDaylightSavingTime: false
+              ),
+              firstWeekday: 1,
+              minimumDaysInFirstWeek: 1
+            )
+            """
+        )
+    }
 
-  func testNSNotification() {
-    var dump = ""
-    customDump(
-      NSNotification(name: .init(rawValue: "co.pointfree"), object: nil, userInfo: nil),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Notification(name: "co.pointfree")
-      """
-    )
-  }
+    func testNSCountedSet() {
+        var dump = ""
+        customDump(
+            NSCountedSet(array: [1, 2, 2, 3, 3, 3]),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Set([
+              1,
+              2,
+              3
+            ])
+            """
+        )
+    }
 
-  func testNSNull() {
-    var dump = ""
-    customDump(
-      NSNull(),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      NSNull()
-      """
-    )
-  }
+    func testNSData() {
+        var dump = ""
+        customDump(
+            NSData(data: .init(repeating: 0, count: 4)),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Data(4 bytes)
+            """
+        )
+    }
 
-  func testNSNumber() {
-    var dump = ""
-    customDump(
-      1 as NSNumber,
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      1
-      """
-    )
+    func testNSDate() {
+        var dump = ""
+        customDump(
+            NSDate(timeIntervalSince1970: 0),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Date(1970-01-01T00:00:00.000Z)
+            """
+        )
+    }
 
-    #if canImport(ObjectiveC)
-      dump = ""
-      customDump(
-        NSNumber(),
-        to: &dump
-      )
-      XCTAssertNoDifference(
-        dump,
-        """
-        (null pointer)
-        """
-      )
-    #endif
-  }
+    func testNSDictionary() {
+        var dump = ""
+        customDump(
+            [1: "1", 2: "2", 3: "3"] as NSDictionary,
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            [
+              1: "1",
+              2: "2",
+              3: "3"
+            ]
+            """
+        )
+    }
 
-  func testNSOrderedSet() {
-    var dump = ""
-    customDump(
-      [1, 2, 3] as NSOrderedSet,
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      [
-        [0]: 1,
-        [1]: 2,
-        [2]: 3
-      ]
-      """
-    )
-  }
+    func testNSError() {
+        var dump = ""
+        customDump(
+            NSError(
+                domain: "co.pointfree",
+                code: 42,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "An error occurred" as NSString
+                ]
+            ),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            NSError(
+              domain: "co.pointfree",
+              code: 42,
+              userInfo: [
+                "NSLocalizedDescription": "An error occurred"
+              ]
+            )
+            """
+        )
 
-  func testNSRange() {
-    var dump = ""
-    customDump(
-      NSRange(0..<1),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      0..<1
-      """
-    )
-  }
+        #if !os(Windows)
+            class SubclassedError: NSError {}
 
-  func testNSSet() {
-    var dump = ""
-    customDump(
-      NSSet(array: [1, 2, 3]),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Set([
-        1,
-        2,
-        3
-      ])
-      """
-    )
-  }
+            dump = ""
+            customDump(
+                SubclassedError(
+                    domain: "co.pointfree",
+                    code: 43,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "An error occurred" as NSString
+                    ]
+                ),
+                to: &dump
+            )
+            XCTAssertNoDifference(
+                dump,
+                """
+                NSError(
+                  domain: "co.pointfree",
+                  code: 43,
+                  userInfo: [
+                    "NSLocalizedDescription": "An error occurred"
+                  ]
+                )
+                """
+            )
+        #endif
 
-  func testNSTimeZone() {
-    var dump = ""
-    customDump(
-      NSTimeZone(forSecondsFromGMT: 0),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      TimeZone(
-        identifier: "GMT",
-        abbreviation: "GMT",
-        secondsFromGMT: 0,
-        isDaylightSavingTime: false
-      )
-      """
-    )
-  }
+        enum BridgedError: Error {
+            case thisIsFine(Int)
+        }
 
-  func testNSURL() {
-    var dump = ""
-    customDump(
-      NSURL(fileURLWithPath: "/tmp"),
-      to: &dump
-    )
-    #if os(Windows)
-      XCTAssertNoDifference(
-        dump,
-        """
-        URL(file:///tmp)
-        """
-      )
-    #else
-      XCTAssertNoDifference(
-        dump,
-        """
-        URL(file:///tmp/)
-        """
-      )
-    #endif
-  }
+        dump = ""
+        customDump(BridgedError.thisIsFine(94) as NSError, to: &dump)
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+            XCTAssertNoDifference(
+                dump,
+                """
+                FoundationTests.BridgedError.thisIsFine(94)
+                """
+            )
+        #elseif compiler(>=5.4)
+            // Can't unwrap bridged Errors on Linux: https://bugs.swift.org/browse/SR-15191
+            XCTAssertNoDifference(
+                dump.replacingOccurrences(
+                    of: #"\(unknown context at \$[[:xdigit:]]+\)\."#,
+                    with: "",
+                    options: .regularExpression
+                ),
+                """
+                NSError(
+                  domain: "CustomDumpTests.FoundationTests.BridgedError",
+                  code: 0,
+                  userInfo: [:]
+                )
+                """
+            )
+        #endif
+    }
 
-  func testNSURLComponents() {
-    var dump = ""
-    customDump(
-      NSURLComponents(string: "https://www.pointfree.co/login?redirect=episodes"),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      URLComponents(
-        scheme: "https",
-        host: "www.pointfree.co",
-        path: "/login",
-        queryItems: [
-          [0]: URLQueryItem(
-            name: "redirect",
-            value: "episodes"
-          )
-        ]
-      )
-      """
-    )
-  }
+    func testNSException() {
+        // NB: `NSException` is unavailable on Linux
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+            var dump = ""
+            customDump(
+                NSException(name: .genericException, reason: "Oops!", userInfo: nil),
+                to: &dump
+            )
+            XCTAssertNoDifference(
+                dump,
+                """
+                NSException(
+                  name: NSGenericException,
+                  reason: "Oops!",
+                  userInfo: nil
+                )
+                """
+            )
+        #endif
+    }
 
-  func testNSURLQueryItem() {
-    var dump = ""
-    customDump(
-      NSURLQueryItem(name: "search", value: "composable architecture"),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      URLQueryItem(
-        name: "search",
-        value: "composable architecture"
-      )
-      """
-    )
-  }
+    func testNSExpression() {
+        // NB: `NSExpression` is unavailable on Linux
+        #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+            var dump = ""
+            customDump(
+                NSExpression(format: "1 + 1"),
+                to: &dump
+            )
+            XCTAssertNoDifference(
+                dump,
+                """
+                1 + 1
+                """
+            )
+        #endif
+    }
 
-  func testNSURLRequest() {
-    var dump = ""
-    let request = NSMutableURLRequest(url: URL(string: "https://www.pointfree.co")!)
-    request.addValue("text/html", forHTTPHeaderField: "Accept")
-    request.httpShouldUsePipelining = false
-    customDump(
-      request,
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      URLRequest(
-        url: URL(https://www.pointfree.co),
-        cachePolicy: 0,
-        timeoutInterval: 60.0,
-        mainDocumentURL: nil,
-        networkServiceType: URLRequest.NetworkServiceType.default,
-        allowsCellularAccess: true,
-        httpMethod: "GET",
-        allHTTPHeaderFields: [
-          "Accept": "text/html"
-        ],
-        httpBody: nil,
-        httpBodyStream: nil,
-        httpShouldHandleCookies: true,
-        httpShouldUsePipelining: false
-      )
-      """
-    )
-  }
+    func testNSIndexPath() {
+        var dump = ""
+        customDump(
+            NSIndexPath(),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            []
+            """
+        )
+    }
 
-  func testNSUUID() {
-    var dump = ""
-    customDump(
-      NSUUID(uuidString: "deadbeef-dead-beef-dead-beefdeadbeef"),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      UUID(DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF)
-      """
-    )
-  }
+    func testNSIndexSet() {
+        var dump = ""
+        customDump(
+            NSIndexSet(indexSet: [1, 2, 3, 5, 7]),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            IndexSet(
+              ranges: [
+                [0]: 1..<4,
+                [1]: 5..<6,
+                [2]: 7..<8
+              ]
+            )
+            """
+        )
+    }
 
-  func testURL() {
-    var dump = ""
-    customDump(
-      URL(string: "https://www.pointfree.co/"),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      URL(https://www.pointfree.co/)
-      """
-    )
-  }
+    func testNSLocale() {
+        var dump = ""
+        customDump(
+            NSLocale(localeIdentifier: "en_US"),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Locale(en_US)
+            """
+        )
+    }
+
+    func testNSMeasurement() {
+        var dump = ""
+        customDump(
+            NSMeasurement(doubleValue: 42, unit: Unit(symbol: "kg")),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Measurement(
+              value: 42.0,
+              unit: "kg"
+            )
+            """
+        )
+    }
+
+    func testNSNotification() {
+        var dump = ""
+        customDump(
+            NSNotification(name: .init(rawValue: "co.pointfree"), object: nil, userInfo: nil),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Notification(name: "co.pointfree")
+            """
+        )
+    }
+
+    func testNSNull() {
+        var dump = ""
+        customDump(
+            NSNull(),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            NSNull()
+            """
+        )
+    }
+
+    func testNSNumber() {
+        var dump = ""
+        customDump(
+            1 as NSNumber,
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            1
+            """
+        )
+
+        #if canImport(ObjectiveC)
+            dump = ""
+            customDump(
+                NSNumber(),
+                to: &dump
+            )
+            XCTAssertNoDifference(
+                dump,
+                """
+                (null pointer)
+                """
+            )
+        #endif
+    }
+
+    func testNSOrderedSet() {
+        var dump = ""
+        customDump(
+            [1, 2, 3] as NSOrderedSet,
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            [
+              [0]: 1,
+              [1]: 2,
+              [2]: 3
+            ]
+            """
+        )
+    }
+
+    func testNSRange() {
+        var dump = ""
+        customDump(
+            NSRange(0..<1),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            0..<1
+            """
+        )
+    }
+
+    func testNSSet() {
+        var dump = ""
+        customDump(
+            NSSet(array: [1, 2, 3]),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Set([
+              1,
+              2,
+              3
+            ])
+            """
+        )
+    }
+
+    func testNSTimeZone() {
+        var dump = ""
+        customDump(
+            NSTimeZone(forSecondsFromGMT: 0),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            TimeZone(
+              identifier: "GMT",
+              abbreviation: "GMT",
+              secondsFromGMT: 0,
+              isDaylightSavingTime: false
+            )
+            """
+        )
+    }
+
+    func testNSURL() {
+        var dump = ""
+        customDump(
+            NSURL(fileURLWithPath: "/tmp"),
+            to: &dump
+        )
+        #if os(Windows)
+            XCTAssertNoDifference(
+                dump,
+                """
+                URL(file:///tmp)
+                """
+            )
+        #else
+            XCTAssertNoDifference(
+                dump,
+                """
+                URL(file:///tmp/)
+                """
+            )
+        #endif
+    }
+
+    func testNSURLComponents() {
+        var dump = ""
+        customDump(
+            NSURLComponents(string: "https://www.pointfree.co/login?redirect=episodes"),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            URLComponents(
+              scheme: "https",
+              host: "www.pointfree.co",
+              path: "/login",
+              queryItems: [
+                [0]: URLQueryItem(
+                  name: "redirect",
+                  value: "episodes"
+                )
+              ]
+            )
+            """
+        )
+    }
+
+    func testNSURLQueryItem() {
+        var dump = ""
+        customDump(
+            NSURLQueryItem(name: "search", value: "composable architecture"),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            URLQueryItem(
+              name: "search",
+              value: "composable architecture"
+            )
+            """
+        )
+    }
+
+    func testNSURLRequest() {
+        var dump = ""
+        let request = NSMutableURLRequest(url: URL(string: "https://www.pointfree.co")!)
+        request.addValue("text/html", forHTTPHeaderField: "Accept")
+        request.httpShouldUsePipelining = false
+        customDump(
+            request,
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            URLRequest(
+              url: URL(https://www.pointfree.co),
+              cachePolicy: 0,
+              timeoutInterval: 60.0,
+              mainDocumentURL: nil,
+              networkServiceType: URLRequest.NetworkServiceType.default,
+              allowsCellularAccess: true,
+              httpMethod: "GET",
+              allHTTPHeaderFields: [
+                "Accept": "text/html"
+              ],
+              httpBody: nil,
+              httpBodyStream: nil,
+              httpShouldHandleCookies: true,
+              httpShouldUsePipelining: false
+            )
+            """
+        )
+    }
+
+    func testNSUUID() {
+        var dump = ""
+        customDump(
+            NSUUID(uuidString: "deadbeef-dead-beef-dead-beefdeadbeef"),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            UUID(DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF)
+            """
+        )
+    }
+
+    func testURL() {
+        var dump = ""
+        customDump(
+            URL(string: "https://www.pointfree.co/"),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            URL(https://www.pointfree.co/)
+            """
+        )
+    }
 }

--- a/Tests/RxComposableArchitectureTests/CustomDumpTests/Conformances/UIKitTests.swift
+++ b/Tests/RxComposableArchitectureTests/CustomDumpTests/Conformances/UIKitTests.swift
@@ -1,33 +1,33 @@
 #if canImport(UIKit)
-  import RxComposableArchitecture
-  import XCTest
-  import UIKit
+    import RxComposableArchitecture
+    import XCTest
+    import UIKit
 
-  final class UIKitTests: XCTestCase {
-    func testUIControlState() {
-      var dump = ""
-      customDump([.selected, .highlighted] as UIControl.State, to: &dump)
-      XCTAssertEqual(
-        dump,
-        """
-        Set([
-          UIControl.State.highlighted,
-          UIControl.State.normal,
-          UIControl.State.selected
-        ])
-        """
-      )
+    final class UIKitTests: XCTestCase {
+        func testUIControlState() {
+            var dump = ""
+            customDump([.selected, .highlighted] as UIControl.State, to: &dump)
+            XCTAssertEqual(
+                dump,
+                """
+                Set([
+                  UIControl.State.highlighted,
+                  UIControl.State.normal,
+                  UIControl.State.selected
+                ])
+                """
+            )
 
-      dump = ""
-      customDump(UIControl.State.normal, to: &dump)
-      XCTAssertEqual(
-        dump,
-        """
-        Set([
-          UIControl.State.normal
-        ])
-        """
-      )
+            dump = ""
+            customDump(UIControl.State.normal, to: &dump)
+            XCTAssertEqual(
+                dump,
+                """
+                Set([
+                  UIControl.State.normal
+                ])
+                """
+            )
+        }
     }
-  }
 #endif

--- a/Tests/RxComposableArchitectureTests/CustomDumpTests/Conformances/UserNotificationsTests.swift
+++ b/Tests/RxComposableArchitectureTests/CustomDumpTests/Conformances/UserNotificationsTests.swift
@@ -1,21 +1,21 @@
 #if canImport(UserNotifications)
-  import RxComposableArchitecture
-  import XCTest
-  import UserNotifications
+    import RxComposableArchitecture
+    import XCTest
+    import UserNotifications
 
-  class UserNotificationsTests: XCTestCase {
-    func testUNAuthorizationOptions() {
-      var dump: String = ""
-      customDump([.badge, .alert] as UNAuthorizationOptions, to: &dump)
-      XCTAssertEqual(
-        dump,
-        """
-        Set([
-          UNAuthorizationOptions.alert,
-          UNAuthorizationOptions.badge
-        ])
-        """
-      )
+    class UserNotificationsTests: XCTestCase {
+        func testUNAuthorizationOptions() {
+            var dump: String = ""
+            customDump([.badge, .alert] as UNAuthorizationOptions, to: &dump)
+            XCTAssertEqual(
+                dump,
+                """
+                Set([
+                  UNAuthorizationOptions.alert,
+                  UNAuthorizationOptions.badge
+                ])
+                """
+            )
+        }
     }
-  }
 #endif

--- a/Tests/RxComposableArchitectureTests/CustomDumpTests/DiffTests.swift
+++ b/Tests/RxComposableArchitectureTests/CustomDumpTests/DiffTests.swift
@@ -2,915 +2,916 @@ import RxComposableArchitecture
 import XCTest
 
 final class DiffTests: XCTestCase {
-  func testAny() {
-    XCTAssertEqual(
-      diff(
-        (1, 2) as Any,
-        (1, 2)
-      ),
-      nil
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        (1, (2, 3)) as Any,
-        "Blob"
-      ),
-      """
-      - (
-      -   1,
-      -   (
-      -     2,
-      -     3
-      -   )
-      - )
-      + "Blob"
-      """
-    )
-  }
-
-  func testAnyType() {
-    XCTAssertNoDifference(
-      diff(
-        Foo.Bar.self as Any.Type,
-        Foo.self
-      ),
-      """
-      - Foo.Bar.self
-      + Foo.self
-      """
-    )
-  }
-
-  func testClass() {
-    XCTAssertNoDifference(
-      diff(
-        UserClass(
-          id: 42,
-          name: "Blob"
-        ),
-        UserClass(
-          id: 42,
-          name: "Blob, Jr."
+    func testAny() {
+        XCTAssertEqual(
+            diff(
+                (1, 2) as Any,
+                (1, 2)
+            ),
+            nil
         )
-      ),
-      """
-        UserClass(
-          id: 42,
-      -   name: "Blob"
-      +   name: "Blob, Jr."
+
+        XCTAssertNoDifference(
+            diff(
+                (1, (2, 3)) as Any,
+                "Blob"
+            ),
+            """
+            - (
+            -   1,
+            -   (
+            -     2,
+            -     3
+            -   )
+            - )
+            + "Blob"
+            """
         )
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        NSObject(),
-        NSObject()
-      ),
-      """
-      - NSObject()
-      + NSObject()
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        RepeatedObject(id: "a"),
-        RepeatedObject(id: "b")
-      ),
-      """
-        RepeatedObject(
-          child: RepeatedObject.Child(
-      -     grandchild: RepeatedObject.Grandchild(id: "a")
-      +     grandchild: RepeatedObject.Grandchild(id: "b")
-          ),
-      -   grandchild: RepeatedObject.Grandchild(↩︎)
-      +   grandchild: RepeatedObject.Grandchild(↩︎)
-        )
-      """
-    )
-  }
-
-  func testClassObjectIdentity() {
-    class User: NSObject {
-      let id = 42
-      let name = "Blob"
     }
 
-    XCTAssertNoDifference(
-      diff(
-        User(),
-        User()
-      )?.replacingOccurrences(of: "0x[[:xdigit:]]+", with: "…", options: .regularExpression),
-      """
-        DiffTests.User(
-      -   _: ObjectIdentifier(…),
-      +   _: ObjectIdentifier(…),
-          id: 42,
-          name: "Blob"
-        )
-      """
-    )
-  }
-
-  func testCollection() {
-    XCTAssertNoDifference(
-      diff(
-        [
-          User(
-            id: 1,
-            name: "Blob"
-          ),
-          User(
-            id: 2,
-            name: "Blob, Jr."
-          ),
-          User(
-            id: 3,
-            name: "Blob, Sr."
-          ),
-        ],
-        [
-          User(
-            id: 1,
-            name: "Blob, Esq."
-          ),
-          User(
-            id: 3,
-            name: "Blob, Sr."
-          ),
-          User(
-            id: 4,
-            name: "Blob, Jr."
-          ),
-        ]
-      ),
-      """
-        [
-          [0]: User(
-            id: 1,
-      -     name: "Blob"
-      +     name: "Blob, Esq."
-          ),
-      -   [1]: User(
-      -     id: 2,
-      -     name: "Blob, Jr."
-      -   ),
-          [1]: User(…),
-      +   [2]: User(
-      +     id: 4,
-      +     name: "Blob, Jr."
-      +   )
-        ]
-      """
-    )
-  }
-
-  func testCollectionCollapsing() {
-    let largeArray = Array(1...1_000)
-    var other = largeArray
-    other[100] = 42
-    other[102] = 42
-    other.insert(42, at: 300)
-    other.remove(at: 700)
-
-    XCTAssertNoDifference(
-      diff(largeArray, other),
-      """
-        [
-          … (100 unchanged),
-      -   [100]: 101,
-      +   [100]: 42,
-          [101]: 102,
-      -   [102]: 103,
-      +   [102]: 42,
-          … (197 unchanged),
-      +   [300]: 42,
-          … (399 unchanged),
-      -   [699]: 700,
-          … (300 unchanged)
-        ]
-      """
-    )
-  }
-
-  func testDictionary() {
-    XCTAssertNoDifference(
-      diff(
-        [
-          1: User(
-            id: 1,
-            name: "Blob"
-          ),
-          2: User(
-            id: 2,
-            name: "Blob, Jr."
-          ),
-        ],
-        [
-          1: User(
-            id: 1,
-            name: "Blob"
-          ),
-          2: User(
-            id: 2,
-            name: "Blob, Sr."
-          ),
-          3: User(
-            id: 3,
-            name: "Dr. Blob"
-          ),
-        ]
-      ),
-      """
-        [
-          2: User(
-            id: 2,
-      -     name: "Blob, Jr."
-      +     name: "Blob, Sr."
-          ),
-      +   3: User(
-      +     id: 3,
-      +     name: "Dr. Blob"
-      +   ),
-          … (1 unchanged)
-        ]
-      """
-    )
-  }
-
-  func testDictionaryCollapsing() {
-    let largeDictionary = Dictionary(uniqueKeysWithValues: Array(1...1_000).map { ($0, "\($0)") })
-    var other = largeDictionary
-    other[100] = "42"
-    other[102] = "42"
-    other[300] = "42"
-    other[700] = nil
-
-    XCTAssertNoDifference(
-      diff(largeDictionary, other),
-      """
-        [
-      -   100: "100",
-      +   100: "42",
-      -   102: "102",
-      +   102: "42",
-      -   300: "300",
-      +   300: "42",
-      -   700: "700",
-          … (996 unchanged)
-        ]
-      """
-    )
-  }
-
-  func testEnum() {
-    XCTAssertEqual(diff(Enum.foo, Enum.foo), nil)
-    XCTAssertEqual(diff(Enum.bar(42), Enum.bar(42)), nil)
-    XCTAssertEqual(
-      diff(Enum.baz(fizz: 1.2, buzz: "Blob"), Enum.baz(fizz: 1.2, buzz: "Blob")), nil)
-
-    XCTAssertNoDifference(
-      diff(Enum.foo, Enum.bar(42)),
-      """
-      - Enum.foo
-      + Enum.bar(42)
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(Enum.bar(42), Enum.bar(43)),
-      """
-      - Enum.bar(42)
-      + Enum.bar(43)
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(Enum.fizz(42, buzz: "Blob"), Enum.fizz(42, buzz: "Glob")),
-      """
-        Enum.fizz(
-          42.0,
-      -   buzz: "Blob"
-      +   buzz: "Glob"
-        )
-      """
-    )
-  }
-
-  func testOptional() {
-    XCTAssertEqual(
-      diff(nil as User?, nil), nil
-    )
-    XCTAssertEqual(
-      diff(User?(.init(id: 42, name: "Blob")), User?(.init(id: 42, name: "Blob"))),
-      nil
-    )
-
-    XCTAssertNoDifference(
-      diff(User?(.init(id: 42, name: "Blob")), nil),
-      """
-      - User(
-      -   id: 42,
-      -   name: "Blob"
-      - )
-      + nil
-      """
-    )
-    XCTAssertNoDifference(
-      diff(User?(.init(id: 42, name: "Blob")), User?(.init(id: 42, name: "Blob, Esq."))),
-      """
-        User(
-          id: 42,
-      -   name: "Blob"
-      +   name: "Blob, Esq."
-        )
-      """
-    )
-  }
-
-  func testSet() {
-    XCTAssertEqual(diff(Set([1, 2, 3]), Set([1, 2, 3])), nil)
-
-    XCTAssertNoDifference(
-      diff(
-        Set([1, 2, 3]),
-        Set([1, 3, 4])
-      ),
-      """
-        Set([
-      -   2,
-      +   4,
-          … (2 unchanged)
-        ])
-      """
-    )
-  }
-
-  func testSetCollapsing() {
-    let largeSet = Set(Array(1...1_000))
-    var other = largeSet
-    other.remove(100)
-    other.remove(102)
-    other.insert(9999)
-
-    XCTAssertNoDifference(
-      diff(largeSet, other),
-      """
-        Set([
-      -   100,
-      -   102,
-      +   9999,
-          … (998 unchanged)
-        ])
-      """
-    )
-  }
-
-  func testSingleValue() {
-    XCTAssertEqual(diff(1, 1), nil)
-    XCTAssertNoDifference(
-      diff(1, 2),
-      """
-      - 1
-      + 2
-      """
-    )
-
-    XCTAssertEqual(diff(true, true), nil)
-    XCTAssertNoDifference(
-      diff(true, false),
-      """
-      - true
-      + false
-      """
-    )
-  }
-
-  func testStruct() {
-    XCTAssertNoDifference(
-      diff(
-        NeverEqualModel(),
-        NeverEqualModel()
-      ),
-      """
-        // Not equal but no difference detected:
-      - NeverEqualModel()
-      + NeverEqualModel()
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        User(
-          id: 42,
-          name: "Blob"
-        ),
-        User(
-          id: 42,
-          name: "Blob, Jr."
-        )
-      ),
-      """
-        User(
-          id: 42,
-      -   name: "Blob"
-      +   name: "Blob, Jr."
-        )
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        Pair(
-          driver: User(
-            id: 1,
-            name: "Blob"
-          ),
-          passenger: User(
-            id: 2,
-            name: "Blob, Jr."
-          )
-        ),
-        Pair(
-          driver: User(
-            id: 1,
-            name: "Blob"
-          ),
-          passenger: User(
-            id: 2,
-            name: "Blob, Sr."
-          )
-        )
-      ),
-      """
-        Pair(
-          driver: User(…),
-          passenger: User(
-            id: 2,
-      -     name: "Blob, Jr."
-      +     name: "Blob, Sr."
-          )
-        )
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        NeverEqualUser(id: 1, name: "Blob"),
-        NeverEqualUser(id: 1, name: "Blob")
-      ),
-      """
-        // Not equal but no difference detected:
-      - NeverEqualUser(…)
-      + NeverEqualUser(…)
-      """
-    )
-  }
-
-  func testTuple() {
-    XCTAssertEqual(diff((1, 2), (1, 2)), nil)
-    XCTAssertNoDifference(
-      diff((1, 2), (1, 3)),
-      """
-        (
-          1,
-      -   2
-      +   3
-        )
-      """
-    )
-
-    XCTAssertEqual(diff((blob: 1, 2), (blob: 1, 2)), nil)
-    XCTAssertNoDifference(
-      diff((blob: 1, 2), (blob: 1, 3)),
-      """
-        (
-          blob: 1,
-      -   2
-      +   3
-        )
-      """
-    )
-
-    XCTAssertEqual(diff((1, (2, 3)), (1, (2, 3))), nil)
-    XCTAssertNoDifference(
-      diff((1, (2, 3)), (0, (2, 3))),
-      """
-        (
-      -   1,
-      +   0,
-          (…)
-        )
-      """
-    )
-
-    XCTAssertEqual(diff((1, ()), (1, ())), nil)
-    XCTAssertNoDifference(
-      diff((1, ()), (0, ())),
-      """
-        (
-      -   1,
-      +   0,
-          ()
-        )
-      """
-    )
-  }
-
-  func testNestedCustomMirror() {
-    #if compiler(>=5.4)
-      XCTAssertNoDifference(
-        diff(
-          NestedDate(date: Date(timeIntervalSince1970: 0)),
-          NestedDate(date: Date(timeIntervalSince1970: 1))
-        ),
-        """
-        - NestedDate(date: Date(1970-01-01T00:00:00.000Z))
-        + NestedDate(date: Date(1970-01-01T00:00:01.000Z))
-        """
-      )
-    #endif
-  }
-
-  func testMultilineString() {
-    XCTAssertNoDifference(
-      diff(
-        """
-        Hello,
-        World!
-        """,
-        """
-        Hello,
-        Blob!
-        """
-      ),
-      #"""
-        """
-        Hello,
-      - World!
-      + Blob!
-        """
-      """#
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        """
-        Hello,
-        World!
-        """[...],
-        """
-        Hello,
-        Blob!
-        """[...]
-      ),
-      #"""
-        """
-        Hello,
-      - World!
-      + Blob!
-        """
-      """#
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        Email(
-          subject: "RE: Upcoming Event",
-          body: """
-            To who it may concern,
-
-            Look forward to it!
-
-            Yours,
-            Blob
+    func testAnyType() {
+        XCTAssertNoDifference(
+            diff(
+                Foo.Bar.self as Any.Type,
+                Foo.self
+            ),
             """
-        ),
-        Email(
-          subject: "RE: Upcoming Event",
-          body: """
-            To whom it may concern,
-
-            Look forward to it!
-
-            Yours,
-            Blob
+            - Foo.Bar.self
+            + Foo.self
             """
         )
-      ),
-      """
-        Email(
-          subject: "RE: Upcoming Event",
-          body: \"\"\"
-      -     To who it may concern,
-      +     To whom it may concern,
-            \n\
-            Look forward to it!
-            \n\
-            Yours,
-            Blob
-            \"\"\"
-        )
-      """
-    )
+    }
 
-    XCTAssertNoDifference(
-      diff(
-        Email(
-          subject: "RE: Upcoming Event",
-          body: """
-            To whom it may concern,
-
-            Look forward to it!
-
-            Yours,
-            Blob
+    func testClass() {
+        XCTAssertNoDifference(
+            diff(
+                UserClass(
+                    id: 42,
+                    name: "Blob"
+                ),
+                UserClass(
+                    id: 42,
+                    name: "Blob, Jr."
+                )
+            ),
             """
-        ),
-        Email(
-          subject: "Re: Upcoming Event",
-          body: """
-            To whom it may concern,
-
-            Look forward to it!
-
-            Yours,
-            Blob
+              UserClass(
+                id: 42,
+            -   name: "Blob"
+            +   name: "Blob, Jr."
+              )
             """
         )
-      ),
-      """
-        Email(
-      -   subject: "RE: Upcoming Event",
-      +   subject: "Re: Upcoming Event",
-          body: "…"
+
+        XCTAssertNoDifference(
+            diff(
+                NSObject(),
+                NSObject()
+            ),
+            """
+            - NSObject()
+            + NSObject()
+            """
         )
-      """
-    )
-  }
 
-  func testAnyHashable() {
-    XCTAssertNoDifference(
-      diff(
-        AnyHashable(42),
-        AnyHashable(43)
-      ),
-      """
-      - 42
-      + 43
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        [
-          AnyHashable(1): User(id: 1, name: "Blob"),
-          AnyHashable("Blob, Jr."): User(id: 2, name: "Blob, Jr."),
-        ],
-        [
-          AnyHashable(1): User(id: 1, name: "Blob, Sr."),
-          AnyHashable("Blob, Jr."): User(id: 2, name: "Blob, Jr., Esq."),
-        ]
-      ),
-      """
-        [
-          "Blob, Jr.": User(
-            id: 2,
-      -     name: "Blob, Jr."
-      +     name: "Blob, Jr., Esq."
-          ),
-          1: User(
-            id: 1,
-      -     name: "Blob"
-      +     name: "Blob, Sr."
-          )
-        ]
-      """
-    )
-  }
-
-  func testDeeplyNested() {
-    let user = FriendlyUser(
-      id: 1,
-      name: "Blob",
-      friends: [
-        .init(
-          id: 2,
-          name: "Blob Jr.",
-          friends: [
-            .init(
-              id: 3,
-              name: "Blob Sr.",
-              friends: [.init(id: 4, name: "Someone", friends: [])]
-            )
-          ]
+        XCTAssertNoDifference(
+            diff(
+                RepeatedObject(id: "a"),
+                RepeatedObject(id: "b")
+            ),
+            """
+              RepeatedObject(
+                child: RepeatedObject.Child(
+            -     grandchild: RepeatedObject.Grandchild(id: "a")
+            +     grandchild: RepeatedObject.Grandchild(id: "b")
+                ),
+            -   grandchild: RepeatedObject.Grandchild(↩︎)
+            +   grandchild: RepeatedObject.Grandchild(↩︎)
+              )
+            """
         )
-      ]
-    )
+    }
 
-    var other = user
-    other.friends[0].friends[0].friends[0].name += " Else"
+    func testClassObjectIdentity() {
+        class User: NSObject {
+            let id = 42
+            let name = "Blob"
+        }
 
-    XCTAssertNoDifference(
-      diff(user, other),
-      """
-        FriendlyUser(
-          id: 1,
-          name: "Blob",
-          friends: [
-            [0]: FriendlyUser(
-              id: 2,
-              name: "Blob Jr.",
-              friends: [
-                [0]: FriendlyUser(
-                  id: 3,
-                  name: "Blob Sr.",
-                  friends: [
-                    [0]: FriendlyUser(
-                      id: 4,
-      -               name: "Someone",
-      +               name: "Someone Else",
-                      friends: []
+        XCTAssertNoDifference(
+            diff(
+                User(),
+                User()
+            )?.replacingOccurrences(of: "0x[[:xdigit:]]+", with: "…", options: .regularExpression),
+            """
+              DiffTests.User(
+            -   _: ObjectIdentifier(…),
+            +   _: ObjectIdentifier(…),
+                id: 42,
+                name: "Blob"
+              )
+            """
+        )
+    }
+
+    func testCollection() {
+        XCTAssertNoDifference(
+            diff(
+                [
+                    User(
+                        id: 1,
+                        name: "Blob"
+                    ),
+                    User(
+                        id: 2,
+                        name: "Blob, Jr."
+                    ),
+                    User(
+                        id: 3,
+                        name: "Blob, Sr."
+                    ),
+                ],
+                [
+                    User(
+                        id: 1,
+                        name: "Blob, Esq."
+                    ),
+                    User(
+                        id: 3,
+                        name: "Blob, Sr."
+                    ),
+                    User(
+                        id: 4,
+                        name: "Blob, Jr."
+                    ),
+                ]
+            ),
+            """
+              [
+                [0]: User(
+                  id: 1,
+            -     name: "Blob"
+            +     name: "Blob, Esq."
+                ),
+            -   [1]: User(
+            -     id: 2,
+            -     name: "Blob, Jr."
+            -   ),
+                [1]: User(…),
+            +   [2]: User(
+            +     id: 4,
+            +     name: "Blob, Jr."
+            +   )
+              ]
+            """
+        )
+    }
+
+    func testCollectionCollapsing() {
+        let largeArray = Array(1...1_000)
+        var other = largeArray
+        other[100] = 42
+        other[102] = 42
+        other.insert(42, at: 300)
+        other.remove(at: 700)
+
+        XCTAssertNoDifference(
+            diff(largeArray, other),
+            """
+              [
+                … (100 unchanged),
+            -   [100]: 101,
+            +   [100]: 42,
+                [101]: 102,
+            -   [102]: 103,
+            +   [102]: 42,
+                … (197 unchanged),
+            +   [300]: 42,
+                … (399 unchanged),
+            -   [699]: 700,
+                … (300 unchanged)
+              ]
+            """
+        )
+    }
+
+    func testDictionary() {
+        XCTAssertNoDifference(
+            diff(
+                [
+                    1: User(
+                        id: 1,
+                        name: "Blob"
+                    ),
+                    2: User(
+                        id: 2,
+                        name: "Blob, Jr."
+                    ),
+                ],
+                [
+                    1: User(
+                        id: 1,
+                        name: "Blob"
+                    ),
+                    2: User(
+                        id: 2,
+                        name: "Blob, Sr."
+                    ),
+                    3: User(
+                        id: 3,
+                        name: "Dr. Blob"
+                    ),
+                ]
+            ),
+            """
+              [
+                2: User(
+                  id: 2,
+            -     name: "Blob, Jr."
+            +     name: "Blob, Sr."
+                ),
+            +   3: User(
+            +     id: 3,
+            +     name: "Dr. Blob"
+            +   ),
+                … (1 unchanged)
+              ]
+            """
+        )
+    }
+
+    func testDictionaryCollapsing() {
+        let largeDictionary = Dictionary(
+            uniqueKeysWithValues: Array(1...1_000).map { ($0, "\($0)") })
+        var other = largeDictionary
+        other[100] = "42"
+        other[102] = "42"
+        other[300] = "42"
+        other[700] = nil
+
+        XCTAssertNoDifference(
+            diff(largeDictionary, other),
+            """
+              [
+            -   100: "100",
+            +   100: "42",
+            -   102: "102",
+            +   102: "42",
+            -   300: "300",
+            +   300: "42",
+            -   700: "700",
+                … (996 unchanged)
+              ]
+            """
+        )
+    }
+
+    func testEnum() {
+        XCTAssertEqual(diff(Enum.foo, Enum.foo), nil)
+        XCTAssertEqual(diff(Enum.bar(42), Enum.bar(42)), nil)
+        XCTAssertEqual(
+            diff(Enum.baz(fizz: 1.2, buzz: "Blob"), Enum.baz(fizz: 1.2, buzz: "Blob")), nil)
+
+        XCTAssertNoDifference(
+            diff(Enum.foo, Enum.bar(42)),
+            """
+            - Enum.foo
+            + Enum.bar(42)
+            """
+        )
+
+        XCTAssertNoDifference(
+            diff(Enum.bar(42), Enum.bar(43)),
+            """
+            - Enum.bar(42)
+            + Enum.bar(43)
+            """
+        )
+
+        XCTAssertNoDifference(
+            diff(Enum.fizz(42, buzz: "Blob"), Enum.fizz(42, buzz: "Glob")),
+            """
+              Enum.fizz(
+                42.0,
+            -   buzz: "Blob"
+            +   buzz: "Glob"
+              )
+            """
+        )
+    }
+
+    func testOptional() {
+        XCTAssertEqual(
+            diff(nil as User?, nil), nil
+        )
+        XCTAssertEqual(
+            diff(User?(.init(id: 42, name: "Blob")), User?(.init(id: 42, name: "Blob"))),
+            nil
+        )
+
+        XCTAssertNoDifference(
+            diff(User?(.init(id: 42, name: "Blob")), nil),
+            """
+            - User(
+            -   id: 42,
+            -   name: "Blob"
+            - )
+            + nil
+            """
+        )
+        XCTAssertNoDifference(
+            diff(User?(.init(id: 42, name: "Blob")), User?(.init(id: 42, name: "Blob, Esq."))),
+            """
+              User(
+                id: 42,
+            -   name: "Blob"
+            +   name: "Blob, Esq."
+              )
+            """
+        )
+    }
+
+    func testSet() {
+        XCTAssertEqual(diff(Set([1, 2, 3]), Set([1, 2, 3])), nil)
+
+        XCTAssertNoDifference(
+            diff(
+                Set([1, 2, 3]),
+                Set([1, 3, 4])
+            ),
+            """
+              Set([
+            -   2,
+            +   4,
+                … (2 unchanged)
+              ])
+            """
+        )
+    }
+
+    func testSetCollapsing() {
+        let largeSet = Set(Array(1...1_000))
+        var other = largeSet
+        other.remove(100)
+        other.remove(102)
+        other.insert(9999)
+
+        XCTAssertNoDifference(
+            diff(largeSet, other),
+            """
+              Set([
+            -   100,
+            -   102,
+            +   9999,
+                … (998 unchanged)
+              ])
+            """
+        )
+    }
+
+    func testSingleValue() {
+        XCTAssertEqual(diff(1, 1), nil)
+        XCTAssertNoDifference(
+            diff(1, 2),
+            """
+            - 1
+            + 2
+            """
+        )
+
+        XCTAssertEqual(diff(true, true), nil)
+        XCTAssertNoDifference(
+            diff(true, false),
+            """
+            - true
+            + false
+            """
+        )
+    }
+
+    func testStruct() {
+        XCTAssertNoDifference(
+            diff(
+                NeverEqualModel(),
+                NeverEqualModel()
+            ),
+            """
+              // Not equal but no difference detected:
+            - NeverEqualModel()
+            + NeverEqualModel()
+            """
+        )
+
+        XCTAssertNoDifference(
+            diff(
+                User(
+                    id: 42,
+                    name: "Blob"
+                ),
+                User(
+                    id: 42,
+                    name: "Blob, Jr."
+                )
+            ),
+            """
+              User(
+                id: 42,
+            -   name: "Blob"
+            +   name: "Blob, Jr."
+              )
+            """
+        )
+
+        XCTAssertNoDifference(
+            diff(
+                Pair(
+                    driver: User(
+                        id: 1,
+                        name: "Blob"
+                    ),
+                    passenger: User(
+                        id: 2,
+                        name: "Blob, Jr."
                     )
-                  ]
+                ),
+                Pair(
+                    driver: User(
+                        id: 1,
+                        name: "Blob"
+                    ),
+                    passenger: User(
+                        id: 2,
+                        name: "Blob, Sr."
+                    )
+                )
+            ),
+            """
+              Pair(
+                driver: User(…),
+                passenger: User(
+                  id: 2,
+            -     name: "Blob, Jr."
+            +     name: "Blob, Sr."
+                )
+              )
+            """
+        )
+
+        XCTAssertNoDifference(
+            diff(
+                NeverEqualUser(id: 1, name: "Blob"),
+                NeverEqualUser(id: 1, name: "Blob")
+            ),
+            """
+              // Not equal but no difference detected:
+            - NeverEqualUser(…)
+            + NeverEqualUser(…)
+            """
+        )
+    }
+
+    func testTuple() {
+        XCTAssertEqual(diff((1, 2), (1, 2)), nil)
+        XCTAssertNoDifference(
+            diff((1, 2), (1, 3)),
+            """
+              (
+                1,
+            -   2
+            +   3
+              )
+            """
+        )
+
+        XCTAssertEqual(diff((blob: 1, 2), (blob: 1, 2)), nil)
+        XCTAssertNoDifference(
+            diff((blob: 1, 2), (blob: 1, 3)),
+            """
+              (
+                blob: 1,
+            -   2
+            +   3
+              )
+            """
+        )
+
+        XCTAssertEqual(diff((1, (2, 3)), (1, (2, 3))), nil)
+        XCTAssertNoDifference(
+            diff((1, (2, 3)), (0, (2, 3))),
+            """
+              (
+            -   1,
+            +   0,
+                (…)
+              )
+            """
+        )
+
+        XCTAssertEqual(diff((1, ()), (1, ())), nil)
+        XCTAssertNoDifference(
+            diff((1, ()), (0, ())),
+            """
+              (
+            -   1,
+            +   0,
+                ()
+              )
+            """
+        )
+    }
+
+    func testNestedCustomMirror() {
+        #if compiler(>=5.4)
+            XCTAssertNoDifference(
+                diff(
+                    NestedDate(date: Date(timeIntervalSince1970: 0)),
+                    NestedDate(date: Date(timeIntervalSince1970: 1))
+                ),
+                """
+                - NestedDate(date: Date(1970-01-01T00:00:00.000Z))
+                + NestedDate(date: Date(1970-01-01T00:00:01.000Z))
+                """
+            )
+        #endif
+    }
+
+    func testMultilineString() {
+        XCTAssertNoDifference(
+            diff(
+                """
+                Hello,
+                World!
+                """,
+                """
+                Hello,
+                Blob!
+                """
+            ),
+            #"""
+              """
+              Hello,
+            - World!
+            + Blob!
+              """
+            """#
+        )
+
+        XCTAssertNoDifference(
+            diff(
+                """
+                Hello,
+                World!
+                """[...],
+                """
+                Hello,
+                Blob!
+                """[...]
+            ),
+            #"""
+              """
+              Hello,
+            - World!
+            + Blob!
+              """
+            """#
+        )
+
+        XCTAssertNoDifference(
+            diff(
+                Email(
+                    subject: "RE: Upcoming Event",
+                    body: """
+                        To who it may concern,
+
+                        Look forward to it!
+
+                        Yours,
+                        Blob
+                        """
+                ),
+                Email(
+                    subject: "RE: Upcoming Event",
+                    body: """
+                        To whom it may concern,
+
+                        Look forward to it!
+
+                        Yours,
+                        Blob
+                        """
+                )
+            ),
+            """
+              Email(
+                subject: "RE: Upcoming Event",
+                body: \"\"\"
+            -     To who it may concern,
+            +     To whom it may concern,
+                  \n\
+                  Look forward to it!
+                  \n\
+                  Yours,
+                  Blob
+                  \"\"\"
+              )
+            """
+        )
+
+        XCTAssertNoDifference(
+            diff(
+                Email(
+                    subject: "RE: Upcoming Event",
+                    body: """
+                        To whom it may concern,
+
+                        Look forward to it!
+
+                        Yours,
+                        Blob
+                        """
+                ),
+                Email(
+                    subject: "Re: Upcoming Event",
+                    body: """
+                        To whom it may concern,
+
+                        Look forward to it!
+
+                        Yours,
+                        Blob
+                        """
+                )
+            ),
+            """
+              Email(
+            -   subject: "RE: Upcoming Event",
+            +   subject: "Re: Upcoming Event",
+                body: "…"
+              )
+            """
+        )
+    }
+
+    func testAnyHashable() {
+        XCTAssertNoDifference(
+            diff(
+                AnyHashable(42),
+                AnyHashable(43)
+            ),
+            """
+            - 42
+            + 43
+            """
+        )
+
+        XCTAssertNoDifference(
+            diff(
+                [
+                    AnyHashable(1): User(id: 1, name: "Blob"),
+                    AnyHashable("Blob, Jr."): User(id: 2, name: "Blob, Jr."),
+                ],
+                [
+                    AnyHashable(1): User(id: 1, name: "Blob, Sr."),
+                    AnyHashable("Blob, Jr."): User(id: 2, name: "Blob, Jr., Esq."),
+                ]
+            ),
+            """
+              [
+                "Blob, Jr.": User(
+                  id: 2,
+            -     name: "Blob, Jr."
+            +     name: "Blob, Jr., Esq."
+                ),
+                1: User(
+                  id: 1,
+            -     name: "Blob"
+            +     name: "Blob, Sr."
                 )
               ]
-            )
-          ]
+            """
         )
-      """
-    )
-  }
+    }
 
-  func testInterleavedIndices() {
-    XCTAssertNoDifference(
-      diff(
-        [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-        ],
-        [
-          1,
-          4,
-          64,
-          7,
-          8,
-          9,
-          10,
-          42,
-        ]
-      ),
-      """
-        [
-          [0]: 1,
-      -   [1]: 2,
-      -   [2]: 3,
-          [1]: 4,
-      -   [4]: 5,
-      +   [2]: 64,
-      -   [5]: 6,
-          … (4 unchanged),
-      +   [7]: 42
-        ]
-      """
-    )
-  }
-
-  func testNamespacedTypes() {
-    XCTAssertNoDifference(
-      diff(
-        Namespaced.Class(x: 0),
-        Namespaced.Class(x: 1)
-      ),
-      """
-      - Namespaced.Class(x: 0)
-      + Namespaced.Class(x: 1)
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        Namespaced.Enum.x(0),
-        Namespaced.Enum.x(1)
-      ),
-      """
-      - Namespaced.Enum.x(0)
-      + Namespaced.Enum.x(1)
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        Namespaced.Struct(x: 0),
-        Namespaced.Struct(x: 1)
-      ),
-      """
-      - Namespaced.Struct(x: 0)
-      + Namespaced.Struct(x: 1)
-      """
-    )
-  }
-
-  func testCustomMirror() {
-    XCTAssertNoDifference(
-      diff(
-        LoginState(
-          email: "blob@pointfree.co",
-          password: "bl0bisawesome",
-          token: "secret"
-        ),
-        LoginState(
-          email: "blob@pointfree.co",
-          password: "bl0bisawesome!",
-          token: "secret"
+    func testDeeplyNested() {
+        let user = FriendlyUser(
+            id: 1,
+            name: "Blob",
+            friends: [
+                .init(
+                    id: 2,
+                    name: "Blob Jr.",
+                    friends: [
+                        .init(
+                            id: 3,
+                            name: "Blob Sr.",
+                            friends: [.init(id: 4, name: "Someone", friends: [])]
+                        )
+                    ]
+                )
+            ]
         )
-      ),
-      """
-        LoginState(
-          email: "blob@pointfree.co",
-      -   password: <redacted>
-      +   password: <redacted>
+
+        var other = user
+        other.friends[0].friends[0].friends[0].name += " Else"
+
+        XCTAssertNoDifference(
+            diff(user, other),
+            """
+              FriendlyUser(
+                id: 1,
+                name: "Blob",
+                friends: [
+                  [0]: FriendlyUser(
+                    id: 2,
+                    name: "Blob Jr.",
+                    friends: [
+                      [0]: FriendlyUser(
+                        id: 3,
+                        name: "Blob Sr.",
+                        friends: [
+                          [0]: FriendlyUser(
+                            id: 4,
+            -               name: "Someone",
+            +               name: "Someone Else",
+                            friends: []
+                          )
+                        ]
+                      )
+                    ]
+                  )
+                ]
+              )
+            """
         )
-      """
-    )
-  }
+    }
 
-  func testCustomOverride() {
-    XCTAssertNoDifference(
-      diff(
-        Wrapper(rawValue: 1),
-        Wrapper(rawValue: 2)
-      ),
-      """
-      - 1
-      + 2
-      """
-    )
-
-    XCTAssertNoDifference(
-      diff(
-        Wrapper(
-          rawValue: LoginState(
-            email: "blob@pointfree.co",
-            password: "bl0bisawesome",
-            token: "secret"
-          )
-        ),
-        Wrapper(
-          rawValue: LoginState(
-            email: "blob@pointfree.co",
-            password: "bl0bisawesome!",
-            token: "secret"
-          )
+    func testInterleavedIndices() {
+        XCTAssertNoDifference(
+            diff(
+                [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                ],
+                [
+                    1,
+                    4,
+                    64,
+                    7,
+                    8,
+                    9,
+                    10,
+                    42,
+                ]
+            ),
+            """
+              [
+                [0]: 1,
+            -   [1]: 2,
+            -   [2]: 3,
+                [1]: 4,
+            -   [4]: 5,
+            +   [2]: 64,
+            -   [5]: 6,
+                … (4 unchanged),
+            +   [7]: 42
+              ]
+            """
         )
-      ),
-      """
-        LoginState(
-          email: "blob@pointfree.co",
-      -   password: <redacted>
-      +   password: <redacted>
+    }
+
+    func testNamespacedTypes() {
+        XCTAssertNoDifference(
+            diff(
+                Namespaced.Class(x: 0),
+                Namespaced.Class(x: 1)
+            ),
+            """
+            - Namespaced.Class(x: 0)
+            + Namespaced.Class(x: 1)
+            """
         )
-      """
-    )
-  }
 
-  func testDifferentTypes() {
-    XCTAssertNoDifference(
-      diff(
-        29.99 as Float as Any,
-        29.99 as Double as Any
-      ),
-      """
-      - 29.99 as Float
-      + 29.99 as Double
-      """
-    )
+        XCTAssertNoDifference(
+            diff(
+                Namespaced.Enum.x(0),
+                Namespaced.Enum.x(1)
+            ),
+            """
+            - Namespaced.Enum.x(0)
+            + Namespaced.Enum.x(1)
+            """
+        )
 
-    XCTAssertNoDifference(
-      diff(
-        [
-          "value": 29.99 as Float
-        ],
-        [
-          "value": 29.99 as Double
-        ]
-      ),
-      """
-        [
-      -   "value": 29.99 as Float
-      +   "value": 29.99 as Double
-        ]
-      """
-    )
-  }
+        XCTAssertNoDifference(
+            diff(
+                Namespaced.Struct(x: 0),
+                Namespaced.Struct(x: 1)
+            ),
+            """
+            - Namespaced.Struct(x: 0)
+            + Namespaced.Struct(x: 1)
+            """
+        )
+    }
+
+    func testCustomMirror() {
+        XCTAssertNoDifference(
+            diff(
+                LoginState(
+                    email: "blob@pointfree.co",
+                    password: "bl0bisawesome",
+                    token: "secret"
+                ),
+                LoginState(
+                    email: "blob@pointfree.co",
+                    password: "bl0bisawesome!",
+                    token: "secret"
+                )
+            ),
+            """
+              LoginState(
+                email: "blob@pointfree.co",
+            -   password: <redacted>
+            +   password: <redacted>
+              )
+            """
+        )
+    }
+
+    func testCustomOverride() {
+        XCTAssertNoDifference(
+            diff(
+                Wrapper(rawValue: 1),
+                Wrapper(rawValue: 2)
+            ),
+            """
+            - 1
+            + 2
+            """
+        )
+
+        XCTAssertNoDifference(
+            diff(
+                Wrapper(
+                    rawValue: LoginState(
+                        email: "blob@pointfree.co",
+                        password: "bl0bisawesome",
+                        token: "secret"
+                    )
+                ),
+                Wrapper(
+                    rawValue: LoginState(
+                        email: "blob@pointfree.co",
+                        password: "bl0bisawesome!",
+                        token: "secret"
+                    )
+                )
+            ),
+            """
+              LoginState(
+                email: "blob@pointfree.co",
+            -   password: <redacted>
+            +   password: <redacted>
+              )
+            """
+        )
+    }
+
+    func testDifferentTypes() {
+        XCTAssertNoDifference(
+            diff(
+                29.99 as Float as Any,
+                29.99 as Double as Any
+            ),
+            """
+            - 29.99 as Float
+            + 29.99 as Double
+            """
+        )
+
+        XCTAssertNoDifference(
+            diff(
+                [
+                    "value": 29.99 as Float
+                ],
+                [
+                    "value": 29.99 as Double
+                ]
+            ),
+            """
+              [
+            -   "value": 29.99 as Float
+            +   "value": 29.99 as Double
+              ]
+            """
+        )
+    }
 }

--- a/Tests/RxComposableArchitectureTests/CustomDumpTests/DumpTests.swift
+++ b/Tests/RxComposableArchitectureTests/CustomDumpTests/DumpTests.swift
@@ -2,757 +2,757 @@ import RxComposableArchitecture
 import XCTest
 
 #if canImport(CoreGraphics)
-  import CoreGraphics
+    import CoreGraphics
 #endif
 
 #if canImport(FoundationNetworking)
-  import FoundationNetworking
+    import FoundationNetworking
 #endif
 
 #if canImport(SwiftUI)
-  import SwiftUI
+    import SwiftUI
 #endif
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class DumpTests: XCTestCase {
-  func testAnyType() {
-    var dump = ""
-    customDump(Foo.Bar.self, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      Foo.Bar.self
-      """
-    )
-  }
-
-  func testClass() {
-    let user = UserClass(
-      id: 42,
-      name: "Blob"
-    )
-
-    var dump = ""
-    customDump(user, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      UserClass(
-        id: 42,
-        name: "Blob"
-      )
-      """
-    )
-
-    dump = ""
-    customDump(user, to: &dump, maxDepth: 0)
-    XCTAssertNoDifference(
-      dump,
-      """
-      UserClass(…)
-      """
-    )
-
-    let foo = RecursiveFoo()
-    foo.foo = foo
-
-    dump = ""
-    customDump(foo, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      RecursiveFoo(
-        foo: RecursiveFoo(↩︎)
-      )
-      """
-    )
-  }
-
-  func testCollection() {
-    let users = [
-      User(
-        id: 1,
-        name: "Blob"
-      ),
-      User(
-        id: 2,
-        name: "Blob, Jr."
-      ),
-      User(
-        id: 3,
-        name: "Blob, Sr."
-      ),
-    ]
-
-    var dump = ""
-    customDump(users, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      [
-        [0]: User(
-          id: 1,
-          name: "Blob"
-        ),
-        [1]: User(
-          id: 2,
-          name: "Blob, Jr."
-        ),
-        [2]: User(
-          id: 3,
-          name: "Blob, Sr."
-        )
-      ]
-      """
-    )
-
-    dump = ""
-    customDump(users, to: &dump, maxDepth: 1)
-    XCTAssertNoDifference(
-      dump,
-      """
-      [
-        [0]: User(…),
-        [1]: User(…),
-        [2]: User(…)
-      ]
-      """
-    )
-
-    dump = ""
-    customDump(users, to: &dump, maxDepth: 0)
-    XCTAssertNoDifference(
-      dump,
-      """
-      […]
-      """
-    )
-  }
-
-  func testDictionary() {
-    var dump = ""
-    customDump(
-      [
-        1: User(
-          id: 1,
-          name: "Blob"
-        ),
-        2: User(
-          id: 2,
-          name: "Blob, Jr."
-        ),
-      ],
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      [
-        1: User(
-          id: 1,
-          name: "Blob"
-        ),
-        2: User(
-          id: 2,
-          name: "Blob, Jr."
-        )
-      ]
-      """
-    )
-
-    dump = ""
-    customDump(
-      [
-        ID(rawValue: "deadbeef"): User(
-          id: 1,
-          name: "Blob"
-        ),
-        ID(rawValue: "beefdead"): User(
-          id: 2,
-          name: "Blob, Jr."
-        ),
-      ],
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      [
-        ID(rawValue: "beefdead"): User(
-          id: 2,
-          name: "Blob, Jr."
-        ),
-        ID(rawValue: "deadbeef"): User(
-          id: 1,
-          name: "Blob"
-        )
-      ]
-      """
-    )
-  }
-
-  func testEnum() {
-    var dump = ""
-    customDump(Enum.foo, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      Enum.foo
-      """
-    )
-
-    dump = ""
-    customDump(Enum.bar(42), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      Enum.bar(42)
-      """
-    )
-
-    dump = ""
-    customDump(Enum.fu(bar: 42), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      Enum.fu(bar: 42)
-      """
-    )
-
-    dump = ""
-    customDump(Enum.baz(fizz: 0.9, buzz: "2"), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      Enum.baz(
-        fizz: 0.9,
-        buzz: "2"
-      )
-      """
-    )
-
-    dump = ""
-    customDump(Enum.fizz(0.9, buzz: "2"), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      Enum.fizz(
-        0.9,
-        buzz: "2"
-      )
-      """
-    )
-  }
-
-  func testOptional() {
-    var dump = ""
-    customDump(User?(.init(id: 42, name: "Blob")), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      User(
-        id: 42,
-        name: "Blob"
-      )
-      """
-    )
-
-    dump = ""
-    customDump(User?(nil), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      nil
-      """
-    )
-  }
-
-  func testSet() {
-    var dump = ""
-    customDump(Set([1, 2, 3]), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      Set([
-        1,
-        2,
-        3
-      ])
-      """
-    )
-  }
-
-  func testSingleValue() {
-    var dump = ""
-    customDump(1, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      1
-      """
-    )
-
-    dump = ""
-    customDump(true, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      true
-      """
-    )
-  }
-
-  func testStruct() {
-    let user = User(
-      id: 42,
-      name: "Blob"
-    )
-
-    var dump = ""
-    customDump(user, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      User(
-        id: 42,
-        name: "Blob"
-      )
-      """
-    )
-
-    dump = ""
-    customDump(user, to: &dump, maxDepth: 0)
-    XCTAssertNoDifference(
-      dump,
-      """
-      User(…)
-      """
-    )
-
-    let pair = Pair(
-      driver: User(
-        id: 1,
-        name: "Blob"
-      ),
-      passenger: User(
-        id: 2,
-        name: "Blob, Jr."
-      )
-    )
-
-    dump = ""
-    customDump(pair, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      Pair(
-        driver: User(
-          id: 1,
-          name: "Blob"
-        ),
-        passenger: User(
-          id: 2,
-          name: "Blob, Jr."
-        )
-      )
-      """
-    )
-
-    dump = ""
-    customDump(pair, to: &dump, maxDepth: 1)
-    XCTAssertNoDifference(
-      dump,
-      """
-      Pair(
-        driver: User(…),
-        passenger: User(…)
-      )
-      """
-    )
-  }
-
-  func testTuple() {
-    var dump = ""
-    customDump((1, 2), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      (
-        1,
-        2
-      )
-      """
-    )
-
-    dump = ""
-    customDump((x: 1, y: 2, ()), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      (
-        x: 1,
-        y: 2,
-        ()
-      )
-      """
-    )
-  }
-
-  func testMultilineString() {
-    var dump = ""
-    customDump("Hello,\nWorld!", to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      #"""
-      """
-      Hello,
-      World!
-      """
-      """#
-    )
-
-    dump = ""
-    customDump("Hello,\nWorld!"[...], to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      #"""
-      """
-      Hello,
-      World!
-      """
-      """#
-    )
-
-    dump = ""
-    customDump(
-      Email(
-        subject: "RE: Upcoming Event",
-        body: """
-          To whom it may concern,
-
-          Look forward to it!
-
-          Yours,
-          Blob
-          """
-      ),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Email(
-        subject: "RE: Upcoming Event",
-        body: \"\"\"
-          To whom it may concern,
-          \n\
-          Look forward to it!
-          \n\
-          Yours,
-          Blob
-          \"\"\"
-      )
-      """
-    )
-
-    dump = ""
-    customDump(
-      ##"""
-      print(
-        #"""
-        Hello, world!
-        """#
-      )
-      """##,
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      ###"""
-      ##"""
-      print(
-        #"""
-        Hello, world!
-        """#
-      )
-      """##
-      """###
-    )
-  }
-
-  func testAnyHashable() {
-    var dump = ""
-    customDump(AnyHashable(42), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      42
-      """
-    )
-
-    dump = ""
-    customDump(
-      [
-        AnyHashable(1): User(id: 1, name: "Blob"),
-        AnyHashable("Blob, Jr."): User(id: 2, name: "Blob, Jr."),
-      ],
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      [
-        "Blob, Jr.": User(
-          id: 2,
-          name: "Blob, Jr."
-        ),
-        1: User(
-          id: 1,
-          name: "Blob"
-        )
-      ]
-      """
-    )
-  }
-
-  #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    func testKeyPath() {
-      var dump = ""
-
-      // Run twice to exercise cached lookup
-      for _ in 1...2 {
-        dump = ""
-        customDump(\UserClass.name, to: &dump)
+    func testAnyType() {
+        var dump = ""
+        customDump(Foo.Bar.self, to: &dump)
         XCTAssertNoDifference(
-          dump,
-          #"""
-          \UserClass.name
-          """#
+            dump,
+            """
+            Foo.Bar.self
+            """
         )
-
-        dump = ""
-        customDump(\Pair.driver.name, to: &dump)
-        XCTAssertNoDifference(
-          dump,
-          #"""
-          \Pair.driver.name
-          """#
-        )
-
-        dump = ""
-        customDump(\User.name.count, to: &dump)
-        XCTAssertNoDifference(
-          dump,
-          #"""
-          KeyPath<User, Int>
-          """#
-        )
-
-        dump = ""
-        customDump(\(x: Double, y: Double).x, to: &dump)
-        XCTAssertNoDifference(
-          dump,
-          #"""
-          WritableKeyPath<(x: Double, y: Double), Double>
-          """#
-        )
-      }
     }
-  #endif
 
-  func testNamespacedTypes() {
-    var dump = ""
-    customDump(
-      Namespaced.Class(x: 0),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Namespaced.Class(x: 0)
-      """
-    )
-
-    dump = ""
-    customDump(
-      Namespaced.Enum.x(0),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Namespaced.Enum.x(0)
-      """
-    )
-
-    dump = ""
-    customDump(
-      Namespaced.Struct(x: 0),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Namespaced.Struct(x: 0)
-      """
-    )
-  }
-
-  func testGenerics() {
-    var dump = ""
-    customDump(
-      Result<Result<Int, Error>, Error>.success(.success(42)),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      Result.success(
-        Result.success(42)
-      )
-      """
-    )
-  }
-
-  func testUnknownContexts() {
-    struct Inline {}
-
-    var dump = ""
-    customDump(
-      Inline.self,
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      DumpTests.Inline.self
-      """
-    )
-
-    dump = ""
-    customDump(
-      Inline(),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      DumpTests.Inline()
-      """
-    )
-  }
-
-  func testCustomMirror() {
-    var dump = ""
-    customDump(Button(), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      Button.cancel(
-        action: nil,
-        label: "Cancel"
-      )
-      """
-    )
-
-    dump = ""
-    customDump(
-      LoginState(
-        email: "blob@pointfree.co",
-        password: "bl0bisawesome!",
-        token: "secret"
-      ),
-      to: &dump
-    )
-    XCTAssertNoDifference(
-      dump,
-      """
-      LoginState(
-        email: "blob@pointfree.co",
-        password: <redacted>
-      )
-      """
-    )
-  }
-
-  func testCustomOverride() {
-    var dump = ""
-    customDump(Wrapper(rawValue: 42), to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      42
-      """
-    )
-  }
-
-  func testStandardLibrary() {
-    var dump = ""
-    customDump("©" as Character, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      "©"
-      """
-    )
-
-    dump = ""
-    customDump("Blob" as StaticString, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      "Blob"
-      """
-    )
-
-    dump = ""
-    customDump("©" as UnicodeScalar, to: &dump)
-    XCTAssertNoDifference(
-      dump,
-      """
-      "©"
-      """
-    )
-  }
-
-  #if canImport(CoreGraphics)
-    func testCoreGraphics() {
-      var dump = ""
-      customDump(
-        CGRect(x: 0.5, y: 0.5, width: 1.5, height: 1.5),
-        to: &dump
-      )
-      XCTAssertNoDifference(
-        dump,
-        """
-        CGRect(
-          origin: CGPoint(
-            x: 0.5,
-            y: 0.5
-          ),
-          size: CGSize(
-            width: 1.5,
-            height: 1.5
-          )
+    func testClass() {
+        let user = UserClass(
+            id: 42,
+            name: "Blob"
         )
-        """
-      )
-    }
-  #endif
 
-  #if canImport(SwiftUI)
-    func testSwiftUI() {
-      var dump = ""
-      customDump(
-        Animation.easeInOut,
-        to: &dump
-      )
-      XCTAssertNoDifference(
-        dump,
-        """
-        Animation.easeInOut
-        """
-      )
+        var dump = ""
+        customDump(user, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            UserClass(
+              id: 42,
+              name: "Blob"
+            )
+            """
+        )
+
+        dump = ""
+        customDump(user, to: &dump, maxDepth: 0)
+        XCTAssertNoDifference(
+            dump,
+            """
+            UserClass(…)
+            """
+        )
+
+        let foo = RecursiveFoo()
+        foo.foo = foo
+
+        dump = ""
+        customDump(foo, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            RecursiveFoo(
+              foo: RecursiveFoo(↩︎)
+            )
+            """
+        )
     }
-  #endif
+
+    func testCollection() {
+        let users = [
+            User(
+                id: 1,
+                name: "Blob"
+            ),
+            User(
+                id: 2,
+                name: "Blob, Jr."
+            ),
+            User(
+                id: 3,
+                name: "Blob, Sr."
+            ),
+        ]
+
+        var dump = ""
+        customDump(users, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            [
+              [0]: User(
+                id: 1,
+                name: "Blob"
+              ),
+              [1]: User(
+                id: 2,
+                name: "Blob, Jr."
+              ),
+              [2]: User(
+                id: 3,
+                name: "Blob, Sr."
+              )
+            ]
+            """
+        )
+
+        dump = ""
+        customDump(users, to: &dump, maxDepth: 1)
+        XCTAssertNoDifference(
+            dump,
+            """
+            [
+              [0]: User(…),
+              [1]: User(…),
+              [2]: User(…)
+            ]
+            """
+        )
+
+        dump = ""
+        customDump(users, to: &dump, maxDepth: 0)
+        XCTAssertNoDifference(
+            dump,
+            """
+            […]
+            """
+        )
+    }
+
+    func testDictionary() {
+        var dump = ""
+        customDump(
+            [
+                1: User(
+                    id: 1,
+                    name: "Blob"
+                ),
+                2: User(
+                    id: 2,
+                    name: "Blob, Jr."
+                ),
+            ],
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            [
+              1: User(
+                id: 1,
+                name: "Blob"
+              ),
+              2: User(
+                id: 2,
+                name: "Blob, Jr."
+              )
+            ]
+            """
+        )
+
+        dump = ""
+        customDump(
+            [
+                ID(rawValue: "deadbeef"): User(
+                    id: 1,
+                    name: "Blob"
+                ),
+                ID(rawValue: "beefdead"): User(
+                    id: 2,
+                    name: "Blob, Jr."
+                ),
+            ],
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            [
+              ID(rawValue: "beefdead"): User(
+                id: 2,
+                name: "Blob, Jr."
+              ),
+              ID(rawValue: "deadbeef"): User(
+                id: 1,
+                name: "Blob"
+              )
+            ]
+            """
+        )
+    }
+
+    func testEnum() {
+        var dump = ""
+        customDump(Enum.foo, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            Enum.foo
+            """
+        )
+
+        dump = ""
+        customDump(Enum.bar(42), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            Enum.bar(42)
+            """
+        )
+
+        dump = ""
+        customDump(Enum.fu(bar: 42), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            Enum.fu(bar: 42)
+            """
+        )
+
+        dump = ""
+        customDump(Enum.baz(fizz: 0.9, buzz: "2"), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            Enum.baz(
+              fizz: 0.9,
+              buzz: "2"
+            )
+            """
+        )
+
+        dump = ""
+        customDump(Enum.fizz(0.9, buzz: "2"), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            Enum.fizz(
+              0.9,
+              buzz: "2"
+            )
+            """
+        )
+    }
+
+    func testOptional() {
+        var dump = ""
+        customDump(User?(.init(id: 42, name: "Blob")), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            User(
+              id: 42,
+              name: "Blob"
+            )
+            """
+        )
+
+        dump = ""
+        customDump(User?(nil), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            nil
+            """
+        )
+    }
+
+    func testSet() {
+        var dump = ""
+        customDump(Set([1, 2, 3]), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            Set([
+              1,
+              2,
+              3
+            ])
+            """
+        )
+    }
+
+    func testSingleValue() {
+        var dump = ""
+        customDump(1, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            1
+            """
+        )
+
+        dump = ""
+        customDump(true, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            true
+            """
+        )
+    }
+
+    func testStruct() {
+        let user = User(
+            id: 42,
+            name: "Blob"
+        )
+
+        var dump = ""
+        customDump(user, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            User(
+              id: 42,
+              name: "Blob"
+            )
+            """
+        )
+
+        dump = ""
+        customDump(user, to: &dump, maxDepth: 0)
+        XCTAssertNoDifference(
+            dump,
+            """
+            User(…)
+            """
+        )
+
+        let pair = Pair(
+            driver: User(
+                id: 1,
+                name: "Blob"
+            ),
+            passenger: User(
+                id: 2,
+                name: "Blob, Jr."
+            )
+        )
+
+        dump = ""
+        customDump(pair, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            Pair(
+              driver: User(
+                id: 1,
+                name: "Blob"
+              ),
+              passenger: User(
+                id: 2,
+                name: "Blob, Jr."
+              )
+            )
+            """
+        )
+
+        dump = ""
+        customDump(pair, to: &dump, maxDepth: 1)
+        XCTAssertNoDifference(
+            dump,
+            """
+            Pair(
+              driver: User(…),
+              passenger: User(…)
+            )
+            """
+        )
+    }
+
+    func testTuple() {
+        var dump = ""
+        customDump((1, 2), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            (
+              1,
+              2
+            )
+            """
+        )
+
+        dump = ""
+        customDump((x: 1, y: 2, ()), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            (
+              x: 1,
+              y: 2,
+              ()
+            )
+            """
+        )
+    }
+
+    func testMultilineString() {
+        var dump = ""
+        customDump("Hello,\nWorld!", to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            #"""
+            """
+            Hello,
+            World!
+            """
+            """#
+        )
+
+        dump = ""
+        customDump("Hello,\nWorld!"[...], to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            #"""
+            """
+            Hello,
+            World!
+            """
+            """#
+        )
+
+        dump = ""
+        customDump(
+            Email(
+                subject: "RE: Upcoming Event",
+                body: """
+                    To whom it may concern,
+
+                    Look forward to it!
+
+                    Yours,
+                    Blob
+                    """
+            ),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Email(
+              subject: "RE: Upcoming Event",
+              body: \"\"\"
+                To whom it may concern,
+                \n\
+                Look forward to it!
+                \n\
+                Yours,
+                Blob
+                \"\"\"
+            )
+            """
+        )
+
+        dump = ""
+        customDump(
+            ##"""
+            print(
+              #"""
+              Hello, world!
+              """#
+            )
+            """##,
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            ###"""
+            ##"""
+            print(
+              #"""
+              Hello, world!
+              """#
+            )
+            """##
+            """###
+        )
+    }
+
+    func testAnyHashable() {
+        var dump = ""
+        customDump(AnyHashable(42), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            42
+            """
+        )
+
+        dump = ""
+        customDump(
+            [
+                AnyHashable(1): User(id: 1, name: "Blob"),
+                AnyHashable("Blob, Jr."): User(id: 2, name: "Blob, Jr."),
+            ],
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            [
+              "Blob, Jr.": User(
+                id: 2,
+                name: "Blob, Jr."
+              ),
+              1: User(
+                id: 1,
+                name: "Blob"
+              )
+            ]
+            """
+        )
+    }
+
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+        func testKeyPath() {
+            var dump = ""
+
+            // Run twice to exercise cached lookup
+            for _ in 1...2 {
+                dump = ""
+                customDump(\UserClass.name, to: &dump)
+                XCTAssertNoDifference(
+                    dump,
+                    #"""
+                    \UserClass.name
+                    """#
+                )
+
+                dump = ""
+                customDump(\Pair.driver.name, to: &dump)
+                XCTAssertNoDifference(
+                    dump,
+                    #"""
+                    \Pair.driver.name
+                    """#
+                )
+
+                dump = ""
+                customDump(\User.name.count, to: &dump)
+                XCTAssertNoDifference(
+                    dump,
+                    #"""
+                    KeyPath<User, Int>
+                    """#
+                )
+
+                dump = ""
+                customDump(\(x: Double, y: Double).x, to: &dump)
+                XCTAssertNoDifference(
+                    dump,
+                    #"""
+                    WritableKeyPath<(x: Double, y: Double), Double>
+                    """#
+                )
+            }
+        }
+    #endif
+
+    func testNamespacedTypes() {
+        var dump = ""
+        customDump(
+            Namespaced.Class(x: 0),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Namespaced.Class(x: 0)
+            """
+        )
+
+        dump = ""
+        customDump(
+            Namespaced.Enum.x(0),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Namespaced.Enum.x(0)
+            """
+        )
+
+        dump = ""
+        customDump(
+            Namespaced.Struct(x: 0),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Namespaced.Struct(x: 0)
+            """
+        )
+    }
+
+    func testGenerics() {
+        var dump = ""
+        customDump(
+            Result<Result<Int, Error>, Error>.success(.success(42)),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            Result.success(
+              Result.success(42)
+            )
+            """
+        )
+    }
+
+    func testUnknownContexts() {
+        struct Inline {}
+
+        var dump = ""
+        customDump(
+            Inline.self,
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            DumpTests.Inline.self
+            """
+        )
+
+        dump = ""
+        customDump(
+            Inline(),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            DumpTests.Inline()
+            """
+        )
+    }
+
+    func testCustomMirror() {
+        var dump = ""
+        customDump(Button(), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            Button.cancel(
+              action: nil,
+              label: "Cancel"
+            )
+            """
+        )
+
+        dump = ""
+        customDump(
+            LoginState(
+                email: "blob@pointfree.co",
+                password: "bl0bisawesome!",
+                token: "secret"
+            ),
+            to: &dump
+        )
+        XCTAssertNoDifference(
+            dump,
+            """
+            LoginState(
+              email: "blob@pointfree.co",
+              password: <redacted>
+            )
+            """
+        )
+    }
+
+    func testCustomOverride() {
+        var dump = ""
+        customDump(Wrapper(rawValue: 42), to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            42
+            """
+        )
+    }
+
+    func testStandardLibrary() {
+        var dump = ""
+        customDump("©" as Character, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            "©"
+            """
+        )
+
+        dump = ""
+        customDump("Blob" as StaticString, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            "Blob"
+            """
+        )
+
+        dump = ""
+        customDump("©" as UnicodeScalar, to: &dump)
+        XCTAssertNoDifference(
+            dump,
+            """
+            "©"
+            """
+        )
+    }
+
+    #if canImport(CoreGraphics)
+        func testCoreGraphics() {
+            var dump = ""
+            customDump(
+                CGRect(x: 0.5, y: 0.5, width: 1.5, height: 1.5),
+                to: &dump
+            )
+            XCTAssertNoDifference(
+                dump,
+                """
+                CGRect(
+                  origin: CGPoint(
+                    x: 0.5,
+                    y: 0.5
+                  ),
+                  size: CGSize(
+                    width: 1.5,
+                    height: 1.5
+                  )
+                )
+                """
+            )
+        }
+    #endif
+
+    #if canImport(SwiftUI)
+        func testSwiftUI() {
+            var dump = ""
+            customDump(
+                Animation.easeInOut,
+                to: &dump
+            )
+            XCTAssertNoDifference(
+                dump,
+                """
+                Animation.easeInOut
+                """
+            )
+        }
+    #endif
 }

--- a/Tests/RxComposableArchitectureTests/CustomDumpTests/Mocks.swift
+++ b/Tests/RxComposableArchitectureTests/CustomDumpTests/Mocks.swift
@@ -1,68 +1,68 @@
-import RxComposableArchitecture
 import Foundation
+import RxComposableArchitecture
 
 class RecursiveFoo { var foo: RecursiveFoo? }
 
 class RepeatedObject {
-  class Child {
+    class Child {
+        let grandchild: Grandchild
+        init(id: String) {
+            grandchild = Grandchild(id: id)
+        }
+    }
+    class Grandchild {
+        let id: String
+        init(id: String) {
+            self.id = id
+        }
+    }
+
+    let child: Child
     let grandchild: Grandchild
     init(id: String) {
-      grandchild = Grandchild(id: id)
+        child = Child(id: id)
+        grandchild = child.grandchild
     }
-  }
-  class Grandchild {
-    let id: String
-    init(id: String) {
-      self.id = id
-    }
-  }
-
-  let child: Child
-  let grandchild: Grandchild
-  init(id: String) {
-    child = Child(id: id)
-    grandchild = child.grandchild
-  }
 }
 
 class UserClass {
-  let id: Int, name: String
-  init(id: Int, name: String) {
-    self.id = id
-    self.name = name
-  }
+    let id: Int, name: String
+    init(id: Int, name: String) {
+        self.id = id
+        self.name = name
+    }
 }
 
 enum Enum {
-  case foo
-  case bar(Int)
-  case baz(fizz: Double, buzz: String)
-  case fizz(Double, buzz: String)
-  case fu(bar: Int)
+    case foo
+    case bar(Int)
+    case baz(fizz: Double, buzz: String)
+    case fizz(Double, buzz: String)
+    case fu(bar: Int)
 }
 
 enum Namespaced {
-  class Class {
-    var x: Int
-    init(x: Int) { self.x = x }
-  }
-  enum Enum { case x(Int) }
-  struct Struct { var x: Int }
+    class Class {
+        var x: Int
+        init(x: Int) { self.x = x }
+    }
+    enum Enum { case x(Int) }
+    struct Struct { var x: Int }
 }
 
 struct Button: CustomDumpReflectable {
-  var customDumpMirror: Mirror {
-    .init(
-      self,
-      children: [
-        "cancel": (
-          action: Any?.none,
-          label: "Cancel"
+    var customDumpMirror: Mirror {
+        .init(
+            self,
+            children: [
+                "cancel": (
+                    action: Any?.none,
+                    label: "Cancel"
+                )
+            ],
+            displayStyle: .enum
         )
-      ],
-      displayStyle: .enum
-    )
-  }
+    }
 }
 
 struct Email: Equatable { let subject: String, body: String }
@@ -70,34 +70,34 @@ struct Email: Equatable { let subject: String, body: String }
 struct Foo { struct Bar {} }
 
 struct FriendlyUser: Equatable {
-  var id: Int
-  var name: String
-  var friends: [FriendlyUser]
+    var id: Int
+    var name: String
+    var friends: [FriendlyUser]
 }
 
 struct ID: Hashable, RawRepresentable { let rawValue: String }
 
 struct Wrapper<RawValue>: CustomDumpRepresentable {
-  let rawValue: RawValue
+    let rawValue: RawValue
 
-  var customDumpValue: Any {
-    self.rawValue
-  }
+    var customDumpValue: Any {
+        self.rawValue
+    }
 }
 
 struct LoginState: CustomDumpReflectable {
-  var email = "", password = "", token: String
+    var email = "", password = "", token: String
 
-  var customDumpMirror: Mirror {
-    .init(
-      self,
-      children: [
-        "email": self.email,
-        "password": Redacted(rawValue: self.password),
-      ],
-      displayStyle: .struct
-    )
-  }
+    var customDumpMirror: Mirror {
+        .init(
+            self,
+            children: [
+                "email": self.email,
+                "password": Redacted(rawValue: self.password),
+            ],
+            displayStyle: .struct
+        )
+    }
 }
 
 struct NestedDate { var date: Date? }
@@ -105,18 +105,18 @@ struct NestedDate { var date: Date? }
 struct NeverEqualModel: Equatable { static func == (lhs: Self, rhs: Self) -> Bool { false } }
 
 struct NeverEqualUser: Equatable {
-  let id: Int
-  let name: String
+    let id: Int
+    let name: String
 
-  static func == (lhs: Self, rhs: Self) -> Bool { false }
+    static func == (lhs: Self, rhs: Self) -> Bool { false }
 }
 
 struct Pair { let driver: User, passenger: User }
 
 struct Redacted<RawValue>: CustomDumpStringConvertible {
-  var rawValue: RawValue
+    var rawValue: RawValue
 
-  var customDumpDescription: String {
-    "<redacted>"
-  }
+    var customDumpDescription: String {
+        "<redacted>"
+    }
 }

--- a/Tests/RxComposableArchitectureTests/CustomDumpTests/XCTAssertNoDifferenceTests.swift
+++ b/Tests/RxComposableArchitectureTests/CustomDumpTests/XCTAssertNoDifferenceTests.swift
@@ -2,15 +2,15 @@ import RxComposableArchitecture
 import XCTest
 
 class XCTAssertNoDifferenceTests: XCTestCase {
-  #if compiler(>=5.4) && (os(iOS) || os(macOS) || os(tvOS) || os(watchOS))
-    func testXCTAssertNoDifference() {
-      XCTExpectFailure()
+    #if compiler(>=5.4) && (os(iOS) || os(macOS) || os(tvOS) || os(watchOS))
+        func testXCTAssertNoDifference() {
+            XCTExpectFailure()
 
-      let user = User(id: 42, name: "Blob")
-      var other = user
-      other.name += " Sr."
+            let user = User(id: 42, name: "Blob")
+            var other = user
+            other.name += " Sr."
 
-      XCTAssertNoDifference(user, other)
-    }
-  #endif
+            XCTAssertNoDifference(user, other)
+        }
+    #endif
 }

--- a/Tests/RxComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/RxComposableArchitectureTests/EffectCancellationTests.swift
@@ -138,7 +138,7 @@ internal final class EffectCancellationTests: XCTestCase {
         Effect<Never>.cancel(id: 1)
             .subscribe()
             .disposed(by: disposeBag)
-        
+
         XCTAssertTrue(cancellationCancellables.isEmpty)
     }
 
@@ -197,7 +197,7 @@ internal final class EffectCancellationTests: XCTestCase {
             .eraseToEffect()
             .cancellable(id: 1)
 
-        for _ in 1 ... .random(in: 1 ... 1000) {
+        for _ in 1 ... .random(in: 1...1000) {
             effect = effect.cancellable(id: 1)
         }
 
@@ -254,14 +254,14 @@ internal final class EffectCancellationTests: XCTestCase {
         scheduler.advance(by: .seconds(1))
         XCTAssertEqual(expectedOutput, [])
     }
-    
+
     internal func testNestedMergeCancellation() {
         let effect = Effect<Int>.merge(
             Observable.of(1, 2)
                 .eraseToEffect()
                 .cancellable(id: 1)
         )
-            .cancellable(id: 2)
+        .cancellable(id: 2)
 
         var output: [Int] = []
         effect

--- a/Tests/RxComposableArchitectureTests/EffectDebounceTests.swift
+++ b/Tests/RxComposableArchitectureTests/EffectDebounceTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import RxSwift
 import RxComposableArchitecture
+import RxSwift
 import XCTest
 
 internal final class EffectDebounceTests: XCTestCase {

--- a/Tests/RxComposableArchitectureTests/EffectDeferredTests.swift
+++ b/Tests/RxComposableArchitectureTests/EffectDeferredTests.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import RxSwift
 import RxComposableArchitecture
+import RxSwift
 import XCTest
 
 internal final class EffectDeferredTests: XCTestCase {

--- a/Tests/RxComposableArchitectureTests/EffectTests.swift
+++ b/Tests/RxComposableArchitectureTests/EffectTests.swift
@@ -161,16 +161,16 @@ internal final class EffectTests: XCTestCase {
         XCTAssertEqual(values, [1])
         XCTAssertEqual(isComplete, true)
     }
-    
+
     func testDoubleCancelInFlight() {
         var result: Int?
-        
+
         _ = Observable.just(42)
             .eraseToEffect()
             .cancellable(id: "id", cancelInFlight: true)
             .cancellable(id: "id", cancelInFlight: true)
             .subscribe { result = $0 }
-        
+
         XCTAssertEqual(result, 42)
     }
 }

--- a/Tests/RxComposableArchitectureTests/EffectThrottleTests.swift
+++ b/Tests/RxComposableArchitectureTests/EffectThrottleTests.swift
@@ -6,14 +6,14 @@ import XCTest
 final class EffectThrottleTests: XCTestCase {
     var disposeBag = DisposeBag()
     let scheduler = TestScheduler(initialClock: 0)
-    
+
     func testThrottleLatest() {
         var values: [Int] = []
         var effectRuns = 0
-        
+
         func runThrottledEffect(value: Int) {
             enum CancelToken {}
-            
+
             Observable.deferred { () -> Observable<Int> in
                 effectRuns += 1
                 return .just(value)
@@ -27,42 +27,42 @@ final class EffectThrottleTests: XCTestCase {
             })
             .disposed(by: disposeBag)
         }
-        
+
         runThrottledEffect(value: 1)
 
         scheduler.advance()
-        
+
         // A value emits right away.
         XCTAssertEqual(values, [1])
-        
+
         runThrottledEffect(value: 2)
-        
+
         scheduler.advance()
-        
+
         // A second value is throttled.
         XCTAssertEqual(values, [1])
-        
+
         scheduler.advance(by: .milliseconds(250))
-        
+
         runThrottledEffect(value: 3)
-        
+
         scheduler.advance(by: .milliseconds(250))
-        
+
         runThrottledEffect(value: 4)
-        
+
         scheduler.advance(by: .milliseconds(250))
-        
+
         runThrottledEffect(value: 5)
-        
+
         // A third value is throttled.
         XCTAssertEqual(values, [1])
-        
+
         scheduler.advance(by: .milliseconds(250))
-        
+
         // The latest value emits.
         XCTAssertEqual(values, [1, 5])
     }
-    
+
     func testThrottleFirst() {
         var values: [Int] = []
         var effectRuns = 0

--- a/Tests/RxComposableArchitectureTests/IdentifiedArrayTests.swift
+++ b/Tests/RxComposableArchitectureTests/IdentifiedArrayTests.swift
@@ -26,10 +26,14 @@ internal final class IdentifiedArrayTests: XCTestCase {
     internal func testInsertContentsOf() {
         var array: IdentifiedArray = [User(id: 1, name: "Blob")]
 
-        array.insert(contentsOf: [User(id: 3, name: "Blob Sr."), User(id: 2, name: "Blob Jr.")], at: 0)
+        array.insert(
+            contentsOf: [User(id: 3, name: "Blob Sr."), User(id: 2, name: "Blob Jr.")], at: 0)
         XCTAssertEqual(
             array,
-            [User(id: 3, name: "Blob Sr."), User(id: 2, name: "Blob Jr."), User(id: 1, name: "Blob")]
+            [
+                User(id: 3, name: "Blob Sr."), User(id: 2, name: "Blob Jr."),
+                User(id: 1, name: "Blob"),
+            ]
         )
     }
 
@@ -37,7 +41,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
         var array: IdentifiedArray = [
             User(id: 3, name: "Blob Sr."),
             User(id: 2, name: "Blob Jr."),
-            User(id: 1, name: "Blob")
+            User(id: 1, name: "Blob"),
         ]
 
         array.remove(at: 1)
@@ -48,7 +52,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
         var array: IdentifiedArray = [
             User(id: 3, name: "Blob Sr."),
             User(id: 2, name: "Blob Jr."),
-            User(id: 1, name: "Blob")
+            User(id: 1, name: "Blob"),
         ]
 
         array.removeAll(where: { $0.name.starts(with: "Blob ") })
@@ -59,7 +63,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
         var array: IdentifiedArray = [
             User(id: 3, name: "Blob Sr."),
             User(id: 2, name: "Blob Jr."),
-            User(id: 1, name: "Blob")
+            User(id: 1, name: "Blob"),
         ]
 
         array.remove(atOffsets: [0, 2])
@@ -71,22 +75,23 @@ internal final class IdentifiedArrayTests: XCTestCase {
             User(id: 3, name: "Blob Sr."),
             User(id: 2, name: "Blob Jr."),
             User(id: 1, name: "Blob"),
-            User(id: 2, name: "Blob Jr.")
+            User(id: 2, name: "Blob Jr."),
         ]
 
         array.replaceSubrange(
-            0 ... 1,
+            0...1,
             with: [
                 User(id: 4, name: "Flob IV"),
-                User(id: 5, name: "Flob V")
+                User(id: 5, name: "Flob V"),
             ]
         )
 
         XCTAssertEqual(
             array,
             [
-                User(id: 4, name: "Flob IV"), User(id: 5, name: "Flob V"), User(id: 1, name: "Blob"),
-                User(id: 2, name: "Blob Jr.")
+                User(id: 4, name: "Flob IV"), User(id: 5, name: "Flob V"),
+                User(id: 1, name: "Blob"),
+                User(id: 2, name: "Blob Jr."),
             ]
         )
     }
@@ -95,7 +100,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
         var array: IdentifiedArray = [
             ComparableValue(id: 1, value: 100),
             ComparableValue(id: 2, value: 50),
-            ComparableValue(id: 3, value: 75)
+            ComparableValue(id: 3, value: 75),
         ]
 
         array.sort { $0.value < $1.value }
@@ -105,7 +110,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
             [
                 ComparableValue(id: 2, value: 50),
                 ComparableValue(id: 3, value: 75),
-                ComparableValue(id: 1, value: 100)
+                ComparableValue(id: 1, value: 100),
             ], array
         )
     }
@@ -114,7 +119,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
         var array: IdentifiedArray = [
             ComparableValue(id: 1, value: 100),
             ComparableValue(id: 2, value: 50),
-            ComparableValue(id: 3, value: 75)
+            ComparableValue(id: 3, value: 75),
         ]
 
         array.sort()
@@ -124,7 +129,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
             [
                 ComparableValue(id: 2, value: 50),
                 ComparableValue(id: 3, value: 75),
-                ComparableValue(id: 1, value: 100)
+                ComparableValue(id: 1, value: 100),
             ], array
         )
     }
@@ -138,7 +143,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
                 User(id: 2, name: "Blob Jr."),
                 User(id: 3, name: "Blob Sr."),
                 User(id: 4, name: "Foo Jr."),
-                User(id: 5, name: "Bar Jr.")
+                User(id: 5, name: "Bar Jr."),
             ]
             var lcrng = LCRNG(seed: 0)
             array.shuffle(using: &lcrng)
@@ -148,7 +153,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
                     User(id: 3, name: "Blob Sr."),
                     User(id: 5, name: "Bar Jr."),
                     User(id: 4, name: "Foo Jr."),
-                    User(id: 2, name: "Blob Jr.")
+                    User(id: 2, name: "Blob Jr."),
                 ],
                 array.elements
             )
@@ -160,7 +165,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
         var array: IdentifiedArray = [
             ComparableValue(id: 1, value: 100),
             ComparableValue(id: 2, value: 50),
-            ComparableValue(id: 3, value: 75)
+            ComparableValue(id: 3, value: 75),
         ]
 
         array.reverse()
@@ -170,7 +175,7 @@ internal final class IdentifiedArrayTests: XCTestCase {
             [
                 ComparableValue(id: 3, value: 75),
                 ComparableValue(id: 2, value: 50),
-                ComparableValue(id: 1, value: 100)
+                ComparableValue(id: 1, value: 100),
             ], array
         )
     }

--- a/Tests/RxComposableArchitectureTests/NeverEqualTests.swift
+++ b/Tests/RxComposableArchitectureTests/NeverEqualTests.swift
@@ -1,6 +1,6 @@
 //
 //  NeverEqualTests.swift
-//  
+//
 //
 //  Created by jefferson.setiawan on 03/06/22.
 //
@@ -11,23 +11,23 @@ import XCTest
 
 internal final class NeverEqualTests: XCTestCase {
     private let disposeBag = DisposeBag()
-    
+
     func testIncrement() {
         @NeverEqual var value = "Hello"
         let oldValue = $value
         value = "hello"
         XCTAssertNotEqual(oldValue, $value)
     }
-    
+
     internal func testDistinctSet() {
         @NeverEqual var value = "Hello"
-        (0 ..< 255).forEach { _ in
+        (0..<255).forEach { _ in
             value = "Hello"
-        } // testing to max 255
-        value = "Hello" // trigger 256, it should reset the numberOfIncrement to 0 again
+        }  // testing to max 255
+        value = "Hello"  // trigger 256, it should reset the numberOfIncrement to 0 again
         XCTAssertEqual($value, NeverEqual(wrappedValue: "Hello"))
     }
-    
+
     internal func testStoreSubscriptionOfNeverEqual() {
         struct MyState: Equatable {
             @NeverEqual var run: Stateless?
@@ -35,7 +35,7 @@ internal final class NeverEqualTests: XCTestCase {
         enum MyAction: Equatable {
             case tap
         }
-        
+
         let store = Store(
             initialState: MyState(),
             reducer: Reducer<MyState, MyAction, Void> { state, action, _ in
@@ -55,10 +55,10 @@ internal final class NeverEqualTests: XCTestCase {
                 }
             })
             .disposed(by: disposeBag)
-        
+
         store.send(.tap)
         XCTAssertEqual(called, 1)
-        
+
         store.send(.tap)
         XCTAssertEqual(called, 2)
     }

--- a/Tests/RxComposableArchitectureTests/SingleSelectionSelectableTypeTests.swift
+++ b/Tests/RxComposableArchitectureTests/SingleSelectionSelectableTypeTests.swift
@@ -24,7 +24,7 @@ internal final class SingleSelectionSelectableTypeTests: XCTestCase {
             Item(id: 1, isSelected: false),
             Item(id: 2, isSelected: false),
             Item(id: 3, isSelected: false),
-            Item(id: 4, isSelected: false)
+            Item(id: 4, isSelected: false),
         ])
 
         let target = State(items: .init(wrappedValue: initialItems))
@@ -36,7 +36,7 @@ internal final class SingleSelectionSelectableTypeTests: XCTestCase {
             Item(id: 0, isSelected: true),
             Item(id: 1, isSelected: false),
             Item(id: 2, isSelected: false),
-            Item(id: 3, isSelected: false)
+            Item(id: 3, isSelected: false),
         ])
 
         let target = State(items: SingleSelection<Item>(wrappedValue: initialItems))
@@ -48,7 +48,7 @@ internal final class SingleSelectionSelectableTypeTests: XCTestCase {
             Item(id: 0, isSelected: false),
             Item(id: 1, isSelected: true),
             Item(id: 2, isSelected: true),
-            Item(id: 3, isSelected: true)
+            Item(id: 3, isSelected: true),
         ])
 
         let target = State(items: SingleSelection<Item>(wrappedValue: initialItems))
@@ -60,7 +60,7 @@ internal final class SingleSelectionSelectableTypeTests: XCTestCase {
             Item(id: 0, isSelected: true),
             Item(id: 1, isSelected: false),
             Item(id: 2, isSelected: false),
-            Item(id: 3, isSelected: false)
+            Item(id: 3, isSelected: false),
         ])
 
         var target = State(items: SingleSelection<Item>(wrappedValue: initialItems))
@@ -69,12 +69,14 @@ internal final class SingleSelectionSelectableTypeTests: XCTestCase {
         AssertSelection(target, selectionId: 1)
     }
 
-    internal func test_initWithMultipleSelection_shouldSelectTheFirstOne_thenChangeSelectionSeveralTime() {
+    internal func
+        test_initWithMultipleSelection_shouldSelectTheFirstOne_thenChangeSelectionSeveralTime()
+    {
         let initialItems = IdentifiedArray([
             Item(id: 0, isSelected: false),
             Item(id: 1, isSelected: true),
             Item(id: 2, isSelected: true),
-            Item(id: 3, isSelected: true)
+            Item(id: 3, isSelected: true),
         ])
 
         var target = State(items: SingleSelection<Item>(wrappedValue: initialItems))
@@ -96,7 +98,8 @@ internal final class SingleSelectionSelectableTypeTests: XCTestCase {
         }
 
         guard let element = selected[id: id] else {
-            XCTFail("element is not valid", file: file, line: line); return
+            XCTFail("element is not valid", file: file, line: line)
+            return
         }
 
         XCTAssertTrue(selected.count == 1 && element.isSelected, file: file, line: line)

--- a/Tests/RxComposableArchitectureTests/SingleSelectionTests.swift
+++ b/Tests/RxComposableArchitectureTests/SingleSelectionTests.swift
@@ -24,10 +24,11 @@ internal final class SingleSelectionTests: XCTestCase {
             Item(id: 1, isSelected: false),
             Item(id: 2, isSelected: false),
             Item(id: 3, isSelected: false),
-            Item(id: 4, isSelected: false)
+            Item(id: 4, isSelected: false),
         ])
 
-        let target = State(items: SingleSelection<Item>(wrappedValue: initialItems, selection: \.isSelected))
+        let target = State(
+            items: SingleSelection<Item>(wrappedValue: initialItems, selection: \.isSelected))
         AssertSelection(target, selectionId: nil)
     }
 
@@ -36,10 +37,11 @@ internal final class SingleSelectionTests: XCTestCase {
             Item(id: 0, isSelected: true),
             Item(id: 1, isSelected: false),
             Item(id: 2, isSelected: false),
-            Item(id: 3, isSelected: false)
+            Item(id: 3, isSelected: false),
         ])
 
-        let target = State(items: SingleSelection<Item>(wrappedValue: initialItems, selection: \.isSelected))
+        let target = State(
+            items: SingleSelection<Item>(wrappedValue: initialItems, selection: \.isSelected))
         AssertSelection(target, selectionId: 0)
     }
 
@@ -48,10 +50,11 @@ internal final class SingleSelectionTests: XCTestCase {
             Item(id: 0, isSelected: false),
             Item(id: 1, isSelected: true),
             Item(id: 2, isSelected: true),
-            Item(id: 3, isSelected: true)
+            Item(id: 3, isSelected: true),
         ])
 
-        let target = State(items: SingleSelection<Item>(wrappedValue: initialItems, selection: \.isSelected))
+        let target = State(
+            items: SingleSelection<Item>(wrappedValue: initialItems, selection: \.isSelected))
         AssertSelection(target, selectionId: 1)
     }
 
@@ -60,24 +63,28 @@ internal final class SingleSelectionTests: XCTestCase {
             Item(id: 0, isSelected: true),
             Item(id: 1, isSelected: false),
             Item(id: 2, isSelected: false),
-            Item(id: 3, isSelected: false)
+            Item(id: 3, isSelected: false),
         ])
 
-        var target = State(items: SingleSelection<Item>(wrappedValue: initialItems, selection: \.isSelected))
+        var target = State(
+            items: SingleSelection<Item>(wrappedValue: initialItems, selection: \.isSelected))
 
         target.items[1].isSelected = true
         AssertSelection(target, selectionId: 1)
     }
 
-    internal func test_initWithMultipleSelection_shouldSelectTheFirstOne_thenChangeSelectionSeveralTime() {
+    internal func
+        test_initWithMultipleSelection_shouldSelectTheFirstOne_thenChangeSelectionSeveralTime()
+    {
         let initialItems = IdentifiedArray([
             Item(id: 0, isSelected: false),
             Item(id: 1, isSelected: true),
             Item(id: 2, isSelected: true),
-            Item(id: 3, isSelected: true)
+            Item(id: 3, isSelected: true),
         ])
 
-        var target = State(items: SingleSelection<Item>(wrappedValue: initialItems, selection: \.isSelected))
+        var target = State(
+            items: SingleSelection<Item>(wrappedValue: initialItems, selection: \.isSelected))
         target.items[2].isSelected = true
         target.items[3].isSelected = true
         AssertSelection(target, selectionId: 3)
@@ -96,7 +103,8 @@ internal final class SingleSelectionTests: XCTestCase {
         }
 
         guard let element = selected[id: id] else {
-            XCTFail("element is not valid", file: file, line: line); return
+            XCTFail("element is not valid", file: file, line: line)
+            return
         }
 
         XCTAssertTrue(selected.count == 1 && element.isSelected, file: file, line: line)

--- a/Tests/RxComposableArchitectureTests/StoreTests.swift
+++ b/Tests/RxComposableArchitectureTests/StoreTests.swift
@@ -103,7 +103,7 @@ internal final class StoreTests: XCTestCase {
 
         XCTAssertEqual(numCalls1, 2)
     }
-    
+
     internal func testScopeCallCountUsingNewScope() {
         let counterReducer = Reducer<Int, Void, Void> { state, _, _ in state += 1
             return .none
@@ -165,7 +165,7 @@ internal final class StoreTests: XCTestCase {
         XCTAssertEqual(numCalls2, 11)
         XCTAssertEqual(numCalls3, 14)
     }
-    
+
     internal func testScopeCallCount2UsingNewScope() {
         let counterReducer = Reducer<Int, Void, Void> { state, _, _ in
             state += 1
@@ -176,19 +176,21 @@ internal final class StoreTests: XCTestCase {
         var numCalls2 = 0
         var numCalls3 = 0
 
-        let store = Store(initialState: 0, reducer: counterReducer, environment: (), useNewScope: true)
-            .scope(state: { (count: Int) -> Int in
-                numCalls1 += 1
-                return count
-            })
-            .scope(state: { (count: Int) -> Int in
-                numCalls2 += 1
-                return count
-            })
-            .scope(state: { (count: Int) -> Int in
-                numCalls3 += 1
-                return count
-            })
+        let store = Store(
+            initialState: 0, reducer: counterReducer, environment: (), useNewScope: true
+        )
+        .scope(state: { (count: Int) -> Int in
+            numCalls1 += 1
+            return count
+        })
+        .scope(state: { (count: Int) -> Int in
+            numCalls2 += 1
+            return count
+        })
+        .scope(state: { (count: Int) -> Int in
+            numCalls3 += 1
+            return count
+        })
 
         XCTAssertEqual(numCalls1, 1)
         XCTAssertEqual(numCalls2, 1)
@@ -212,7 +214,7 @@ internal final class StoreTests: XCTestCase {
         XCTAssertEqual(numCalls2, 4)
         XCTAssertEqual(numCalls3, 4)
     }
-    
+
     internal func testScopeAtIndexCallCount2() {
         struct Item: HashDiffable, Equatable {
             var id: Int
@@ -234,33 +236,35 @@ internal final class StoreTests: XCTestCase {
 
         var numCalls1 = 0
         var numCalls2 = 0
-        
+
         let mock = (1...3).map {
             Item(id: $0, qty: 1)
         }
 
-        let store = Store(initialState: IdentifiedArrayOf(mock), reducer: itemReducer, environment: ())
-            .scope(state: { (item: IdentifiedArrayOf<Item>) -> IdentifiedArrayOf<Item> in
-                numCalls1 += 1
-                return item
-            })
-            .scope(at: 1, action: Action.item)!
-            .scope(state: { (item: Item) -> Item in
-                numCalls2 += 1
-                return item
-            })
+        let store = Store(
+            initialState: IdentifiedArrayOf(mock), reducer: itemReducer, environment: ()
+        )
+        .scope(state: { (item: IdentifiedArrayOf<Item>) -> IdentifiedArrayOf<Item> in
+            numCalls1 += 1
+            return item
+        })
+        .scope(at: 1, action: Action.item)!
+        .scope(state: { (item: Item) -> Item in
+            numCalls2 += 1
+            return item
+        })
 
         store.send((1, .didTap))
         XCTAssertEqual(numCalls1, 4)
         XCTAssertEqual(numCalls2, 5)
         XCTAssertEqual(store.state.qty, 2)
-        
+
         store.send((1, .didTap))
         XCTAssertEqual(numCalls1, 6)
         XCTAssertEqual(numCalls2, 8)
         XCTAssertEqual(store.state.qty, 3)
     }
-    
+
     internal func testScopeAtIndexCallCount2UseNewScope() {
         struct Item: HashDiffable, Equatable {
             var id: Int
@@ -282,27 +286,30 @@ internal final class StoreTests: XCTestCase {
 
         var numCalls1 = 0
         var numCalls2 = 0
-        
+
         let mock = (1...3).map {
             Item(id: $0, qty: 1)
         }
 
-        let store = Store(initialState: IdentifiedArrayOf(mock), reducer: itemReducer, environment: (), useNewScope: true)
-            .scope(state: { (item: IdentifiedArrayOf<Item>) -> IdentifiedArrayOf<Item> in
-                numCalls1 += 1
-                return item
-            })
-            .scope(at: 1, action: Action.item)!
-            .scope(state: { (item: Item) -> Item in
-                numCalls2 += 1
-                return item
-            })
+        let store = Store(
+            initialState: IdentifiedArrayOf(mock), reducer: itemReducer, environment: (),
+            useNewScope: true
+        )
+        .scope(state: { (item: IdentifiedArrayOf<Item>) -> IdentifiedArrayOf<Item> in
+            numCalls1 += 1
+            return item
+        })
+        .scope(at: 1, action: Action.item)!
+        .scope(state: { (item: Item) -> Item in
+            numCalls2 += 1
+            return item
+        })
 
         store.send((1, .didTap))
         XCTAssertEqual(numCalls1, 2)
         XCTAssertEqual(numCalls2, 2)
         XCTAssertEqual(store.state.qty, 2)
-        
+
         store.send((1, .didTap))
         XCTAssertEqual(numCalls1, 3)
         XCTAssertEqual(numCalls2, 3)
@@ -483,7 +490,7 @@ internal final class StoreTests: XCTestCase {
         }
         subject.onCompleted()
     }
-    
+
     internal func testCoalesceSynchronousActions() {
         let store = Store(
             initialState: 0,
@@ -502,19 +509,19 @@ internal final class StoreTests: XCTestCase {
             },
             environment: ()
         )
-        
+
         var emissions: [Int] = []
         store.subscribe { $0 }
             .subscribe { emissions.append($0) }
             .disposed(by: disposeBag)
-        
+
         XCTAssertEqual(emissions, [0])
-        
+
         store.send(0)
-        
+
         XCTAssertEqual(emissions, [0, 1, 2, 3])
     }
-    
+
     internal func testCoalesceSynchronousActionsUsingNewScope() {
         let store = Store(
             initialState: 0,
@@ -534,36 +541,36 @@ internal final class StoreTests: XCTestCase {
             environment: (),
             useNewScope: true
         )
-        
+
         var emissions: [Int] = []
         store.subscribe { $0 }
             .subscribe { emissions.append($0) }
             .disposed(by: disposeBag)
-        
+
         XCTAssertEqual(emissions, [0])
-        
+
         store.send(0)
-        
+
         XCTAssertEqual(emissions, [0, 3])
     }
-    
+
     internal func testSyncEffectsFromEnvironment() {
         enum Action: Equatable {
             // subscribes to a long living effect, potentially feeding data
             // back into the store
             case onAppear
-            
+
             // Talks to the environment, eventually feeding data back into the store
             case onUserAction
-            
+
             // External event coming in from the environment, updating state
             case externalAction
         }
-        
+
         struct Environment {
             var externalEffects = PublishSubject<Action>()
         }
-        
+
         let counterReducer = Reducer<Int, Action, Environment> { state, action, env in
             switch action {
             case .onAppear:
@@ -580,13 +587,14 @@ internal final class StoreTests: XCTestCase {
             }
             return .none
         }
-        let parentStore = Store(initialState: 1, reducer: counterReducer, environment: Environment(), useNewScope: true)
-        
+        let parentStore = Store(
+            initialState: 1, reducer: counterReducer, environment: Environment(), useNewScope: true)
+
         // subscribes to a long living publisher of actions
         parentStore.send(.onAppear)
-        
+
         parentStore.send(.onUserAction)
-        
+
         // State should be at 2 now
         XCTAssertEqual(parentStore.state, 2)
     }


### PR DESCRIPTION
This PR introduces formatting code using [swift-format](https://github.com/apple/swift-format) to tidy up and standardize code style in this repository.

Current rules that's used is:
- indentation: 4 spaces