### PR TITLE
[Reducer Protocol] - Add New Test Cases

### DIFF
--- a/Package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Package.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Package.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,52 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift",
+        "state": {
+          "branch": null,
+          "revision": "cec68169a048a079f461ba203fe85636548d7a89",
+          "version": "5.1.3"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
+          "version": "1.1.4"
+        }
+      },
+      {
+        "package": "Benchmark",
+        "repositoryURL": "https://github.com/google/swift-benchmark",
+        "state": {
+          "branch": null,
+          "revision": "8163295f6fe82356b0bcf8e1ab991645de17d096",
+          "version": "0.1.2"
+        }
+      },
+      {
+        "package": "swift-case-paths",
+        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
+        "state": {
+          "branch": null,
+          "revision": "bb436421f57269fbcfe7360735985321585a86e5",
+          "version": "0.10.1"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "16e6409ee82e1b81390bdffbf217b9c08ab32784",
+          "version": "0.5.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
@@ -251,7 +251,7 @@ public final class TestStore<State, ScopedState, Action, ScopedAction, Environme
         reducer: Reducer,
         file: StaticString = #file,
         line: UInt = #line,
-        failingWhenNothingChange: Bool = false,
+        failingWhenNothingChange: Bool = true,
         useNewScope: Bool = false
     )
     where
@@ -325,7 +325,7 @@ public final class TestStore<State, ScopedState, Action, ScopedAction, Environme
         environment: Environment,
         file: StaticString = #file,
         line: UInt = #line,
-        failingWhenNothingChange: Bool = false,
+        failingWhenNothingChange: Bool = true,
         useNewScope: Bool = false
     )
     where State == ScopedState, Action == ScopedAction {
@@ -363,7 +363,7 @@ public final class TestStore<State, ScopedState, Action, ScopedAction, Environme
         store: Store<State, TestReducer<State, Action>.Action>,
         timeout: UInt64 = 100 * NSEC_PER_MSEC,
         toScopedState: @escaping (State) -> ScopedState,
-        failingWhenNothingChange: Bool = false,
+        failingWhenNothingChange: Bool = true,
         useNewScope: Bool = false
     ) {
         self._environment = _environment

--- a/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
@@ -267,11 +267,16 @@ public final class TestStore<State, ScopedState, Action, ScopedAction, Environme
         self.fromScopedAction = { $0 }
         self.line = line
         self.reducer = reducer
-        self.store = Store(initialState: initialState, reducer: reducer)
         self.timeout = 100 * NSEC_PER_MSEC
         self.toScopedState = { $0 }
         self.failingWhenNothingChange = failingWhenNothingChange
         self.useNewScope = useNewScope
+        
+        self.store = Store(
+            initialState: initialState,
+            reducer: reducer,
+            useNewScope: useNewScope
+        )
     }
     
     @available(
@@ -337,11 +342,16 @@ public final class TestStore<State, ScopedState, Action, ScopedAction, Environme
         self.fromScopedAction = { $0 }
         self.line = line
         self.reducer = reducer
-        self.store = Store(initialState: initialState, reducer: reducer)
         self.timeout = 100 * NSEC_PER_MSEC
         self.toScopedState = { $0 }
         self.failingWhenNothingChange = failingWhenNothingChange
         self.useNewScope = useNewScope
+        
+        self.store = Store(
+            initialState: initialState,
+            reducer: reducer,
+            useNewScope: useNewScope
+        )
     }
     
     internal init(

--- a/Tests/RxComposableArchitectureTests/StoreOldScopeTest.swift
+++ b/Tests/RxComposableArchitectureTests/StoreOldScopeTest.swift
@@ -1,18 +1,20 @@
+//
+//  StoreOldScopeTest.swift
+//  
+//
+//  Created by andhika.setiadi on 14/11/22.
+//
+
 import RxSwift
 import XCTest
 
 @testable import RxComposableArchitecture
 
-@MainActor
-internal final class StoreTests: XCTestCase {
+internal final class StoreOldScopeTest: XCTestCase {
     private let disposeBag = DisposeBag()
     
     internal func testCancellableIsRemovedOnImmediatelyCompletingEffect() {
-        let store = Store(
-            initialState: (),
-            reducer: EmptyReducer<Void, Void>(),
-            useNewScope: true
-        )
+        let store = Store(initialState: (), reducer: EmptyReducer<Void, Void>())
         
         XCTAssertEqual(store.effectDisposables.count, 0)
         
@@ -38,11 +40,7 @@ internal final class StoreTests: XCTestCase {
             }
         })
         
-        let store = Store(
-            initialState: (),
-            reducer: reducer,
-            useNewScope: true
-        )
+        let store = Store(initialState: (), reducer: reducer)
         
         XCTAssertEqual(store.effectDisposables.count, 0)
         
@@ -61,11 +59,7 @@ internal final class StoreTests: XCTestCase {
             return .none
         })
         
-        let parentStore = Store(
-            initialState: 0,
-            reducer: counterReducer,
-            useNewScope: true
-        )
+        let parentStore = Store(initialState: 0, reducer: counterReducer)
         let childStore = parentStore.scope(state: String.init)
         
         var values: [String] = []
@@ -86,11 +80,7 @@ internal final class StoreTests: XCTestCase {
             return .none
         })
         
-        let parentStore = Store(
-            initialState: 0,
-            reducer: counterReducer,
-            useNewScope: true
-        )
+        let parentStore = Store(initialState: 0, reducer: counterReducer)
         let childStore = parentStore.scope(state: String.init)
         
         var values: [Int] = []
@@ -113,13 +103,13 @@ internal final class StoreTests: XCTestCase {
         })
         
         var numCalls1 = 0
-        _ = Store(initialState: 0, reducer: counterReducer, useNewScope: true)
+        _ = Store(initialState: 0, reducer: counterReducer)
             .scope(state: { (count: Int) -> Int in
                 numCalls1 += 1
                 return count
             })
         
