### PR TITLE
Update TestStore ordering

### DIFF
--- a/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
@@ -351,9 +351,9 @@ extension TestStore where State == LocalState, Action == LocalAction {
 extension TestStore where LocalState: Equatable {
     public func send(
         _ action: LocalAction,
+        _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
         file: StaticString = #file,
-        line: UInt = #line,
-        _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil
+        line: UInt = #line
     ) {
         if !receivedActions.isEmpty {
             var actions = ""
@@ -451,9 +451,9 @@ extension TestStore where LocalState: Equatable, Action: Equatable {
     ///     expected.
     public func receive(
         _ expectedAction: Action,
+        _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil,
         file: StaticString = #file,
-        line: UInt = #line,
-        _ updateExpectingResult: ((inout LocalState) throws -> Void)? = nil
+        line: UInt = #line
     ) {
         guard !receivedActions.isEmpty else {
             XCTFail(
@@ -525,9 +525,9 @@ extension TestStore where LocalState: Equatable, Action: Equatable {
         func assert(step: Step) {
             switch step.type {
             case let .send(action, update):
-                self.send(action, file: step.file, line: step.line, update)
+                self.send(action, update, file: step.file, line: step.line)
             case let .receive(expectedAction, update):
-                self.receive(expectedAction, file: step.file, line: step.line, update)
+                self.receive(expectedAction, update, file: step.file, line: step.line)
             case let .environment(work):
                 if !self.receivedActions.isEmpty {
                     var actions = ""

--- a/Tests/RxComposableArchitectureTests/StoreTests.swift
+++ b/Tests/RxComposableArchitectureTests/StoreTests.swift
@@ -95,7 +95,7 @@ internal final class StoreTests: XCTestCase {
         }
 
         var numCalls1 = 0
-        _ = Store(initialState: 0, reducer: counterReducer, environment: ())
+        _ = Store(initialState: 0, reducer: counterReducer, environment: (), useNewScope: false)
             .scope(state: { (count: Int) -> Int in
                 numCalls1 += 1
                 return count
@@ -129,7 +129,7 @@ internal final class StoreTests: XCTestCase {
         var numCalls2 = 0
         var numCalls3 = 0
 
-        let store = Store(initialState: 0, reducer: counterReducer, environment: ())
+        let store = Store(initialState: 0, reducer: counterReducer, environment: (), useNewScope: false)
             .scope(state: { (count: Int) -> Int in
                 numCalls1 += 1
                 return count
@@ -239,7 +239,7 @@ internal final class StoreTests: XCTestCase {
             Item(id: $0, qty: 1)
         }
 
-        let store = Store(initialState: IdentifiedArrayOf(mock), reducer: itemReducer, environment: ())
+        let store = Store(initialState: IdentifiedArrayOf(mock), reducer: itemReducer, environment: (), useNewScope: false)
             .scope(state: { (item: IdentifiedArrayOf<Item>) -> IdentifiedArrayOf<Item> in
                 numCalls1 += 1
                 return item
@@ -500,7 +500,8 @@ internal final class StoreTests: XCTestCase {
                     return .none
                 }
             },
-            environment: ()
+            environment: (),
+            useNewScope: false
         )
         
         var emissions: [Int] = []


### PR DESCRIPTION
- Need to update TestStore ordering, so when we finally migrate to original TCA, won't create much tech debt.