### PR TITLE
Use new scope by default

### DIFF
--- a/Sources/RxComposableArchitecture/Store.swift
+++ b/Sources/RxComposableArchitecture/Store.swift
@@ -539,7 +539,7 @@ public struct StoreConfig {
 
 extension StoreConfig {
     public static var `default`: StoreConfig = .init(
-        useNewScope: { false },
+        useNewScope: { true },
         mainThreadChecksEnabled: { true },
         cancelsEffectsOnDeinit: { true }
     )

--- a/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
@@ -330,7 +330,7 @@ extension TestStore where State == LocalState, Action == LocalAction {
         reducer: Reducer<State, Action, Environment>,
         environment: Environment,
         failingWhenNothingChange: Bool = true,
-        useNewScope: Bool = StoreConfig.default.useNewScope(),
+        useNewScope: Bool = false,
         file: StaticString = #file,
         line: UInt = #line
     ) {

--- a/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
@@ -330,7 +330,7 @@ extension TestStore where State == LocalState, Action == LocalAction {
         reducer: Reducer<State, Action, Environment>,
         environment: Environment,
         failingWhenNothingChange: Bool = true,
-        useNewScope: Bool = false,
+        useNewScope: Bool = StoreConfig.default.useNewScope(),
         file: StaticString = #file,
         line: UInt = #line
     ) {


### PR DESCRIPTION
Encourage users to use new scope