-        XCTAssertEqual(numCalls1, 1)
+        XCTAssertEqual(numCalls1, 2)
     }
     
     internal func testScopeCallCount2() {
@@ -132,7 +122,7 @@ internal final class StoreTests: XCTestCase {
         var numCalls2 = 0
         var numCalls3 = 0
         
-        let store = Store(initialState: 0, reducer: counterReducer, useNewScope: true)
+        let store = Store(initialState: 0, reducer: counterReducer)
             .scope(state: { (count: Int) -> Int in
                 numCalls1 += 1
                 return count
@@ -146,30 +136,30 @@ internal final class StoreTests: XCTestCase {
                 return count
             })
         
-        XCTAssertEqual(numCalls1, 1)
-        XCTAssertEqual(numCalls2, 1)
-        XCTAssertEqual(numCalls3, 1)
-        
-        _ = store.send(())
-        
         XCTAssertEqual(numCalls1, 2)
         XCTAssertEqual(numCalls2, 2)
         XCTAssertEqual(numCalls3, 2)
         
         _ = store.send(())
         
-        XCTAssertEqual(numCalls1, 3)
-        XCTAssertEqual(numCalls2, 3)
-        XCTAssertEqual(numCalls3, 3)
+        XCTAssertEqual(numCalls1, 4)
+        XCTAssertEqual(numCalls2, 5)
+        XCTAssertEqual(numCalls3, 6)
         
         _ = store.send(())
         
-        XCTAssertEqual(numCalls1, 4)
-        XCTAssertEqual(numCalls2, 4)
-        XCTAssertEqual(numCalls3, 4)
+        XCTAssertEqual(numCalls1, 6)
+        XCTAssertEqual(numCalls2, 8)
+        XCTAssertEqual(numCalls3, 10)
+        
+        _ = store.send(())
+        
+        XCTAssertEqual(numCalls1, 8)
+        XCTAssertEqual(numCalls2, 11)
+        XCTAssertEqual(numCalls3, 14)
     }
     
-    internal func testScopeAtIndexCallCount2UseNewScope() {
+    internal func testScopeAtIndexCallCount2() {
         struct Item: HashDiffable, Equatable {
             var id: Int
             var qty: Int
@@ -195,7 +185,7 @@ internal final class StoreTests: XCTestCase {
             Item(id: $0, qty: 1)
         }
         
-        let store = Store(initialState: IdentifiedArrayOf(mock), reducer: itemReducer, useNewScope: true)
+        let store = Store(initialState: IdentifiedArrayOf(mock), reducer: itemReducer)
             .scope(state: { (item: IdentifiedArrayOf<Item>) -> IdentifiedArrayOf<Item> in
                 numCalls1 += 1
                 return item
@@ -207,13 +197,13 @@ internal final class StoreTests: XCTestCase {
             })
         
         _ = store.send((1, .didTap))
-        XCTAssertEqual(numCalls1, 2)
-        XCTAssertEqual(numCalls2, 2)
+        XCTAssertEqual(numCalls1, 4)
+        XCTAssertEqual(numCalls2, 4)
         XCTAssertEqual(store.state.qty, 2)
         
         _ = store.send((1, .didTap))
-        XCTAssertEqual(numCalls1, 3)
-        XCTAssertEqual(numCalls2, 3)
+        XCTAssertEqual(numCalls1, 6)
+        XCTAssertEqual(numCalls2, 6)
         XCTAssertEqual(store.state.qty, 3)
     }
     
@@ -245,11 +235,7 @@ internal final class StoreTests: XCTestCase {
             }
         })
         
-        let store = Store(
-            initialState: (),
-            reducer: counterReducer,
-            useNewScope: true
-        )
+        let store = Store(initialState: (), reducer: counterReducer)
         
         _ = store.send(.tap)
         
@@ -268,11 +254,7 @@ internal final class StoreTests: XCTestCase {
             }
         })
         
-        let store = Store(
-            initialState: 0,
-            reducer: reducer,
-            useNewScope: true
-        )
+        let store = Store(initialState: 0, reducer: reducer)
         _ = store.send(.incr)
         XCTAssertEqual(store.state, 10000)
     }
@@ -287,11 +269,7 @@ internal final class StoreTests: XCTestCase {
             return .none
         })
         
-        let parentStore = Store(
-            initialState: AppState(),
-            reducer: appReducer,
-            useNewScope: true
-        )
+        let parentStore = Store(initialState: AppState(), reducer: appReducer)
         
         // NB: This test needs to hold a strong reference to the emitted stores
         var outputs: [Int?] = []
@@ -343,8 +321,7 @@ internal final class StoreTests: XCTestCase {
                         .observeOn(MainScheduler.instance)
                         .eraseToEffect()
                 }
-            }),
-            useNewScope: true
+            })
         )
         
         parentStore.ifLet { childStore in
@@ -388,8 +365,7 @@ internal final class StoreTests: XCTestCase {
                     state += 1
                     return .none
                 }
-            }),
-            useNewScope: true
+            })
         )
         store.send(.initialize)
         store.send(.incrementTapped)
@@ -418,8 +394,7 @@ internal final class StoreTests: XCTestCase {
                     state = action
                     return .none
                 }
-            }),
-            useNewScope: true
+            })
         )
         
         var emissions: [Int] = []
@@ -431,18 +406,43 @@ internal final class StoreTests: XCTestCase {
         
         _ = store.send(0)
         
-        XCTAssertEqual(emissions, [0, 3])
+        XCTAssertEqual(emissions, [0, 1, 2, 3])
     }
     
     internal func testSyncEffectsFromEnvironment() {
-        /// Here we no need anymore to mock the environment
-        /// since we already provide on testValue
-        ///
-        let parentStore = Store(
-            initialState: CounterFeature.State(counter: 1),
-            reducer: CounterFeature(),
-            useNewScope: true
-        )
+        enum Action: Equatable {
+            // subscribes to a long living effect, potentially feeding data
+            // back into the store
+            case onAppear
+            
+            // Talks to the environment, eventually feeding data back into the store
+            case onUserAction
+            
+            // External event coming in from the environment, updating state
+            case externalAction
+        }
+        
+        struct Environment {
+            var externalEffects = PublishSubject<Action>()
+        }
+        
+        let counterReducer = Reducer<Int, Action, Environment> { state, action, env in
+            switch action {
+            case .onAppear:
+                return env.externalEffects.eraseToEffect()
+            case .onUserAction:
+                return .fireAndForget {
+                    // This would actually do something async in the environment
+                    // that feeds back eventually via the `externalEffectPublisher`
+                    // Here we send an action sync, which could e.g. happen for an error case, ..
+                    env.externalEffects.onNext(.externalAction)
+                }
+            case .externalAction:
+                state += 1
+            }
+            return .none
+        }
+        let parentStore = Store(initialState: 1, reducer: counterReducer, environment: Environment())
         
         // subscribes to a long living publisher of actions
         _ = parentStore.send(.onAppear)
@@ -450,7 +450,7 @@ internal final class StoreTests: XCTestCase {
         _ = parentStore.send(.onUserAction)
         
         // State should be at 2 now
-        XCTAssertEqual(parentStore.state.counter, 2)
+        XCTAssertEqual(parentStore.state, 2)
     }
     
     internal func testBufferedActionProcessing() {
@@ -515,137 +515,4 @@ internal final class StoreTests: XCTestCase {
             .child(2),
           ])
       }
