### PR TITLE
[Main] - Bump Changes to 0.51.0 Base Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "0.8.1"),
         .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
         .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.8.5"),
-        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.3.0"),
+        .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.9.1"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.2.0")
     ],
     targets: [

--- a/Sources/RxComposableArchitecture/Effect.swift
+++ b/Sources/RxComposableArchitecture/Effect.swift
@@ -76,7 +76,7 @@ extension Effect {
     ///   struct State { … }
     ///   enum FeatureAction {
     ///     case factButtonTapped
-    ///     case faceResponse(TaskResult<String>)
+    ///     case factResponse(TaskResult<String>)
     ///   }
     ///   @Dependency(\.numberFact) var numberFact
     ///

--- a/Sources/RxComposableArchitecture/Internal/Deprecated.swift
+++ b/Sources/RxComposableArchitecture/Internal/Deprecated.swift
@@ -7,6 +7,15 @@
 
 import Darwin
 
+// MARK: - Deprecated after 0.50.4
+
+@available(
+  *,
+  deprecated,
+  message: "Use 'Effect<Action>.Send' instead."
+)
+public typealias Send<Action> = Effect<Action>.Send
+
 // MARK: - Deprecated after 0.42.0:
 
 /// This API has been soft-deprecated in favor of ``ReducerProtocol``.

--- a/Sources/RxComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
+++ b/Sources/RxComposableArchitecture/Reducer/AnyReducer/AnyReducer.swift
@@ -238,7 +238,7 @@ public struct AnyReducer<State, Action, Environment> {
                 localAction,
                 toLocalEnvironment(globalEnvironment)
             )
-            .map(toLocalAction.embed)
+            .map { toLocalAction.embed($0) }
         }
     }
     

--- a/Sources/RxComposableArchitecture/Reducer/Reducers/DebugReducer.swift
+++ b/Sources/RxComposableArchitecture/Reducer/Reducers/DebugReducer.swift
@@ -36,8 +36,6 @@ public struct _ReducerPrinter<State, Action> {
 extension _ReducerPrinter {
     public static var customDump: Self {
         Self { receivedAction, oldState, newState in
-            @Dependency(\.context) var context
-            guard context != .preview else { return }
             var target = ""
             target.write("received action:\n")
             CustomDump.customDump(receivedAction, to: &target, indent: 2)
@@ -49,8 +47,6 @@ extension _ReducerPrinter {
 
     public static var actionLabels: Self {
         Self { receivedAction, _, _ in
-            @Dependency(\.context) var context
-            guard context != .preview else { return }
             print("received action: \(debugCaseOutput(receivedAction))")
         }
     }

--- a/Sources/RxComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
+++ b/Sources/RxComposableArchitecture/Reducer/Reducers/ForEachReducer.swift
@@ -53,7 +53,7 @@ extension ReducerProtocol {
     public func forEach<ElementState, ElementAction, ID: Hashable, Element: ReducerProtocol>(
         _ toElementsState: WritableKeyPath<State, IdentifiedArray<ID, ElementState>>,
         action toElementAction: CasePath<Action, (ID, ElementAction)>,
-        @ReducerBuilder<ElementState, ElementAction> _ element: () -> Element,
+        @ReducerBuilder<ElementState, ElementAction> element: () -> Element,
         file: StaticString = #file,
         fileID: StaticString = #fileID,
         line: UInt = #line

--- a/Sources/RxComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
+++ b/Sources/RxComposableArchitecture/Reducer/Reducers/IfCaseLetReducer.swift
@@ -155,6 +155,6 @@ public struct _IfCaseLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>
         }
         defer { state = self.toChildState.embed(childState) }
         return self.child.reduce(into: &childState, action: childAction)
-            .map(self.toChildAction.embed)
+            .map { self.toChildAction.embed($0) }
     }
 }

--- a/Sources/RxComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
+++ b/Sources/RxComposableArchitecture/Reducer/Reducers/IfLetReducer.swift
@@ -148,6 +148,6 @@ public struct _IfLetReducer<Parent: ReducerProtocol, Child: ReducerProtocol>: Re
             return .none
         }
         return self.child.reduce(into: &state[keyPath: self.toChildState]!, action: childAction)
-            .map(self.toChildAction.embed)
+            .map { self.toChildAction.embed($0) }
     }
 }

--- a/Sources/RxComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/RxComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -256,7 +256,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
         case let .keyPath(toChildState):
             return self.child
                 .reduce(into: &state[keyPath: toChildState], action: childAction)
-                .map(self.toChildAction.embed)
+                .map { self.toChildAction.embed($0) }
         case let .optionalPath(toChildState, file, fileID, line):
             guard var childState = toChildState.extract(from: state) else {
                 runtimeWarn(
@@ -296,7 +296,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
 
             return self.child
                 .reduce(into: &childState, action: childAction)
-                .map(self.toChildAction.embed)
+                .map { self.toChildAction.embed($0) }
         }
     }
 }

