### PR TITLE
Fixing Memory Leak on Scope Child Reducer

### DIFF
--- a/Sources/RxComposableArchitecture/Store.swift
+++ b/Sources/RxComposableArchitecture/Store.swift
@@ -856,7 +856,7 @@ extension ScopedReducer: AnyScopedReducer {
                 guard !reducer.isSending else { return }
                 childStore?.relay.accept(toRescopedState(newValue))
             })
-            .disposed(by: store.disposeBag)
+            .disposed(by: childStore.disposeBag)
         return childStore
     }
 }


### PR DESCRIPTION
We found that  our scoped reducer having memory leak issue when we tried to open simple example (you can tried on ScopingVC.swift) and pop the page, it will still having the scoped reducer reference in our app.

How:
We fixed the disposeBag reference to the `childStore` reference so when the scoped reducer is destroyed, it will also disposed the relay(our scope State stream) of the scoped reducer