-    
-    internal func testCascadingTaskCancellation() async {
-        enum Action { case task, response, response1, response2 }
-
-        let reducer = Reduce<Int, Action>({ state, action in
-            switch action {
-            case .task:
-                return .task { .response }
-            case .response:
-                return .merge(
-                    Observable<Action>.never().eraseToEffect(),
-                    .task { .response1 }
-                )
-            case .response1:
-                return .merge(
-                    Observable<Action>.never().eraseToEffect(),
-                    .task { .response2 }
-                )
-            case .response2:
-                return Observable<Action>.never().eraseToEffect()
-            }
-        })
-
-        let store = TestStore(
-            initialState: 0,
-            reducer: reducer,
-            useNewScope: true
-        )
-
-        let task = await store.send(Action.task)
-        await store.receive(Action.response)
-        await store.receive(Action.response1)
-        await store.receive(Action.response2)
-        await task.cancel()
-    }
-    
-    internal func testTaskCancellationEmpty() async {
-        enum Action { case task }
-        
-        let store = TestStore(
-            initialState: 0,
-            reducer: Reduce<Int, Action>({ state, action in
-                switch action {
-                case .task:
-                    return .fireAndForget { try await Task.never() }
-                }
-            }),
-            useNewScope: true
-        )
-        
-        await store.send(.task).cancel()
-    }
-    
-    internal func testScopeCancellation() async throws {
-        let neverEndingTask = Task<Void, Error> { try await Task.never() }
-
-        let store = Store(
-          initialState: (),
-          reducer: Reduce<Void, Void>({ _, _ in
-            .fireAndForget {
-              try await neverEndingTask.value
-            }
-          }),
-          useNewScope: true
-        )
-        let scopedStore = store.scope(state: { $0 })
-
-        let sendTask = scopedStore.send(())
-        await Task.yield()
-        neverEndingTask.cancel()
-        try await XCTUnwrap(sendTask).value
-        XCTAssertEqual(store.effectDisposables.count, 0)
-        XCTAssertEqual(scopedStore.effectDisposables.count, 0)
-      }
 }
-
-/// we use CounterFeature reducer on this file test scope only
-///
-fileprivate struct CounterFeature: ReducerProtocol {
-    fileprivate struct State: Equatable {
-        internal var counter: Int
-    }
-    
-    fileprivate enum Action: Equatable {
-        // subscribes to a long living effect, potentially feeding data
-        // back into the store
-        case onAppear
-        
-        // Talks to the environment, eventually feeding data back into the store
-        case onUserAction
-        
-        // External event coming in from the environment, updating state
-        case externalAction
-    }
-    
-    @Dependency(\.counterEnv) private var env
-    
-    fileprivate func reduce(into state: inout State, action: Action) -> Effect<Action> {
-        switch action {
-        case .onAppear:
-            return env.externalEffects.eraseToEffect()
-        case .onUserAction:
-            return .fireAndForget {
-                // This would actually do something async in the environment
-                // that feeds back eventually via the `externalEffectPublisher`
-                // Here we send an action sync, which could e.g. happen for an error case, ..
-                env.externalEffects.onNext(.externalAction)
-            }
-        case .externalAction:
-            state.counter += 1
-        }
-        return .none
-    }
-}
-
-fileprivate struct CounterEnvironment {
-    fileprivate var externalEffects: PublishSubject<CounterFeature.Action>
-}
-
-extension CounterEnvironment {
-    fileprivate static let mock = Self(externalEffects: PublishSubject<CounterFeature.Action>())
-}
-
-extension CounterEnvironment: TestDependencyKey {
-    fileprivate static var testValue: CounterEnvironment { .mock }
-}
-
-extension DependencyValues {
-    fileprivate var counterEnv: CounterEnvironment {
-        get { self[CounterEnvironment.self] }
-        set { self[CounterEnvironment.self] = newValue }
-    }
-}
-

--- a/Tests/RxComposableArchitectureTests/StoreOldScopeTest.swift
+++ b/Tests/RxComposableArchitectureTests/StoreOldScopeTest.swift
@@ -10,11 +10,17 @@ import XCTest
 
 @testable import RxComposableArchitecture
 
+/// All Test cases in here using `useNewScope: false` on both Store(...) and TestStore(...)
+///
 internal final class StoreOldScopeTest: XCTestCase {
     private let disposeBag = DisposeBag()
     
     internal func testCancellableIsRemovedOnImmediatelyCompletingEffect() {
-        let store = Store(initialState: (), reducer: EmptyReducer<Void, Void>())
+        let store = Store(
+            initialState: (),
+            reducer: EmptyReducer<Void, Void>(),
+            useNewScope: false
+        )
         
         XCTAssertEqual(store.effectDisposables.count, 0)
         
@@ -40,7 +46,11 @@ internal final class StoreOldScopeTest: XCTestCase {
             }
         })
         
-        let store = Store(initialState: (), reducer: reducer)
+        let store = Store(
+            initialState: (),
+            reducer: reducer,
+            useNewScope: false
+        )
         
         XCTAssertEqual(store.effectDisposables.count, 0)
         
@@ -59,7 +69,11 @@ internal final class StoreOldScopeTest: XCTestCase {
             return .none
         })
         
-        let parentStore = Store(initialState: 0, reducer: counterReducer)
+        let parentStore = Store(
+            initialState: 0,
+            reducer: counterReducer,
+            useNewScope: false
+        )
         let childStore = parentStore.scope(state: String.init)
         
         var values: [String] = []
@@ -80,7 +94,11 @@ internal final class StoreOldScopeTest: XCTestCase {
             return .none
         })
         
-        let parentStore = Store(initialState: 0, reducer: counterReducer)
+        let parentStore = Store(
+            initialState: 0,
+            reducer: counterReducer,
+            useNewScope: false
+        )
         let childStore = parentStore.scope(state: String.init)
         
         var values: [Int] = []
@@ -103,7 +121,7 @@ internal final class StoreOldScopeTest: XCTestCase {
         })
         
         var numCalls1 = 0