--- a/Sources/RxComposableArchitecture/Reducer/Reducers/Scope.swift
+++ b/Sources/RxComposableArchitecture/Reducer/Reducers/Scope.swift
@@ -146,7 +146,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
     public init<ChildState, ChildAction>(
         state toChildState: WritableKeyPath<ParentState, ChildState>,
         action toChildAction: CasePath<ParentAction, ChildAction>,
-        @ReducerBuilder<ChildState, ChildAction> _ child: () -> Child
+        @ReducerBuilder<ChildState, ChildAction> child: () -> Child
     ) where ChildState == Child.State, ChildAction == Child.Action {
         self.init(
             toChildState: .keyPath(toChildState),
@@ -159,7 +159,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
     public init<ChildState, ChildAction>(
         state toChildState: OptionalPath<ParentState, ChildState>,
         action toChildAction: CasePath<ParentAction, ChildAction>,
-        @ReducerBuilder<ChildState, ChildAction> _ child: () -> Child,
+        @ReducerBuilder<ChildState, ChildAction> child: () -> Child,
         file: StaticString = #file,
         fileID: StaticString = #fileID,
         line: UInt = #line
@@ -234,7 +234,7 @@ public struct Scope<ParentState, ParentAction, Child: ReducerProtocol>: ReducerP
     public init<ChildState, ChildAction>(
         state toChildState: CasePath<ParentState, ChildState>,
         action toChildAction: CasePath<ParentAction, ChildAction>,
-        @ReducerBuilder<ChildState, ChildAction> _ child: () -> Child,
+        @ReducerBuilder<ChildState, ChildAction> child: () -> Child,
         file: StaticString = #file,
         fileID: StaticString = #fileID,
         line: UInt = #line

--- a/Sources/RxComposableArchitecture/Store.swift
+++ b/Sources/RxComposableArchitecture/Store.swift
@@ -442,10 +442,32 @@ public final class Store<State, Action> {
             
             case let .run(priority, operation):
                 tasks.wrappedValue.append(
-                    Task(priority: priority) {
+                    Task(priority: priority) { @MainActor [weak self] in
+                        #if DEBUG
+                            var isCompleted = false
+                            defer { isCompleted = true }
+                        #endif
                         await operation(
-                            Send {
-                                if let task = self.send($0, originatingFrom: action) {
+                            Effect<Action>.Send {
+                                #if DEBUG
+                                    if isCompleted {
+                                        runtimeWarn(
+                                          """
+                                          An action was sent from a completed effect:
+                                            Action:
+                                              \(debugCaseOutput($0))
+                                            Effect returned from:
+                                              \(debugCaseOutput(action))
+                                          Avoid sending actions using the 'send' argument from 'EffectTask.run' after \
+                                          the effect has completed. This can happen if you escape the 'send' argument in \
+                                          an unstructured context.
+                                          To fix this, make sure that your 'run' closure does not return until you're \
+                                          done calling 'send'.
+                                          """
+                                        )
+                                    }
+                                #endif
+                                if let task = self?.send($0, originatingFrom: action) {
                                     tasks.wrappedValue.append(task)
                                 }
                             }

--- a/Sources/RxComposableArchitecture/Store.swift
+++ b/Sources/RxComposableArchitecture/Store.swift
@@ -787,7 +787,7 @@ private struct StoreScope<RootState, RootAction>: AnyStoreScope {
                 
                 guard
                     let scopedAction = fromRescopedAction(rescopedState, rescopedAction),
-                    let rootAction = fromScopedAction(scopedStore.state.value, scopedAction)
+                    let rootAction = fromScopedAction(scopedStore.state, scopedAction)
                 else { return .none }
                 
                 self.root.send(rootAction)
@@ -809,7 +809,7 @@ private struct StoreScope<RootState, RootAction>: AnyStoreScope {
         rescopedStore.scope = StoreScope<RootState, RootAction>(
             root: self.root,
             fromScopedAction: {
-                fromRescopedAction($0, $1).flatMap { fromScopedAction(scopedStore.state.value, $0) }
+                fromRescopedAction($0, $1).flatMap { fromScopedAction(scopedStore.state, $0) }
             }
         )
         return rescopedStore

--- a/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
+++ b/Sources/RxComposableArchitecture/TestSupport/TestStore.swift
@@ -1284,9 +1284,14 @@ extension TestStore where ScopedState: Equatable, Action: Equatable {
         file: StaticString = #file,
         line: UInt = #line
     ) {
+        var expectedActionDump = ""
+        customDump(expectedAction, to: &expectedActionDump, indent: 2)
         self.receiveAction(
             matching: { expectedAction == $0 },
-            failureMessage: #"Expected to receive an action "\#(expectedAction)", but didn't get one."#,
+            failureMessage: """
+                Expected to receive the following action, but didn't: …
+                \(expectedActionDump)
+                """,
             unexpectedActionDescription: { receivedAction in
                 TaskResultDebugging.$emitRuntimeWarnings.withValue(false) {
                     diff(expectedAction, receivedAction, format: .proportional)
@@ -1734,14 +1739,14 @@ extension TestStore where ScopedState: Equatable, Action: Equatable {
             }
             
             if !actions.isEmpty {
-                var action = ""
-                customDump(actions, to: &action)
+                var actionsDump = ""
+                customDump(actions, to: &actionsDump)
                 XCTFailHelper(
         """
         \(actions.count) received action\
         \(actions.count == 1 ? " was" : "s were") skipped:
         
-        \(action)
+        \(actionsDump)
         """,
         file: file,
         line: line
@@ -2390,6 +2395,34 @@ private func _XCTExpectFailure(
     
     XCTExpectFailureWithOptionsInBlock(failureReason, options, failingBlock)
 #endif
+}
+
+extension TestStore {
+    @MainActor
+    @available(
+        *,
+         unavailable,
+         message: "State and Action must conform to Equatable to receive actions."
+    )
+    public func receive(
+        _ expectedAction: Action,
+        assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+    }
+    
+    @MainActor
+    @discardableResult
+    @available(*, unavailable, message: "State must conform to Equatable to send actions.")
+    public func send(
+        _ action: ScopedAction,
+        assert updateStateToExpectedResult: ((inout ScopedState) throws -> Void)? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async -> TestStoreTask {
+        TestStoreTask(rawValue: nil, timeout: 0)
+    }
 }
 
 #endif

--- a/Tests/RxComposableArchitectureTests/BindingLocalTests.swift
+++ b/Tests/RxComposableArchitectureTests/BindingLocalTests.swift
@@ -1,0 +1,47 @@
+//
+//  BindingLocalTests.swift
+//
+//
+//  Created by andhika.setiadi on 18/12/23.
+//
+
+#if DEBUG
+  import XCTest
+
+  @testable import RxComposableArchitecture
+
+  @MainActor
+  final class BindingLocalTests: XCTestCase {
+    public func testBindingLocalIsActive() {
+      XCTAssertFalse(BindingLocal.isActive)
+
+      struct MyReducer: ReducerProtocol {
+        struct State: Equatable {
+          var text = ""
+        }
+
+        enum Action: Equatable {
+          case textChanged(String)
+        }
+
+        func reduce(into state: inout State, action: Action) -> Effect<Action> {
+          switch action {
+          case let .textChanged(text):
+            state.text = text
+            return .none
+          }
+        }
+      }
+
+      let store = Store(initialState: MyReducer.State(), reducer: MyReducer())
+      let viewStore = ViewStore(store, observe: { $0 })
+
+      let binding = viewStore.binding(get: \.text) { text in
+        XCTAssertTrue(BindingLocal.isActive)
+        return .textChanged(text)
+      }
+      binding.wrappedValue = "Hello!"
+      XCTAssertEqual(viewStore.text, "Hello!")
+    }
+  }
+#endif

--- a/Tests/RxComposableArchitectureTests/EffectRunTests.swift
+++ b/Tests/RxComposableArchitectureTests/EffectRunTests.swift
@@ -116,4 +116,47 @@ final class EffectRunTests: XCTestCase {
     let store = TestStore(initialState: State(), reducer: reducer)
     await store.send(.tapped).finish()
   }
+
+    #if DEBUG
+        func testRunEscapeFailure() async throws {
+            XCTExpectFailure {
+                $0.compactDescription == """
+              An action was sent from a completed effect:
+                Action:
+                  EffectRunTests.Action.response
+                Effect returned from:
+                  EffectRunTests.Action.tap
+              Avoid sending actions using the 'send' argument from 'EffectTask.run' after the effect has \
+              completed. This can happen if you escape the 'send' argument in an unstructured context.
+              To fix this, make sure that your 'run' closure does not return until you're done calling \
+              'send'.
+              """
+            }
+            
+            enum Action { case tap, response }
+            
+            let queue = DispatchQueue.test
+            
+            let store = Store(
+                initialState: 0,
+                reducer: Reduce<Int, Action> { _, action in
+                    switch action {
+                    case .tap:
+                        return .run { send in
+                            Task(priority: .userInitiated) {
+                                try await queue.sleep(for: .seconds(1))
+                                await send(.response)
+                            }
+                        }
+                    case .response:
+                        return .none
+                    }
+                }
+            )
+            
+            let viewStore = ViewStore(store, observe: { $0 })
+            await viewStore.send(.tap).finish()
+            await queue.advance(by: .seconds(1))
+        }
+    #endif
 }

--- a/Tests/RxComposableArchitectureTests/StoreFilterTests.swift
+++ b/Tests/RxComposableArchitectureTests/StoreFilterTests.swift
@@ -1,0 +1,36 @@
+//
+//  File.swift
+//  
+//
+//  Created by andhika.setiadi on 18/12/23.
+//
+
+#if DEBUG
+    import XCTest
+    import RxSwift
+
+    @testable import RxComposableArchitecture
+
+    @MainActor
+    final class StoreFilterTests: XCTestCase {
+        let disposeBag = DisposeBag()
+        
+        func testFilter() {
+            let store = Store<Int?, Void>(initialState: nil, reducer: EmptyReducer())
+                .filter { state, _ in state != nil }
+            
+            let viewStore = ViewStore(store, observe: { $0 })
+            var count = 0
+            viewStore
+                .observable
+                .subscribe(onNext: { _ in count += 1 })
+                .disposed(by: disposeBag)
+            
+            XCTAssertEqual(count, 1)
+            viewStore.send(())
+            XCTAssertEqual(count, 1)
+            viewStore.send(())
+            XCTAssertEqual(count, 1)
+        }
+    }
+#endif

--- a/Tests/RxComposableArchitectureTests/TestStoreFailureTests.swift
+++ b/Tests/RxComposableArchitectureTests/TestStoreFailureTests.swift
@@ -216,7 +216,10 @@
       XCTExpectFailure {
         store.receive(.action)
       } issueMatcher: { issue in
-          issue.compactDescription == #"Expected to receive an action "action", but didn't get one."#
+          issue.compactDescription == """
+            Expected to receive the following action, but didn't: …
+              TestStoreFailureTests.Action.action
+            """
       }
     }
 

--- a/Tests/RxComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/RxComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -104,20 +104,21 @@ final class TestStoreNonExhaustiveTests: XCTestCase {
     }
     
     func testCancelInFlightEffects_Strict() async {
-        let store = TestStore(
-            initialState: 0,
-            reducer: Reduce<Int, Bool> { _, action in
-                    .run { _ in try await Task.sleep(nanoseconds: NSEC_PER_SEC / 4) }
-            },
-            useNewScope: true
-        )
-        
-        let task = await store.send(true)
-        await task.finish(timeout: NSEC_PER_SEC / 2)
-        XCTExpectFailure {
-            $0.compactDescription == "There were no in-flight effects to skip."
+        await _withMainSerialExecutor {
+            let store = TestStore(
+                initialState: 0,
+                reducer: Reduce<Int, Bool> { _, action in
+                        .run { _ in try await Task.sleep(nanoseconds: NSEC_PER_SEC / 4) }
+                }
+            )
+            
+            let task = await store.send(true)
+            await task.finish(timeout: NSEC_PER_SEC / 2)
+            XCTExpectFailure {
+                $0.compactDescription == "There were no in-flight effects to skip."
+            }
+            await store.skipInFlightEffects(strict: true)
         }
-        await store.skipInFlightEffects(strict: true)
     }
     
     func testCancelInFlightEffects_NonExhaustive() async {

--- a/Tests/RxComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
+++ b/Tests/RxComposableArchitectureTests/TestStoreNonExhaustiveTests.swift
@@ -104,7 +104,7 @@ final class TestStoreNonExhaustiveTests: XCTestCase {
     }
     
     func testCancelInFlightEffects_Strict() async {
-        await _withMainSerialExecutor {
+        await withMainSerialExecutor {
             let store = TestStore(
                 initialState: 0,
                 reducer: Reduce<Int, Bool> { _, action in

--- a/development-podspecs/CasePaths.podspec.json
+++ b/development-podspecs/CasePaths.podspec.json
@@ -1,6 +1,6 @@
 {
     "name": "CasePaths",
-    "version": "0.1.0",
+    "version": "0.8.1",
     "authors": "local pod",
     "homepage": "https://github.com/pointfreeco/swift-case-paths",
     "summary": "local pod",


### PR DESCRIPTION
We split into several phases to bump our codebase version to 0.59.0
as we plan this bump for 0.51.0 in this PR:

```
- 0.50.0 to 0.51.0
    - 0.50.0 -> 0.50.1 = https://github.com/pointfreeco/swift-composable-architecture/compare/0.50.0...0.50.1
    - 0.50.1 -> 0.50.2 = https://github.com/pointfreeco/swift-composable-architecture/compare/0.50.1...0.50.2
    - 0.50.2 -> 0.50.3 = https://github.com/pointfreeco/swift-composable-architecture/compare/0.50.2...0.50.3
    - 0.50.3 -> 0.51.0 = https://github.com/pointfreeco/swift-composable-architecture/compare/0.50.3...0.51.0
```