### PR TITLE
[Bootstrap x Dependencies] - V1 Support Example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         xcode:
           - '13.4.1'
-          - '14.1'
+          - '14.3.1'
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
       matrix:
         xcode:
           - '13.4.1'
-          - '14.1'
+          - '14.3.1'
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3

--- a/Sources/RxComposableArchitecture/Debugging/Bootstrapping.swift
+++ b/Sources/RxComposableArchitecture/Debugging/Bootstrapping.swift
@@ -151,7 +151,7 @@ import Foundation
         /// }
         /// ```
         /// - Parameter for: the `Reducer` to be injected
-        /// - Parameter withMock: the closure for mocking reducer
+        /// - Parameter withMock: the closure for mocking reducer's dependencies
         public static func mock<Reducer>(
             for reducer: Reducer,
             _ withMock: @escaping (Reducer) -> _DependencyKeyWritingReducer<Reducer>

--- a/Sources/RxComposableArchitecture/Debugging/Bootstrapping.swift
+++ b/Sources/RxComposableArchitecture/Debugging/Bootstrapping.swift
@@ -120,15 +120,65 @@ import Foundation
         /// - Warning: this api only supposed to be used on `BootstrapPicker`
         internal static func clearAll() {
             _bootstrappedEnvironments.removeAll()
+            _bootstrappedDependencies.removeAll()
         }
 
         /// get all Bootstrapped identifier
         /// - Warning: this api only supposed to be used on `BootstrapPicker`
         /// - Returns: all active indentifier
         internal static func getAllBootstrappedIdentifier() -> [String] {
-            _bootstrappedEnvironments.map(\.key)
+            _bootstrappedEnvironments.map(\.key) + _bootstrappedDependencies.map(\.key)
+        }
+    }
+
+    /// for our `Dependencies` mocking functionality
+    ///
+    extension Bootstrap {
+        /// Inject your `Reducer` along with your custom `Dependencies`
+        ///
+        /// ## Example
+        ///
+        /// ```swift
+        /// let requestFail = Environment {
+        ///    request: {
+        ///       return Effect(value: .failure(.serverError))
+        ///    }
+        /// }
+        ///
+        /// Bootstrap.mock(for: FeatureA()) { currentReducer in
+        ///     currentReducer
+        ///         .dependency(\.featureAEnvironment, mockFailed)
+        /// }
+        /// ```
+        /// - Parameter for: the `Reducer` to be injected
+        /// - Parameter withMock: the closure for mocking reducer
+        public static func mock<Reducer>(
+            for reducer: Reducer,
+            _ withMock: @escaping (Reducer) -> _DependencyKeyWritingReducer<Reducer>
+        ) where Reducer: ReducerProtocol {
+            let reducerTypeString = String(reflecting: type(of: reducer))
+            let mockedReducer = withMock(reducer)
+            
+            _bootstrappedDependencies[reducerTypeString] = mockedReducer
+        }
+
+        /// Clear previous custom `Reducer` that injected with your custom `Dependencies`
+        ///
+        /// ## Example
+        ///
+        /// ```swift
+        /// Bootstrap.clear(for: FeatureA.self)
+        /// ```
+        ///
+        /// - Parameter keypath: the kaypath for our injected dependencies
+        public static func clear<Reducer>(
+            for reducer: Reducer.Type
+        ) where Reducer: ReducerProtocol {
+            let reducerTypeString = String(reflecting: reducer)
+            _bootstrappedDependencies.removeValue(forKey: reducerTypeString)
         }
     }
 
     internal var _bootstrappedEnvironments: [String: Any] = [:]
+    internal var _bootstrappedDependencies: [String: Any] = [:]
 #endif

--- a/Sources/RxComposableArchitecture/Store.swift
+++ b/Sources/RxComposableArchitecture/Store.swift
@@ -51,16 +51,22 @@ public final class Store<State, Action> {
             /// here we save our dependencies-bootstrap reducer
             /// the fallback value will be original reducer without any dependencies bootstrap
             ///
-            var currentReducer: any ReducerProtocol<R.State, R.Action> = reducer
             if let mockedReducer = _bootstrappedDependencies[reducerTypeString] as? _DependencyKeyWritingReducer<R> {
-                currentReducer = mockedReducer
+                #if swift(>=5.7)
+                    self.reducer = mockedReducer
+                #else
+                    self.reducer = mockedReducer.reduce
+                #endif
+            } else {
+                /// means we didn't find any bootstrap dependecies for this reducer
+                /// return the original ones
+                ///
+                #if swift(>=5.7)
+                    self.reducer = reducer
+                #else
+                    self.reducer = reducer.reduce
+                #endif
             }
-            
-            #if swift(>=5.7)
-                self.reducer = currentReducer
-            #else
-                self.reducer = currentReducer.reduce
-            #endif
         #else
             /// means on non-debug mode
             /// we not applied any bootstrap dependencies

--- a/Tests/RxComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/RxComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -362,7 +362,7 @@ final class TestStoreNonExhaustiveTests: XCTestCase {
             $0.compactDescription == """
             A state change does not match expectation: …
 
-                  TestStoreNonExhaustiveTests.State(
+                  TestStoreNonExhaustiveTests.Feature.State(
                 −   count: 2,
                 +   count: 1,
                     isLoggedIn: true


### PR DESCRIPTION
Adding V1 Support for Example mocking using Bootstrap

usage:

```
/// 📝 Call Bootstrap in here applied any mocking on closure
///
Bootstrap.mock(for: EnvironmentFeature()) { currentReducer in

    /// 📝 here we can mock our reducer with your mocked dependencies
    ///
    currentReducer.dependency(\.envVCEnvironment, .mockFailed)
}

let viewController = EnvironmentDemoVC()

navigationController?.pushViewController(viewController, animated: true)
```

How to clear mock:
```
Bootstrap.clear(for: EnvironmentFeature.self)
```