-        _ = Store(initialState: 0, reducer: counterReducer)
+        _ = Store(initialState: 0, reducer: counterReducer, useNewScope: false)
             .scope(state: { (count: Int) -> Int in
                 numCalls1 += 1
                 return count
@@ -122,7 +140,7 @@ internal final class StoreOldScopeTest: XCTestCase {
         var numCalls2 = 0
         var numCalls3 = 0
         
-        let store = Store(initialState: 0, reducer: counterReducer)
+        let store = Store(initialState: 0, reducer: counterReducer, useNewScope: false)
             .scope(state: { (count: Int) -> Int in
                 numCalls1 += 1
                 return count
@@ -185,16 +203,20 @@ internal final class StoreOldScopeTest: XCTestCase {
             Item(id: $0, qty: 1)
         }
         
-        let store = Store(initialState: IdentifiedArrayOf(mock), reducer: itemReducer)
-            .scope(state: { (item: IdentifiedArrayOf<Item>) -> IdentifiedArrayOf<Item> in
-                numCalls1 += 1
-                return item
-            })
-            .scope(at: 1, action: Action.item)!
-            .scope(state: { (item: Item) -> Item in
-                numCalls2 += 1
-                return item
-            })
+        let store = Store(
+            initialState: IdentifiedArrayOf(mock),
+            reducer: itemReducer,
+            useNewScope: false
+        )
+        .scope(state: { (item: IdentifiedArrayOf<Item>) -> IdentifiedArrayOf<Item> in
+            numCalls1 += 1
+            return item
+        })
+        .scope(at: 1, action: Action.item)!
+        .scope(state: { (item: Item) -> Item in
+            numCalls2 += 1
+            return item
+        })
         
         _ = store.send((1, .didTap))
         XCTAssertEqual(numCalls1, 4)
@@ -235,7 +257,7 @@ internal final class StoreOldScopeTest: XCTestCase {
             }
         })
         
-        let store = Store(initialState: (), reducer: counterReducer)
+        let store = Store(initialState: (), reducer: counterReducer, useNewScope: false)
         
         _ = store.send(.tap)
         
@@ -254,7 +276,7 @@ internal final class StoreOldScopeTest: XCTestCase {
             }
         })
         
-        let store = Store(initialState: 0, reducer: reducer)
+        let store = Store(initialState: 0, reducer: reducer, useNewScope: false)
         _ = store.send(.incr)
         XCTAssertEqual(store.state, 10000)
     }
@@ -269,7 +291,11 @@ internal final class StoreOldScopeTest: XCTestCase {
             return .none
         })
         
-        let parentStore = Store(initialState: AppState(), reducer: appReducer)
+        let parentStore = Store(
+            initialState: AppState(),
+            reducer: appReducer,
+            useNewScope: false
+        )
         
         // NB: This test needs to hold a strong reference to the emitted stores
         var outputs: [Int?] = []
@@ -321,7 +347,8 @@ internal final class StoreOldScopeTest: XCTestCase {
                         .observeOn(MainScheduler.instance)
                         .eraseToEffect()
                 }
-            })
+            }),
+            useNewScope: false
         )
         
         parentStore.ifLet { childStore in
@@ -394,7 +421,8 @@ internal final class StoreOldScopeTest: XCTestCase {
                     state = action
                     return .none
                 }
-            })
+            }),
+            useNewScope: false
         )
         
         var emissions: [Int] = []
@@ -442,7 +470,12 @@ internal final class StoreOldScopeTest: XCTestCase {
             }
             return .none
         }
-        let parentStore = Store(initialState: 1, reducer: counterReducer, environment: Environment())
+        let parentStore = Store(
+            initialState: 1,
+            reducer: counterReducer,
+            environment: Environment(),
+            useNewScope: false
+        )
         
         // subscribes to a long living publisher of actions
         _ = parentStore.send(.onAppear)
