### PR TITLE
[Reducer Protocol] - Support Bootstrap MockKit

### DIFF
--- a/Sources/RxComposableArchitecture/Dependencies/Dependency.swift
+++ b/Sources/RxComposableArchitecture/Dependencies/Dependency.swift
@@ -85,7 +85,11 @@ public struct Dependency<Value>: @unchecked Sendable {
             currentDependency.fileID = self.fileID
             currentDependency.line = self.line
             return DependencyValues.$currentDependency.withValue(currentDependency) {
-                DependencyValues._current[keyPath: self.keyPath]
+                /// To support our Bootstrap MockKit implementation
+                /// Here we tried first get the `Mocked Environment` from Bootstrap MockKit
+                /// and give fallback value to original our dependency injection when not get any mocked environment
+                ///
+                Bootstrap.get(environment: Value.self) ?? DependencyValues._current[keyPath: self.keyPath]
             }
         #else
             return DependencyValues._current[keyPath: self.keyPath]


### PR DESCRIPTION
Add support to environment mocking when using DependencyValues on Reducer Protocol Implementation