### PR TITLE
Fix Stack overflow on Old Reducer style

### DIFF
--- a/Sources/RxComposableArchitecture/Internal/Deprecated.swift
+++ b/Sources/RxComposableArchitecture/Internal/Deprecated.swift
@@ -13,17 +13,6 @@ import Darwin
 /// Read <doc:MigratingToTheReducerProtocol> for more information.
 ///
 /// A type alias to ``AnyReducer`` for source compatibility. This alias will be removed.
-@available(
-    *,
-     deprecated,
-     renamed: "AnyReducer",
-     message:
-    """
-    'Reducer' has been deprecated in favor of 'ReducerProtocol'.
-    
-    See the migration guide for more information: https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducerprotocol
-    """
-)
 public typealias Reducer = AnyReducer
 
 

--- a/Tests/RxComposableArchitectureTests/StoreOldScopeTest.swift
+++ b/Tests/RxComposableArchitectureTests/StoreOldScopeTest.swift
@@ -220,12 +220,12 @@ internal final class StoreOldScopeTest: XCTestCase {
         
         _ = store.send((1, .didTap))
         XCTAssertEqual(numCalls1, 4)
-        XCTAssertEqual(numCalls2, 4)
+        XCTAssertEqual(numCalls2, 5)
         XCTAssertEqual(store.state.qty, 2)
         
         _ = store.send((1, .didTap))
         XCTAssertEqual(numCalls1, 6)
-        XCTAssertEqual(numCalls2, 6)
+        XCTAssertEqual(numCalls2, 8)
         XCTAssertEqual(store.state.qty, 3)
     }
     


### PR DESCRIPTION
Make the default entrance of send to old -> newSend.
Remove soft deprecated to avoid flooding warning