@@ -491,7 +524,8 @@ internal final class StoreOldScopeTest: XCTestCase {
 
         let parentStore = Store(
           initialState: ParentState(),
-          reducer: parentReducer
+          reducer: parentReducer,
+          useNewScope: false
         )
 
         parentStore

--- a/Tests/RxComposableArchitectureTests/StoreTests.swift
+++ b/Tests/RxComposableArchitectureTests/StoreTests.swift
@@ -1,6 +1,5 @@
 import RxSwift
 import XCTest
-import Combine
 
 @testable import RxComposableArchitecture
 

--- a/Tests/RxComposableArchitectureTests/StoreTests.swift
+++ b/Tests/RxComposableArchitectureTests/StoreTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 @testable import RxComposableArchitecture
 
+/// All Test cases in here using `useNewScope: true` on both Store(...) and TestStore(...)
+///
 @MainActor
 internal final class StoreTests: XCTestCase {
     private let disposeBag = DisposeBag()
@@ -10,8 +12,7 @@ internal final class StoreTests: XCTestCase {
     internal func testCancellableIsRemovedOnImmediatelyCompletingEffect() {
         let store = Store(
             initialState: (),
-            reducer: EmptyReducer<Void, Void>(),
-            useNewScope: true
+            reducer: EmptyReducer<Void, Void>()
         )
         
         XCTAssertEqual(store.effectDisposables.count, 0)
@@ -40,8 +41,7 @@ internal final class StoreTests: XCTestCase {
         
         let store = Store(
             initialState: (),
-            reducer: reducer,
-            useNewScope: true
+            reducer: reducer
         )
         
         XCTAssertEqual(store.effectDisposables.count, 0)
@@ -63,8 +63,7 @@ internal final class StoreTests: XCTestCase {
         
         let parentStore = Store(
             initialState: 0,
-            reducer: counterReducer,
-            useNewScope: true
+            reducer: counterReducer
         )
         let childStore = parentStore.scope(state: String.init)
         
@@ -88,8 +87,7 @@ internal final class StoreTests: XCTestCase {
         
         let parentStore = Store(
             initialState: 0,
-            reducer: counterReducer,
-            useNewScope: true
+            reducer: counterReducer
         )
         let childStore = parentStore.scope(state: String.init)
         
@@ -113,7 +111,7 @@ internal final class StoreTests: XCTestCase {
         })
         
         var numCalls1 = 0
-        _ = Store(initialState: 0, reducer: counterReducer, useNewScope: true)
+        _ = Store(initialState: 0, reducer: counterReducer)
             .scope(state: { (count: Int) -> Int in
                 numCalls1 += 1
                 return count
@@ -132,7 +130,7 @@ internal final class StoreTests: XCTestCase {
         var numCalls2 = 0
         var numCalls3 = 0
         
-        let store = Store(initialState: 0, reducer: counterReducer, useNewScope: true)
+        let store = Store(initialState: 0, reducer: counterReducer)
             .scope(state: { (count: Int) -> Int in
                 numCalls1 += 1
                 return count
@@ -195,7 +193,7 @@ internal final class StoreTests: XCTestCase {
             Item(id: $0, qty: 1)
         }
         
-        let store = Store(initialState: IdentifiedArrayOf(mock), reducer: itemReducer, useNewScope: true)
+        let store = Store(initialState: IdentifiedArrayOf(mock), reducer: itemReducer)
             .scope(state: { (item: IdentifiedArrayOf<Item>) -> IdentifiedArrayOf<Item> in
                 numCalls1 += 1
                 return item
@@ -247,8 +245,7 @@ internal final class StoreTests: XCTestCase {
         
         let store = Store(
             initialState: (),
-            reducer: counterReducer,
-            useNewScope: true
+            reducer: counterReducer
         )
         
         _ = store.send(.tap)
@@ -270,8 +267,7 @@ internal final class StoreTests: XCTestCase {
         
         let store = Store(
             initialState: 0,
-            reducer: reducer,
-            useNewScope: true
+            reducer: reducer
         )
         _ = store.send(.incr)
         XCTAssertEqual(store.state, 10000)
@@ -289,8 +285,7 @@ internal final class StoreTests: XCTestCase {
         
         let parentStore = Store(
             initialState: AppState(),
-            reducer: appReducer,
-            useNewScope: true
+            reducer: appReducer
         )
         
         // NB: This test needs to hold a strong reference to the emitted stores
@@ -343,8 +338,7 @@ internal final class StoreTests: XCTestCase {
                         .observeOn(MainScheduler.instance)
                         .eraseToEffect()
                 }
-            }),
-            useNewScope: true
+            })
         )
         
         parentStore.ifLet { childStore in
@@ -418,8 +412,7 @@ internal final class StoreTests: XCTestCase {
                     state = action
                     return .none
                 }
-            }),
-            useNewScope: true
+            })
         )
         
         var emissions: [Int] = []
@@ -440,8 +433,7 @@ internal final class StoreTests: XCTestCase {
         ///
         let parentStore = Store(
             initialState: CounterFeature.State(counter: 1),
-            reducer: CounterFeature(),
-            useNewScope: true
+            reducer: CounterFeature()
         )
         
         // subscribes to a long living publisher of actions
@@ -577,8 +569,7 @@ internal final class StoreTests: XCTestCase {
             .fireAndForget {
               try await neverEndingTask.value
             }
-          }),
-          useNewScope: true
+          })
         )
         let scopedStore = store.scope(state: { $0 })
 

--- a/Tests/RxComposableArchitectureTests/TestStoreOldScopeTests.swift
+++ b/Tests/RxComposableArchitectureTests/TestStoreOldScopeTests.swift
@@ -10,6 +10,8 @@ import XCTest
 
 @testable import RxComposableArchitecture
 
+/// All Test cases in here using `useNewScope: false` on both Store(...) and TestStore(...)
+///
 internal class TestStoreOldScopeTests: XCTestCase {
     private let disposeBag = DisposeBag()
     
@@ -56,8 +58,7 @@ internal class TestStoreOldScopeTests: XCTestCase {
         
         let store = TestStore(
             initialState: State(),
-            reducer: reducer,
-            useNewScope: false
+            reducer: reducer
         )
         
         _ = store.send(Action.a)
@@ -103,8 +104,7 @@ internal class TestStoreOldScopeTests: XCTestCase {
             
             let store = TestStore(
                 initialState: State(),
-                reducer: reducer,
-                useNewScope: false
+                reducer: reducer
             )
             
             store.send(.increment) {
@@ -149,8 +149,7 @@ internal class TestStoreOldScopeTests: XCTestCase {
             
             let store = TestStore(
                 initialState: State(),
-                reducer: reducer,
-                useNewScope: false
+                reducer: reducer
             )
             
             store.send(.noop)
@@ -184,8 +183,7 @@ internal class TestStoreOldScopeTests: XCTestCase {
                     count += 1
                     return .none
                 }
-            }),
-            useNewScope: false
+            })
         )
         
         store.send(.a) {

--- a/Tests/RxComposableArchitectureTests/TestStoreOldScopeTests.swift
+++ b/Tests/RxComposableArchitectureTests/TestStoreOldScopeTests.swift
@@ -1,8 +1,8 @@
 //
-//  File.swift
+//  TestStoreOldScopeTests.swift
 //  
 //
-//  Created by andhika.setiadi on 13/11/22.
+//  Created by andhika.setiadi on 14/11/22.
 //
 
 import RxSwift
@@ -10,11 +10,10 @@ import XCTest
 
 @testable import RxComposableArchitecture
 
-@MainActor
-internal class TestStoreTests: XCTestCase {
+internal class TestStoreOldScopeTests: XCTestCase {
     private let disposeBag = DisposeBag()
     
-    internal func testEffectConcatenation() async {
+    internal func testEffectConcatenation() {
         struct CancelID: Hashable {}
         struct State: Equatable {}
         
@@ -58,52 +57,26 @@ internal class TestStoreTests: XCTestCase {
         let store = TestStore(
             initialState: State(),
             reducer: reducer,
-            useNewScope: true
+            useNewScope: false
         )
         
-        _ = await store.send(Action.a)
+        _ = store.send(Action.a)
         
         mainQueue.advance(by: .seconds(1))
         
-        await store.receive(Action.b1)
-        await store.receive(Action.b2)
-        await store.receive(Action.b3)
+        store.receive(Action.b1)
+        store.receive(Action.b2)
+        store.receive(Action.b3)
         
-        await store.receive(Action.c1)
-        await store.receive(Action.c2)
-        await store.receive(Action.c3)
+        store.receive(Action.c1)
+        store.receive(Action.c2)
+        store.receive(Action.c3)
         
-        _ = await store.send(Action.d)
-    }
-    
-    internal func testAsync() async {
-        enum Action: Equatable {
-            case tap
-            case response(Int)
-        }
-        
-        let store = TestStore(
-            initialState: 0,
-            reducer: Reduce<Int, Action>({ state, action in
-                switch action {
-                case .tap:
-                    return .task { .response(42) }
-                case let .response(number):
-                    state = number
-                    return .none
-                }
-            }),
-            useNewScope: true
-        )
-        
-        _ = await store.send(.tap)
-        await store.receive(.response(42)) {
-            $0 = 42
-        }
+        _ = store.send(Action.d)
     }
     
     #if DEBUG
-        internal func testExpectedStateEquality() async {
+        internal func testExpectedStateEquality() {
             struct State: Equatable {
                 var count: Int = 0
                 var isChanging: Bool = false
@@ -131,14 +104,14 @@ internal class TestStoreTests: XCTestCase {
             let store = TestStore(
                 initialState: State(),
                 reducer: reducer,
-                useNewScope: true
+                useNewScope: false
             )
             
-            _ = await store.send(.increment) {
+            store.send(.increment) {
                 $0.isChanging = true
             }
             
-            await store.receive(.changed(from: 0, to: 1)) {
+            store.receive(.changed(from: 0, to: 1)) {
                 $0.isChanging = false
                 $0.count = 1
             }
@@ -156,7 +129,7 @@ internal class TestStoreTests: XCTestCase {
             }
         }
     
-        internal func testExpectedStateEqualityMustModify() async {
+        internal func testExpectedStateEqualityMustModify() {
             struct State: Equatable {
                 var count: Int = 0
             }
@@ -177,11 +150,11 @@ internal class TestStoreTests: XCTestCase {
             let store = TestStore(
                 initialState: State(),
                 reducer: reducer,
-                useNewScope: true
+                useNewScope: false
             )
             
-            _ = await store.send(.noop)
-            await store.receive(.finished)
+            store.send(.noop)
+            store.receive(.finished)
             
             XCTExpectFailure {
                 _ = store.send(.noop) {
@@ -197,7 +170,7 @@ internal class TestStoreTests: XCTestCase {
         }
     #endif
     
-    internal func testStateAccess() async {
+    internal func testStateAccess() {
         enum Action { case a, b, c, d }
         
         let store = TestStore(
@@ -212,28 +185,28 @@ internal class TestStoreTests: XCTestCase {
                     return .none
                 }
             }),
-            useNewScope: true
+            useNewScope: false
         )
         
-        _ = await store.send(.a) {
+        store.send(.a) {
             $0 = 1
             XCTAssertEqual(store.state, 0)
         }
         XCTAssertEqual(store.state, 1)
         
-        await store.receive(.b) {
+        store.receive(.b) {
             $0 = 2
             XCTAssertEqual(store.state, 1)
         }
         XCTAssertEqual(store.state, 2)
         
-        await store.receive(.c) {
+        store.receive(.c) {
             $0 = 3
             XCTAssertEqual(store.state, 2)
         }
         XCTAssertEqual(store.state, 3)
         
-        await store.receive(.d) {
+        store.receive(.d) {
             $0 = 4
             XCTAssertEqual(store.state, 3)
         }
@@ -241,3 +214,4 @@ internal class TestStoreTests: XCTestCase {
         XCTAssertEqual(store.state, 4)
     }
 }
+

--- a/Tests/RxComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/RxComposableArchitectureTests/TestStoreTests.swift
@@ -35,10 +35,8 @@ internal class TestStoreTests: XCTestCase {
                     .delay(.seconds(1), scheduler: mainQueue)
                     .eraseToEffect(),
                     
-                    /// this effect to mimic Never Publisher `Empty(completeImmediately: false)`
-                    Observable<Int>.interval(.seconds(1), scheduler: mainQueue)
-                        .map { _ in Observable<Int>.empty() }
-                        .fireAndForget()
+                    Observable<Action>.never()
+                        .eraseToEffect()
                         .cancellable(id: CancelID())
                 )
             case .b1:
@@ -60,8 +58,7 @@ internal class TestStoreTests: XCTestCase {
         let store = TestStore(
             initialState: State(),
             reducer: reducer,
-            failingWhenNothingChange: true,
-            useNewScope: true
+            useNewScope: false
         )
         
         _ = store.send(Action.a)
@@ -77,6 +74,68 @@ internal class TestStoreTests: XCTestCase {
         store.receive(Action.c3)
         
         _ = store.send(Action.d)
+    }
+    
+    internal func testEffectConcatenation_usingNewScope() async {
+        struct CancelID: Hashable {}
+        struct State: Equatable {}
+        
+        enum Action: Equatable {
+            case a, b1, b2, b3, c1, c2, c3, d
+        }
+        
+        let mainQueue = TestScheduler(initialClock: 0)
+        
+        let reducer = Reduce<State, Action>({ _, action in
+            switch action {
+            case .a:
+                return .merge(
+                    Effect.concatenate(
+                        .init(value: .b1),
+                        .init(value: .c1)
+                    )
+                    .delay(.seconds(1), scheduler: mainQueue)
+                    .eraseToEffect(),
+                    
+                    Observable<Action>.never()
+                        .eraseToEffect()
+                        .cancellable(id: CancelID())
+                )
+            case .b1:
+                return Effect.concatenate(.init(value: .b2), .init(value: .b3))
+            case .c1:
+                return Effect
+                    .concatenate(
+                        .init(value: .c2),
+                        .init(value: .c3)
+                    )
+            case .b2, .b3, .c2, .c3:
+                return .none
+                
+            case .d:
+                return .cancel(id: CancelID())
+            }
+        })
+        
+        let store = TestStore(
+            initialState: State(),
+            reducer: reducer,
+            useNewScope: true
+        )
+        
+        _ = await store.send(Action.a)
+        
+        mainQueue.advance(by: .seconds(1))
+        
+        await store.receive(Action.b1)
+        await store.receive(Action.b2)
+        await store.receive(Action.b3)
+        
+        await store.receive(Action.c1)
+        await store.receive(Action.c2)
+        await store.receive(Action.c3)
+        
+        _ = await store.send(Action.d)
     }
     
     internal func testAsync() async {
@@ -96,50 +155,11 @@ internal class TestStoreTests: XCTestCase {
                     return .none
                 }
             }),
-            failingWhenNothingChange: true,
             useNewScope: true
         )
         
-        await store.send(.tap)
+        _ = await store.send(.tap)
         await store.receive(.response(42)) {
-            $0 = 42
-        }
-    }
-    
-    /// TODO: Choose one, the real func is testAsync
-    internal func testAsync2() {
-        enum Action: Equatable {
-            case tap
-            case response(Int)
-        }
-        
-        let scheduler = TestScheduler(initialClock: 0)
-        
-        let store = TestStore(
-            initialState: 0,
-            reducer: Reduce<Int, Action>({ state, action in
-                switch action {
-                case .tap:
-                    /// TODO: Need to check if this one is equivalent to .task { ... } usage
-                    return Observable<Int>.just(42)
-                        .map { newNumber -> Action in Action.response(newNumber) }
-                        .delay(.milliseconds(500), scheduler: scheduler)
-                        .eraseToEffect()
-                    
-                case let .response(number):
-                    state = number
-                    return .none
-                }
-            }),
-            failingWhenNothingChange: true,
-            useNewScope: true
-        )
-        
-        store.send(.tap)
-        
-        scheduler.advance(by: .milliseconds(500))
-        
-        store.receive(.response(42)) {
             $0 = 42
         }
     }
@@ -173,8 +193,7 @@ internal class TestStoreTests: XCTestCase {
             let store = TestStore(
                 initialState: State(),
                 reducer: reducer,
-                failingWhenNothingChange: true,
-                useNewScope: true
+                useNewScope: false
             )
             
             store.send(.increment) {
@@ -182,6 +201,59 @@ internal class TestStoreTests: XCTestCase {
             }
             
             store.receive(.changed(from: 0, to: 1)) {
+                $0.isChanging = false
+                $0.count = 1
+            }
+            
+            XCTExpectFailure {
+                _ = store.send(.increment) {
+                    $0.isChanging = false
+                }
+            }
+            XCTExpectFailure {
+                store.receive(.changed(from: 1, to: 2)) {
+                    $0.isChanging = true
+                    $0.count = 1100
+                }
+            }
+        }
+    
+        internal func testExpectedStateEquality_usingNewScope() async {
+            struct State: Equatable {
+                var count: Int = 0
+                var isChanging: Bool = false
+            }
+            
+            enum Action: Equatable {
+                case increment
+                case changed(from: Int, to: Int)
+            }
+            
+            let reducer = Reduce<State, Action>({ state, action in
+                switch action {
+                case .increment:
+                    state.isChanging = true
+                    return Effect(value: .changed(from: state.count, to: state.count + 1))
+                case .changed(let from, let to):
+                    state.isChanging = false
+                    if state.count == from {
+                        state.count = to
+                    }
+                    return .none
+                }
+            })
+            
+            let store = TestStore(
+                initialState: State(),
+                reducer: reducer,
+                useNewScope: true
+            )
+            
+            _ = await store.send(.increment) {
+                $0.isChanging = true
+            }
+            
+            await store.receive(.changed(from: 0, to: 1)) {
                 $0.isChanging = false
                 $0.count = 1
             }
@@ -220,15 +292,54 @@ internal class TestStoreTests: XCTestCase {
             let store = TestStore(
                 initialState: State(),
                 reducer: reducer,
-                failingWhenNothingChange: true,
-                useNewScope: true
+                useNewScope: false
             )
             
             store.send(.noop)
             store.receive(.finished)
             
             XCTExpectFailure {
-                store.send(.noop) {
+                _ = store.send(.noop) {
+                    $0.count = 0
+                }
+            }
+            
+            XCTExpectFailure {
+                store.receive(.finished) {
+                    $0.count = 0
+                }
+            }
+        }
+    
+        internal func testExpectedStateEqualityMustModify() async {
+            struct State: Equatable {
+                var count: Int = 0
+            }
+            
+            enum Action: Equatable {
+                case noop, finished
+            }
+            
+            let reducer = Reduce<State, Action>({ state, action in
+                switch action {
+                case .noop:
+                    return Effect(value: .finished)
+                case .finished:
+                    return .none
+                }
+            })
+            
+            let store = TestStore(
+                initialState: State(),
+                reducer: reducer,
+                useNewScope: true
+            )
+            
+            _ = await store.send(.noop)
+            await store.receive(.finished)
+            
+            XCTExpectFailure {
+                _ = store.send(.noop) {
                     $0.count = 0
                 }
             }
@@ -256,8 +367,7 @@ internal class TestStoreTests: XCTestCase {
                     return .none
                 }
             }),
-            failingWhenNothingChange: true,
-            useNewScope: true
+            useNewScope: false
         )
         
         store.send(.a) {
@@ -279,6 +389,50 @@ internal class TestStoreTests: XCTestCase {
         XCTAssertEqual(store.state, 3)
         
         store.receive(.d) {
+            $0 = 4
+            XCTAssertEqual(store.state, 3)
+        }
+        
+        XCTAssertEqual(store.state, 4)
+    }
+    
+    internal func testStateAccess_useNewScope() async {
+        enum Action { case a, b, c, d }
+        
+        let store = TestStore(
+            initialState: 0,
+            reducer: Reduce<Int, Action>({ count, action in
+                switch action {
+                case .a:
+                    count += 1
+                    return .merge(.init(value: .b), .init(value: .c), .init(value: .d))
+                case .b, .c, .d:
+                    count += 1
+                    return .none
+                }
+            }),
+            useNewScope: true
+        )
+        
+        _ = await store.send(.a) {
+            $0 = 1
+            XCTAssertEqual(store.state, 0)
+        }
+        XCTAssertEqual(store.state, 1)
+        
+        await store.receive(.b) {
+            $0 = 2
+            XCTAssertEqual(store.state, 1)
+        }
+        XCTAssertEqual(store.state, 2)
+        
+        await store.receive(.c) {
+            $0 = 3
+            XCTAssertEqual(store.state, 2)
+        }
+        XCTAssertEqual(store.state, 3)
+        
+        await store.receive(.d) {
             $0 = 4
             XCTAssertEqual(store.state, 3)
         }

--- a/Tests/RxComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/RxComposableArchitectureTests/TestStoreTests.swift
@@ -1,0 +1,288 @@
+//
+//  File.swift
+//  
+//
+//  Created by andhika.setiadi on 13/11/22.
+//
+
+import RxSwift
+import XCTest
+
+@testable import RxComposableArchitecture
+
+@MainActor
+internal class TestStoreTests: XCTestCase {
+    private let disposeBag = DisposeBag()
+    
+    internal func testEffectConcatenation() {
+        struct CancelID: Hashable {}
+        struct State: Equatable {}
+        
+        enum Action: Equatable {
+            case a, b1, b2, b3, c1, c2, c3, d
+        }
+        
+        let mainQueue = TestScheduler(initialClock: 0)
+        
+        let reducer = Reduce<State, Action>({ _, action in
+            switch action {
+            case .a:
+                return .merge(
+                    Effect.concatenate(
+                        .init(value: .b1),
+                        .init(value: .c1)
+                    )
+                    .delay(.seconds(1), scheduler: mainQueue)
+                    .eraseToEffect(),
+                    
+                    /// this effect to mimic Never Publisher `Empty(completeImmediately: false)`
+                    Observable<Int>.interval(.seconds(1), scheduler: mainQueue)
+                        .map { _ in Observable<Int>.empty() }
+                        .fireAndForget()
+                        .cancellable(id: CancelID())
+                )
+            case .b1:
+                return Effect.concatenate(.init(value: .b2), .init(value: .b3))
+            case .c1:
+                return Effect
+                    .concatenate(
+                        .init(value: .c2),
+                        .init(value: .c3)
+                    )
+            case .b2, .b3, .c2, .c3:
+                return .none
+                
+            case .d:
+                return .cancel(id: CancelID())
+            }
+        })
+        
+        let store = TestStore(
+            initialState: State(),
+            reducer: reducer,
+            failingWhenNothingChange: true,
+            useNewScope: true
+        )
+        
+        _ = store.send(Action.a)
+        
+        mainQueue.advance(by: .seconds(1))
+        
+        store.receive(Action.b1)
+        store.receive(Action.b2)
+        store.receive(Action.b3)
+        
+        store.receive(Action.c1)
+        store.receive(Action.c2)
+        store.receive(Action.c3)
+        
+        _ = store.send(Action.d)
+    }
+    
+    internal func testAsync() async {
+        enum Action: Equatable {
+            case tap
+            case response(Int)
+        }
+        
+        let store = TestStore(
+            initialState: 0,
+            reducer: Reduce<Int, Action>({ state, action in
+                switch action {
+                case .tap:
+                    return .task { .response(42) }
+                case let .response(number):
+                    state = number
+                    return .none
+                }
+            }),
+            failingWhenNothingChange: true,
+            useNewScope: true
+        )
+        
+        await store.send(.tap)
+        await store.receive(.response(42)) {
+            $0 = 42
+        }
+    }
+    
+    /// TODO: Choose one, the real func is testAsync
+    internal func testAsync2() {
+        enum Action: Equatable {
+            case tap
+            case response(Int)
+        }
+        
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let store = TestStore(
+            initialState: 0,
+            reducer: Reduce<Int, Action>({ state, action in
+                switch action {
+                case .tap:
+                    /// TODO: Need to check if this one is equivalent to .task { ... } usage
+                    return Observable<Int>.just(42)
+                        .map { newNumber -> Action in Action.response(newNumber) }
+                        .delay(.milliseconds(500), scheduler: scheduler)
+                        .eraseToEffect()
+                    
+                case let .response(number):
+                    state = number
+                    return .none
+                }
+            }),
+            failingWhenNothingChange: true,
+            useNewScope: true
+        )
+        
+        store.send(.tap)
+        
+        scheduler.advance(by: .milliseconds(500))
+        
+        store.receive(.response(42)) {
+            $0 = 42
+        }
+    }
+    
+    #if DEBUG
+        internal func testExpectedStateEquality() {
+            struct State: Equatable {
+                var count: Int = 0
+                var isChanging: Bool = false
+            }
+            
+            enum Action: Equatable {
+                case increment
+                case changed(from: Int, to: Int)
+            }
+            
+            let reducer = Reduce<State, Action>({ state, action in
+                switch action {
+                case .increment:
+                    state.isChanging = true
+                    return Effect(value: .changed(from: state.count, to: state.count + 1))
+                case .changed(let from, let to):
+                    state.isChanging = false
+                    if state.count == from {
+                        state.count = to
+                    }
+                    return .none
+                }
+            })
+            
+            let store = TestStore(
+                initialState: State(),
+                reducer: reducer,
+                failingWhenNothingChange: true,
+                useNewScope: true
+            )
+            
+            store.send(.increment) {
+                $0.isChanging = true
+            }
+            
+            store.receive(.changed(from: 0, to: 1)) {
+                $0.isChanging = false
+                $0.count = 1
+            }
+            
+            XCTExpectFailure {
+                _ = store.send(.increment) {
+                    $0.isChanging = false
+                }
+            }
+            XCTExpectFailure {
+                store.receive(.changed(from: 1, to: 2)) {
+                    $0.isChanging = true
+                    $0.count = 1100
+                }
+            }
+        }
+        
+        internal func testExpectedStateEqualityMustModify() {
+            struct State: Equatable {
+                var count: Int = 0
+            }
+            
+            enum Action: Equatable {
+                case noop, finished
+            }
+            
+            let reducer = Reduce<State, Action>({ state, action in
+                switch action {
+                case .noop:
+                    return Effect(value: .finished)
+                case .finished:
+                    return .none
+                }
+            })
+            
+            let store = TestStore(
+                initialState: State(),
+                reducer: reducer,
+                failingWhenNothingChange: true,
+                useNewScope: true
+            )
+            
+            store.send(.noop)
+            store.receive(.finished)
+            
+            XCTExpectFailure {
+                store.send(.noop) {
+                    $0.count = 0
+                }
+            }
+            
+            XCTExpectFailure {
+                store.receive(.finished) {
+                    $0.count = 0
+                }
+            }
+        }
+    #endif
+    
+    internal func testStateAccess() {
+        enum Action { case a, b, c, d }
+        
+        let store = TestStore(
+            initialState: 0,
+            reducer: Reduce<Int, Action>({ count, action in
+                switch action {
+                case .a:
+                    count += 1
+                    return .merge(.init(value: .b), .init(value: .c), .init(value: .d))
+                case .b, .c, .d:
+                    count += 1
+                    return .none
+                }
+            }),
+            failingWhenNothingChange: true,
+            useNewScope: true
+        )
+        
+        store.send(.a) {
+            $0 = 1
+            XCTAssertEqual(store.state, 0)
+        }
+        XCTAssertEqual(store.state, 1)
+        
+        store.receive(.b) {
+            $0 = 2
+            XCTAssertEqual(store.state, 1)
+        }
+        XCTAssertEqual(store.state, 2)
+        
+        store.receive(.c) {
+            $0 = 3
+            XCTAssertEqual(store.state, 2)
+        }
+        XCTAssertEqual(store.state, 3)
+        
+        store.receive(.d) {
+            $0 = 4
+            XCTAssertEqual(store.state, 3)
+        }
+        
+        XCTAssertEqual(store.state, 4)
+    }
+}

--- a/Tests/RxComposableArchitectureTests/TestStoreTests.swift
+++ b/Tests/RxComposableArchitectureTests/TestStoreTests.swift
@@ -10,6 +10,8 @@ import XCTest
 
 @testable import RxComposableArchitecture
 
+/// All Test cases in here using `useNewScope: true` on both Store(...) and TestStore(...)
+///
 @MainActor
 internal class TestStoreTests: XCTestCase {
     private let disposeBag = DisposeBag()


### PR DESCRIPTION
Changes:
- Update test cases using new reducer protocol implementation
- Fix Async await action test can't be cancelled
- Add more test case for `StoreTests` & `TestStoreTests`
- update `failingWhenNothingChanges` flag to `true` on new TestStore code
- Separate the `StoreTests` & `TestStoreTests` into different files both for `useNewScope` value `true` and `false`